### PR TITLE
feat: Add ToAnySlice

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,11 +636,11 @@ slice := lo.ReplaceAll(in, -1, 42)
 // []int{0, 1, 0, 1, 2, 3, 0}
 ```
 
-### ToInterfaceSlice
+### ToAnySlice
 
 Returns a slice with all elements mapped to any type
 ```go
-elements := lo.ToInterfaceSlice[int]([]int{1, 5, 1})
+elements := lo.ToAnySlice[int]([]int{1, 5, 1})
 // []any{1, 5, 1}
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Supported helpers for slices:
 - Reject
 - Count
 - CountBy
+- ToInterfaceSlice
 
 Supported helpers for maps:
 
@@ -633,6 +634,14 @@ slice := lo.ReplaceAll(in, 0, 42)
 
 slice := lo.ReplaceAll(in, -1, 42)
 // []int{0, 1, 0, 1, 2, 3, 0}
+```
+
+### ToInterfaceSlice
+
+Returns a slice with all elements mapped to any type
+```go
+elements := lo.ToInterfaceSlice[int]([]int{1, 5, 1})
+// []any{1, 5, 1}
 ```
 
 ### Keys

--- a/slice.go
+++ b/slice.go
@@ -406,3 +406,12 @@ func Replace[T comparable](collection []T, old T, new T, n int) []T {
 func ReplaceAll[T comparable](collection []T, old T, new T) []T {
 	return Replace[T](collection, old, new, -1)
 }
+
+// ToInterfaceSlice returns a slice with all elements mapped to any type
+func ToInterfaceSlice[T any](collection []T) []any {
+	result := make([]any, len(collection))
+	for i, item := range collection {
+		result[i] = item
+	}
+	return result
+}

--- a/slice.go
+++ b/slice.go
@@ -407,8 +407,8 @@ func ReplaceAll[T comparable](collection []T, old T, new T) []T {
 	return Replace[T](collection, old, new, -1)
 }
 
-// ToInterfaceSlice returns a slice with all elements mapped to any type
-func ToInterfaceSlice[T any](collection []T) []any {
+// ToAnySlice returns a slice with all elements mapped to any type
+func ToAnySlice[T any](collection []T) []any {
 	result := make([]any, len(collection))
 	for i, item := range collection {
 		result[i] = item

--- a/slice_test.go
+++ b/slice_test.go
@@ -456,13 +456,13 @@ func TestReplaceAll(t *testing.T) {
 	is.Equal([]int{0, 1, 0, 1, 2, 3, 0}, out2)
 }
 
-func TestToInterfaceSlice(t *testing.T) {
+func TestToAnySlice(t *testing.T) {
 	is := assert.New(t)
 
 	in1 := []int{0, 1, 2, 3}
 	in2 := []int{}
-	out1 := ToInterfaceSlice(in1)
-	out2 := ToInterfaceSlice(in2)
+	out1 := ToAnySlice(in1)
+	out2 := ToAnySlice(in2)
 
 	is.Equal([]any{0, 1, 2, 3}, out1)
 	is.Equal([]any{}, out2)

--- a/slice_test.go
+++ b/slice_test.go
@@ -455,3 +455,15 @@ func TestReplaceAll(t *testing.T) {
 	is.Equal([]int{42, 1, 42, 1, 2, 3, 42}, out1)
 	is.Equal([]int{0, 1, 0, 1, 2, 3, 0}, out2)
 }
+
+func TestToInterfaceSlice(t *testing.T) {
+	is := assert.New(t)
+
+	in1 := []int{0, 1, 2, 3}
+	in2 := []int{}
+	out1 := ToInterfaceSlice(in1)
+	out2 := ToInterfaceSlice(in2)
+
+	is.Equal([]any{0, 1, 2, 3}, out1)
+	is.Equal([]any{}, out2)
+}


### PR DESCRIPTION
Small helper function which returns slice with all elements mapped to any type.

It is common for other libraries to accept a variadic number of arguments of interface type. _ToAnySlice_ allows easily to convert slice with concrete type to any