### PR TITLE
test(util): add test case and fix assert logic in RangeWithSteps

### DIFF
--- a/util_test.go
+++ b/util_test.go
@@ -1,8 +1,9 @@
 package lo
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRange(t *testing.T) {
@@ -34,11 +35,13 @@ func TestRangeClose(t *testing.T) {
 	result1 := RangeWithSteps(0, 20, 6)
 	result2 := RangeWithSteps(0, 3, -5)
 	result3 := RangeWithSteps(1, 1, 0)
-	result4 := RangeWithSteps[float64](1.0, 4.0, 2.0)
-	result5 := RangeWithSteps[float32](-1.0, -4.0, -1.0)
-	is.Equal(result1, []int{0, 6, 12, 18})
-	is.Equal(result2, []int{})
-	is.Equal(result3, []int{})
-	is.Equal(result4, []float64{1.0, 3.0})
-	is.Equal(result5, []float32{-1.0, -2.0, -3.0})
+	result4 := RangeWithSteps(3, 2, 1)
+	result5 := RangeWithSteps[float64](1.0, 4.0, 2.0)
+	result6 := RangeWithSteps[float32](-1.0, -4.0, -1.0)
+	is.Equal([]int{0, 6, 12, 18}, result1)
+	is.Equal([]int{}, result2)
+	is.Equal([]int{}, result3)
+	is.Equal([]int{}, result4)
+	is.Equal([]float64{1.0, 3.0}, result5)
+	is.Equal([]float32{-1.0, -2.0, -3.0}, result6)
 }


### PR DESCRIPTION
* Add a new test case to reach 100% coverage in `RangeWithSteps`.
* Reverse the order of the [is.Equal](https://pkg.go.dev/github.com/stretchr/testify/assert#Equal) parameters (`expected` should be the first parameter)

> [func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool](https://pkg.go.dev/github.com/stretchr/testify/assert#Equal)