### PR TITLE
Nth: addressing #136 - fixing -1 bug on slice of length 1. 

### DIFF
--- a/find.go
+++ b/find.go
@@ -2,7 +2,6 @@ package lo
 
 import (
 	"fmt"
-	"math"
 	"math/rand"
 
 	"golang.org/x/exp/constraints"
@@ -188,18 +187,16 @@ func Last[T any](collection []T) (T, error) {
 // Nth returns the element at index `nth` of collection. If `nth` is negative, the nth element
 // from the end is returned. An error is returned when nth is out of slice bounds.
 func Nth[T any](collection []T, nth int) (T, error) {
-	if int(math.Abs(float64(nth))) >= len(collection) {
+	l := len(collection)
+	if nth >= l || -nth > l {
 		var t T
 		return t, fmt.Errorf("nth: %d out of slice bounds", nth)
 	}
 
-	length := len(collection)
-
 	if nth >= 0 {
 		return collection[nth], nil
 	}
-
-	return collection[length+nth], nil
+	return collection[l+nth], nil
 }
 
 // Sample returns a random item from collection.

--- a/find_test.go
+++ b/find_test.go
@@ -176,6 +176,7 @@ func TestNth(t *testing.T) {
 	result3, err3 := Nth([]int{0, 1, 2, 3}, 42)
 	result4, err4 := Nth([]int{}, 0)
 	result5, err5 := Nth([]int{42}, 0)
+	result6, err6 := Nth([]int{42}, -1)
 
 	is.Equal(result1, 2)
 	is.Equal(err1, nil)
@@ -187,6 +188,8 @@ func TestNth(t *testing.T) {
 	is.Equal(err4, fmt.Errorf("nth: 0 out of slice bounds"))
 	is.Equal(result5, 42)
 	is.Equal(err5, nil)
+	is.Equal(result6, 42)
+	is.Equal(err6, nil)
 }
 
 func TestSample(t *testing.T) {


### PR DESCRIPTION
- Fixed incorrect Nth behavior for -1 index.
- More performant index checking (haven't tested, but removed Math.Abs call and casting to/from float64)

~~Used constraints.Integer for 'nth' parameter.~~
~~Panic instead of raising error on out of range.~~