### PR TITLE
Add support for optional chaining

### DIFF
--- a/pointers.go
+++ b/pointers.go
@@ -1,5 +1,7 @@
 package lo
 
+const nilPointerPanic = "runtime error: invalid memory address or nil pointer dereference"
+
 // ToPtr returns a pointer copy of value.
 func ToPtr[T any](x T) *T {
 	return &x
@@ -28,5 +30,21 @@ func Coalesce[T comparable](v ...T) (result T, ok bool) {
 		}
 	}
 
+	return
+}
+
+func Safe[T any](cb func() T) (result T, ok bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			if err, ok := r.(error); ok && err.Error() == nilPointerPanic {
+				ok = false
+			} else {
+				panic(r)
+			}
+		}
+	}()
+
+	result = cb()
+	ok = true
 	return
 }


### PR DESCRIPTION
Some experimentations:

```go
type a struct {
	foo *string
}
type b struct {
	a *a
}
type c struct {
	b *b
}

v := &c{
	b: &b{
		a: nil,
	},
}

result, ok := lo.Safe(func() string { return *v.b.a.foo })
// "", false
```
