### PR TITLE
Nth: use constraints.Integer for nth param.

### DIFF
--- a/find.go
+++ b/find.go
@@ -208,17 +208,18 @@ func Last[T any](collection []T) (T, error) {
 
 // Nth returns the element at index `nth` of collection. If `nth` is negative, the nth element
 // from the end is returned. An error is returned when nth is out of slice bounds.
-func Nth[T any](collection []T, nth int) (T, error) {
+func Nth[T any, N constraints.Integer](collection []T, nth N) (T, error) {
+  n := int(nth)
 	l := len(collection)
-	if nth >= l || -nth > l {
+	if n >= l || -n > l {
 		var t T
-		return t, fmt.Errorf("nth: %d out of slice bounds", nth)
+		return t, fmt.Errorf("nth: %d out of slice bounds", n)
 	}
 
-	if nth >= 0 {
-		return collection[nth], nil
+	if n >= 0 {
+		return collection[n], nil
 	}
-	return collection[l+nth], nil
+	return collection[l+n], nil
 }
 
 // Sample returns a random item from collection.

--- a/find.go
+++ b/find.go
@@ -209,7 +209,7 @@ func Last[T any](collection []T) (T, error) {
 // Nth returns the element at index `nth` of collection. If `nth` is negative, the nth element
 // from the end is returned. An error is returned when nth is out of slice bounds.
 func Nth[T any, N constraints.Integer](collection []T, nth N) (T, error) {
-  n := int(nth)
+	n := int(nth)
 	l := len(collection)
 	if n >= l || -n > l {
 		var t T


### PR DESCRIPTION
Mentioned in my original issue #136 and is superset to PR #137 

~~**Panic**~~
~~[Three months ago, Nth was changed to return an error instead of panicking.](https://github.com/samber/lo/commit/a59137782c3457b6039f8654b1cc9fa5af48e948) Admittedly, the explicit error handling is arguably more Go-y, however, I propose going back to panicking because:~~
~~- it's a simpler method signature, no error handling~~
~~- it is a similar behavior to normal slice accessing: `mySlice[outOfBoundsIndex]` panics~~

**constraints.Integer**
This is a more generic, backwards-compatible method signature change. Any integer type will work for `nth` parameter.