### PR TITLE
Update go.yml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,8 +16,9 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
-
+        go-version: 1.18.0-beta1
+        stable: false
+  
     - name: Build
       run: make build
 


### PR DESCRIPTION
use unstavle 1.18.0-beta1 until golang 1.18 is officially released