### PR TITLE
feat: adding Compact

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Supported helpers for slices:
 - Reject
 - Count
 - CountBy
+- Compact
 
 Supported helpers for maps:
 
@@ -645,6 +646,17 @@ slice := lo.ReplaceAll(in, 0, 42)
 
 slice := lo.ReplaceAll(in, -1, 42)
 // []int{0, 1, 0, 1, 2, 3, 0}
+```
+
+### Compact
+
+Returns a slice of all non-zero elements.
+
+```go
+in := []string{"", "foo", "", "bar", ""}
+
+slice := lo.Compact[string](in)
+// []string{"foo", "bar"}
 ```
 
 ### Keys

--- a/slice.go
+++ b/slice.go
@@ -406,3 +406,18 @@ func Replace[T comparable](collection []T, old T, new T, n int) []T {
 func ReplaceAll[T comparable](collection []T, old T, new T) []T {
 	return Replace(collection, old, new, -1)
 }
+
+// Compact returns a slice of all non-zero elements.
+func Compact[T comparable](collection []T) []T {
+	var zero T
+
+	result := []T{}
+
+	for _, item := range collection {
+		if item != zero {
+			result = append(result, item)
+		}
+	}
+
+	return result
+}

--- a/slice_test.go
+++ b/slice_test.go
@@ -455,3 +455,44 @@ func TestReplaceAll(t *testing.T) {
 	is.Equal([]int{42, 1, 42, 1, 2, 3, 42}, out1)
 	is.Equal([]int{0, 1, 0, 1, 2, 3, 0}, out2)
 }
+
+func TestCompact(t *testing.T) {
+	is := assert.New(t)
+
+	r1 := Compact([]int{2, 0, 4, 0})
+
+	is.Equal(r1, []int{2, 4})
+
+	r2 := Compact([]string{"", "foo", "", "bar", ""})
+
+	is.Equal(r2, []string{"foo", "bar"})
+
+	r3 := Compact([]bool{true, false, true, false})
+
+	is.Equal(r3, []bool{true, true})
+
+	type foo struct {
+		bar int
+		baz string
+	}
+
+	// slice of structs
+	// If all fields of an element are zero values, Compact removes it.
+
+	r4 := Compact([]foo{
+		{bar: 1, baz: "a"}, // all fields are non-zero values
+		{bar: 0, baz: ""},  // all fields are zero values
+		{bar: 2, baz: ""},  // bar is non-zero
+	})
+
+	is.Equal(r4, []foo{{bar: 1, baz: "a"}, {bar: 2, baz: ""}})
+
+	// slice of pointers to structs
+	// If an element is nil, Compact removes it.
+
+	e1, e2, e3 := foo{bar: 1, baz: "a"}, foo{bar: 0, baz: ""}, foo{bar: 2, baz: ""}
+	// NOTE: e2 is a zero value of foo, but its pointer &e2 is not a zero value of *foo.
+	r5 := Compact([]*foo{&e1, &e2, nil, &e3})
+
+	is.Equal(r5, []*foo{&e1, &e2, &e3})
+}


### PR DESCRIPTION
`Compact` returns a new slice with all zero values removed (`0` for `int`, `false` for `bool`, `""` for `string` and so on). This is inspired by [Lodash `compact` method](https://lodash.com/docs/4.17.15#compact).