### PR TITLE
add parallel methods for maps

### DIFF
--- a/parallel/map.go
+++ b/parallel/map.go
@@ -1,0 +1,40 @@
+package parallel
+
+import "sync"
+
+//ForEachKeyValue call iteratee concurrently for each key value pair in m with no limit on concurrency
+func ForEachKeyValue[K comparable, V any](m map[K]V, iteratee func(key K, value V)) {
+	ForEachKeyValueMax(m, 0, iteratee)
+}
+
+//ForEachKeyValueMax call iteratee concurrently for each key value pair in m with max limit on concurrency
+func ForEachKeyValueMax[K comparable, V any](m map[K]V, max int, iteratee func(key K, value V)) {
+	var wg sync.WaitGroup
+	wg.Add(len(m))
+
+	var ch chan struct{}
+	if max != 0 {
+		ch = make(chan struct{}, max)
+	}
+
+	for k, v := range m {
+
+		if max != 0 {
+			ch <- struct{}{}
+		}
+
+		go func(_k K, _v V) {
+			defer func() {
+				if max != 0 {
+					<-ch
+				}
+				wg.Done()
+			}()
+
+			iteratee(_k, _v)
+		}(k, v)
+
+	}
+
+	wg.Wait()
+}

--- a/parallel/map_test.go
+++ b/parallel/map_test.go
@@ -1,0 +1,110 @@
+package parallel
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestForEachKeyValue(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		input := map[string]int{}
+		ForEachKeyValue(input, func(_ string, _ int) {
+			t.Errorf("unexpected fn call for empty map")
+		})
+	})
+	t.Run("call fn for each key value concurrently", func(t *testing.T) {
+		input := map[string]int{
+			"a": 1,
+			"b": 2,
+			"c": 3,
+		}
+		result := map[string]struct {
+			value    int
+			calledAt time.Time
+		}{}
+		mu := sync.Mutex{}
+		startTime := time.Now()
+		allowedCallDelta := time.Millisecond * 2
+		ForEachKeyValue(input, func(key string, value int) {
+			mu.Lock()
+			result[key] = struct {
+				value    int
+				calledAt time.Time
+			}{value, time.Now()}
+			mu.Unlock()
+			time.Sleep(time.Millisecond * 50)
+		})
+
+		if resultLen, inputLen := len(result), len(input); resultLen != inputLen {
+			t.Errorf("result len of %d is not equal to input len of %d", resultLen, inputLen)
+		}
+
+		for k, v := range input {
+			resultValue, ok := result[k]
+			if !ok {
+				t.Errorf("fn was not called with key %v", k)
+			}
+			if resultValue.value != input[k] {
+				t.Errorf("fn was called with unexpected value %v for key %v.. expected value %v", resultValue.value, k, v)
+			}
+			if !withinDuration(startTime, resultValue.calledAt, allowedCallDelta) {
+				t.Errorf("expected fn to be called within %v of startTime %v but was called at %v", allowedCallDelta, startTime, resultValue.calledAt)
+			}
+		}
+	})
+}
+
+func TestForEachKeyValueMax(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		input := map[string]int{}
+		ForEachKeyValueMax(input, 1, func(_ string, _ int) {
+			t.Errorf("unexpected fn call for empty map")
+		})
+	})
+	t.Run("call fn for each key value with max concurrency", func(t *testing.T) {
+		input := map[string]int{
+			"a": 1,
+			"b": 2,
+			"c": 3,
+			"d": 4,
+			"e": 5,
+		}
+		result := orderedMap{}
+		mu := sync.Mutex{}
+		startTime := time.Now()
+		allowedCallDelta := time.Millisecond * 10
+		fnExecutionTime := time.Millisecond * 50
+		ForEachKeyValueMax(input, 1, func(key string, value int) {
+			mu.Lock()
+			result.Add(key, orderedMapValue{
+				value:    value,
+				calledAt: time.Now(),
+			})
+			mu.Unlock()
+			time.Sleep(fnExecutionTime)
+		})
+
+		if resultLen, inputLen := len(result.m), len(input); resultLen != inputLen {
+			t.Errorf("result len of %d is not equal to input len of %d", resultLen, inputLen)
+		}
+
+		for k, v := range input {
+			resultValue, ok := result.m[k]
+			if !ok {
+				t.Errorf("fn was not called with key %v", k)
+			}
+			if resultValue.value != input[k] {
+				t.Errorf("fn was called with unexpected value %v for key %v.. expected value %v", resultValue.value, k, v)
+			}
+		}
+
+		for idx, value := range result.s {
+			timeToAdd := time.Duration(idx) * fnExecutionTime
+			expectedCallTime := startTime.Add(timeToAdd)
+			if !withinDuration(expectedCallTime, value.value.calledAt, allowedCallDelta) {
+				t.Errorf("expected fn to be called within %v of expectedTime %v but was called at %v.. difference of %v", allowedCallDelta, expectedCallTime, value.value.calledAt, expectedCallTime.Sub(value.value.calledAt).String())
+			}
+		}
+	})
+}

--- a/parallel/test_helpers.go
+++ b/parallel/test_helpers.go
@@ -1,0 +1,33 @@
+package parallel
+
+import "time"
+
+func withinDuration(expected, actual time.Time, delta time.Duration) bool {
+	dt := expected.Sub(actual)
+
+	return dt > -delta && dt < delta
+}
+
+type orderedMapValue struct {
+	value    int
+	calledAt time.Time
+}
+
+type orderedMap struct {
+	m map[string]orderedMapValue
+	s []struct {
+		key   string
+		value orderedMapValue
+	}
+}
+
+func (o *orderedMap) Add(key string, value orderedMapValue) {
+	if o.m == nil {
+		o.m = make(map[string]orderedMapValue)
+	}
+	o.m[key] = value
+	o.s = append(o.s, struct {
+		key   string
+		value orderedMapValue
+	}{key, value})
+}


### PR DESCRIPTION
Adds parallel helper methods for maps:
- `ForEachKeyValue` call `iteratee` concurrently for each key value pair in `m` with no limit on concurrency
- `ForEachKeyValueMax` call `iteratee` concurrently for each key value pair in `m` with `max` limit on concurrency