### PR TITLE
[fix] Dockerfile path in COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM golang:1.18rc1-bullseye
 
 WORKDIR /go/src/github.com/samber/lo
 
-COPY Makefile go.* /go/src/github.com/samber/lo/
+COPY Makefile go.* ./
 
 RUN make tools


### PR DESCRIPTION
Since you made a **WORKDIR** command before a **COPY** with the same destination path. you just need a short declaration.