### PR TITLE
feat: add MustOk

### DIFF
--- a/ok.go
+++ b/ok.go
@@ -1,0 +1,67 @@
+package lo
+
+// MustOk has the same behavior than Must, but receives bool instead of error.
+func MustOk[T any](val T, ok bool) T {
+	if !ok{
+		panic("not ok")
+	}
+
+	return val
+}
+
+// MustOk0 has the same behavior than MustOk, but callback returns no variable.
+func MustOk0(ok bool) {
+	if !ok {
+		panic("not ok")
+	}
+}
+
+// MustOk1 is an alias to MustOk
+func MustOk1[T any](val T, ok bool) T {
+	return MustOk(val, ok)
+}
+
+// MustOk2 has the same behavior than MustOk, but callback returns 2 variable.
+func MustOk2[T1 any, T2 any](val1 T1, val2 T2, ok bool) (T1, T2) {
+	if !ok {
+		panic("not ok")
+	}
+
+	return val1, val2
+}
+
+// MustOk3 has the same behavior than MustOk, but callback returns 3 variable.
+func MustOk3[T1 any, T2 any, T3 any](val1 T1, val2 T2, val3 T3, ok bool) (T1, T2, T3) {
+	if !ok {
+		panic("not ok")
+	}
+
+	return val1, val2, val3
+}
+
+// MustOk4 has the same behavior than MustOk, but callback returns 4 variable.
+func MustOk4[T1 any, T2 any, T3 any, T4 any](val1 T1, val2 T2, val3 T3, val4 T4, ok bool) (T1, T2, T3, T4) {
+	if !ok {
+		panic("not ok")
+	}
+
+	return val1, val2, val3, val4
+}
+
+// MustOk5 has the same behavior than MustOk, but callback returns 5 variable.
+func MustOk5[T1 any, T2 any, T3 any, T4 any, T5 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 T5, ok bool) (T1, T2, T3, T4, T5) {
+	if !ok {
+		panic("not ok")
+	}
+
+	return val1, val2, val3, val4, val5
+}
+
+// MustOk6 has the same behavior than MustOk, but callback returns 6 variable.
+func MustOk6[T1 any, T2 any, T3 any, T4 any, T5 any, T6 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 T5, val6 T6, ok bool) (T1, T2, T3, T4, T5, T6) {
+	if !ok {
+		panic("not ok")
+	}
+
+	return val1, val2, val3, val4, val5, val6
+}

--- a/ok_test.go
+++ b/ok_test.go
@@ -1,0 +1,93 @@
+package lo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMustOk(t *testing.T) {
+	is := assert.New(t)
+	is.Equal("foo", MustOk("foo", true))
+	is.Panics(
+		func() {
+			MustOk("", false)
+		},
+	)
+}
+
+func TestMustOkX(t *testing.T) {
+	is := assert.New(t)
+
+	{
+		is.Panics(func() {
+			MustOk0(false)
+		})
+		is.NotPanics(func() {
+			MustOk0(true)
+		})
+	}
+
+	{
+		val1 := MustOk1(1, true)
+		is.Equal(1, val1)
+		is.Panics(func() {
+			MustOk1(1, false)
+		})
+	}
+
+	{
+		val1, val2 := MustOk2(1, 2, true)
+		is.Equal(1, val1)
+		is.Equal(2, val2)
+		is.Panics(func() {
+			MustOk2(1, 2, false)
+		})
+	}
+
+	{
+		val1, val2, val3 := MustOk3(1, 2, 3, true)
+		is.Equal(1, val1)
+		is.Equal(2, val2)
+		is.Equal(3, val3)
+		is.Panics(func() {
+			MustOk3(1, 2, 3, false)
+		})
+	}
+
+	{
+		val1, val2, val3, val4 := MustOk4(1, 2, 3, 4, true)
+		is.Equal(1, val1)
+		is.Equal(2, val2)
+		is.Equal(3, val3)
+		is.Equal(4, val4)
+		is.Panics(func() {
+			MustOk4(1, 2, 3, 4, false)
+		})
+	}
+
+	{
+		val1, val2, val3, val4, val5 := MustOk5(1, 2, 3, 4, 5, true)
+		is.Equal(1, val1)
+		is.Equal(2, val2)
+		is.Equal(3, val3)
+		is.Equal(4, val4)
+		is.Equal(5, val5)
+		is.Panics(func() {
+			MustOk5(1, 2, 3, 4, 5, false)
+		})
+	}
+
+	{
+		val1, val2, val3, val4, val5, val6 := MustOk6(1, 2, 3, 4, 5, 6, true)
+		is.Equal(1, val1)
+		is.Equal(2, val2)
+		is.Equal(3, val3)
+		is.Equal(4, val4)
+		is.Equal(5, val5)
+		is.Equal(6, val6)
+		is.Panics(func() {
+			MustOk6(1, 2, 3, 4, 5, 6, false)
+		})
+	}
+}


### PR DESCRIPTION
`error` can't become union type like `error |  bool` because `error` has method `Error() string`. So I added MustOk.  #99