### PR TITLE
fix: wrong output of a Switch example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1132,7 +1132,7 @@ result := lo.Switch[int, string](1).
         return "1"
     }).
     Default("42")
-// "42"
+// "1"
 ```
 
 ### ToPtr


### PR DESCRIPTION
Switch Mixed:
```go
result := lo.Switch[int, string](1).
    CaseF(1, func() string {
        return "1"
    }).
    Default("42")
// "42"  <- should be "1"
```