### PR TITLE
Add Coalesce

### DIFF
--- a/find.go
+++ b/find.go
@@ -237,3 +237,16 @@ func Samples[T any](collection []T, count int) []T {
 
 	return results
 }
+
+// Coalesce returns the first non-default arguments. Arguments must be comparable.
+func Coalesce[T comparable](v ...T) (result T, ok bool) {
+	for _, e := range v {
+		if e != result {
+			result = e
+			ok = true
+			return
+		}
+	}
+
+	return
+}

--- a/find_test.go
+++ b/find_test.go
@@ -214,3 +214,61 @@ func TestSamples(t *testing.T) {
 	is.Equal(result1, []string{"a", "b", "c"})
 	is.Equal(result2, []string{})
 }
+
+func TestCoalesce(t *testing.T) {
+	is := assert.New(t)
+
+	newStr := func(v string) *string { return &v }
+	var nilStr *string
+	str1 := newStr("str1")
+	str2 := newStr("str2")
+
+	type structType struct {
+		field1 int
+		field2 float64
+	}
+	var zeroStruct structType
+	struct1 := structType{1, 1.0}
+	struct2 := structType{2, 2.0}
+
+	result1, ok1 := Coalesce[int]()
+	result2, ok2 := Coalesce(3)
+	result3, ok3 := Coalesce[*string](nil, nilStr)
+	result4, ok4 := Coalesce(nilStr, str1)
+	result5, ok5 := Coalesce(nilStr, str1, str2)
+	result6, ok6 := Coalesce(str1, str2, nilStr)
+	result7, ok7 := Coalesce(0, 1, 2, 3)
+	result8, ok8 := Coalesce(zeroStruct)
+	result9, ok9 := Coalesce(zeroStruct, struct1)
+	result10, ok10 := Coalesce(zeroStruct, struct1, struct2)
+
+	is.Equal(0, result1)
+	is.False(ok1)
+
+	is.Equal(3, result2)
+	is.True(ok2)
+
+	is.Nil(result3)
+	is.False(ok3)
+
+	is.Equal(str1, result4)
+	is.True(ok4)
+
+	is.Equal(str1, result5)
+	is.True(ok5)
+
+	is.Equal(str1, result6)
+	is.True(ok6)
+
+	is.Equal(result7, 1)
+	is.True(ok7)
+
+	is.Equal(result8, zeroStruct)
+	is.False(ok8)
+
+	is.Equal(result9, struct1)
+	is.True(ok9)
+
+	is.Equal(result10, struct1)
+	is.True(ok10)
+}


### PR DESCRIPTION
 Because non-pointer types cannot become nil, `lo.Coalesce` checks arguments is default or not. If `T` is pointer type, default value is nil, so the function returns first non-nil arguments.
 
 Arguments must be comparable because they must be compared with default value (`result T`), There other options to use `reflect` to check default value, which let `T any`.