### PR TITLE
Use struct{} for sets

### DIFF
--- a/intersect.go
+++ b/intersect.go
@@ -36,10 +36,10 @@ func Some[T comparable](collection []T, subset []T) bool {
 // Intersect returns the intersection between two collections.
 func Intersect[T comparable](list1 []T, list2 []T) []T {
 	result := []T{}
-	seen := map[T]bool{}
+	seen := map[T]struct{}{}
 
 	for _, elem := range list1 {
-		seen[elem] = true
+		seen[elem] = struct{}{}
 	}
 
 	for _, elem := range list2 {
@@ -58,15 +58,15 @@ func Difference[T comparable](list1 []T, list2 []T) ([]T, []T) {
 	left := []T{}
 	right := []T{}
 
-	seenLeft := map[T]bool{}
-	seenRight := map[T]bool{}
+	seenLeft := map[T]struct{}{}
+	seenRight := map[T]struct{}{}
 
 	for _, elem := range list1 {
-		seenLeft[elem] = true
+		seenLeft[elem] = struct{}{}
 	}
 
 	for _, elem := range list2 {
-		seenRight[elem] = true
+		seenRight[elem] = struct{}{}
 	}
 
 	for _, elem := range list1 {

--- a/slice.go
+++ b/slice.go
@@ -47,14 +47,14 @@ func ForEach[T any](collection []T, iteratee func(T, int)) {
 // The order of result values is determined by the order they occur in the array.
 func Uniq[T comparable](collection []T) []T {
 	result := make([]T, 0, len(collection))
-	seen := make(map[T]bool, len(collection))
+	seen := make(map[T]struct{}, len(collection))
 
 	for _, item := range collection {
 		if _, ok := seen[item]; ok {
 			continue
 		}
 
-		seen[item] = true
+		seen[item] = struct{}{}
 		result = append(result, item)
 	}
 
@@ -66,7 +66,7 @@ func Uniq[T comparable](collection []T) []T {
 // invoked for each element in array to generate the criterion by which uniqueness is computed.
 func UniqBy[T any, U comparable](collection []T, iteratee func(T) U) []T {
 	result := make([]T, 0, len(collection))
-	seen := make(map[U]bool, len(collection))
+	seen := make(map[U]struct{}, len(collection))
 
 	for _, item := range collection {
 		key := iteratee(item)
@@ -75,7 +75,7 @@ func UniqBy[T any, U comparable](collection []T, iteratee func(T) U) []T {
 			continue
 		}
 
-		seen[key] = true
+		seen[key] = struct{}{}
 		result = append(result, item)
 	}
 


### PR DESCRIPTION
Hello
Isn't it better to use `struct{}` for sets values? Bools use 1 byte of memory but `struct{}`s do not use memory at all!