### PR TITLE
doc: add description of Empty() to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Other functional programming helpers:
 - Switch / Case / Default
 - ToPtr
 - ToSlicePtr
+- Empty
 
 Time based helpers:
 
@@ -876,6 +877,19 @@ Returns a slice of pointer copy of value.
 ```go
 ptr := lo.ToSlicePtr[string]([]string{"hello", "world"})
 // []*string{"hello", "world"}
+```
+
+### Empty
+
+Returns an empty value.
+
+```go
+lo.Empty[int]()
+// 0
+lo.Empty[string]()
+// ""
+lo.Empty[bool]()
+// false
 ```
 
 ### Attempt


### PR DESCRIPTION
I added description of `Empty()` usage sample in readme.

Closes #69 