### PR TITLE
[docs] Use package name in Coalesce example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1232,15 +1232,15 @@ lo.Empty[bool]()
 Returns the first non-empty arguments. Arguments must be comparable.
 
 ```go
-result, ok := Coalesce(0, 1, 2, 3)
+result, ok := lo.Coalesce(0, 1, 2, 3)
 // 1 true
 
-result, ok := Coalesce("")
+result, ok := lo.Coalesce("")
 // "" false
 
 var nilStr *string
 str := "foobar"
-result, ok := Coalesce[*string](nil, nilStr, &str)
+result, ok := lo.Coalesce[*string](nil, nilStr, &str)
 // &"foobar" true
 ```
 


### PR DESCRIPTION
Prepended `lo.` to make it consistent with other examples