### PR TITLE
feat: add parallel.Find

### DIFF
--- a/parallel/slice.go
+++ b/parallel/slice.go
@@ -3,7 +3,7 @@ package parallel
 import "sync"
 
 // Map manipulates a slice and transforms it to a slice of another type.
-// `iteratee` is call in parallel. Result keep the same order.
+// `iteratee` is called in parallel. Result keep the same order.
 func Map[T any, R any](collection []T, iteratee func(T, int) R) []R {
 	result := make([]R, len(collection))
 
@@ -26,7 +26,7 @@ func Map[T any, R any](collection []T, iteratee func(T, int) R) []R {
 }
 
 // ForEach iterates over elements of collection and invokes iteratee for each element.
-// `iteratee` is call in parallel.
+// `iteratee` is called in parallel.
 func ForEach[T any](collection []T, iteratee func(T, int)) {
 	var wg sync.WaitGroup
 	wg.Add(len(collection))
@@ -43,7 +43,7 @@ func ForEach[T any](collection []T, iteratee func(T, int)) {
 
 // Times invokes the iteratee n times, returning an array of the results of each invocation.
 // The iteratee is invoked with index as argument.
-// `iteratee` is call in parallel.
+// `iteratee` is called in parallel.
 func Times[T any](count int, iteratee func(int) T) []T {
 	result := make([]T, count)
 
@@ -66,7 +66,7 @@ func Times[T any](count int, iteratee func(int) T) []T {
 }
 
 // GroupBy returns an object composed of keys generated from the results of running each element of collection through iteratee.
-// `iteratee` is call in parallel.
+// `iteratee` is called in parallel.
 func GroupBy[T any, U comparable](collection []T, iteratee func(T) U) map[U][]T {
 	result := map[U][]T{}
 
@@ -95,7 +95,7 @@ func GroupBy[T any, U comparable](collection []T, iteratee func(T) U) map[U][]T 
 // PartitionBy returns an array of elements split into groups. The order of grouped values is
 // determined by the order they occur in collection. The grouping is generated from the results
 // of running each element of collection through iteratee.
-// `iteratee` is call in parallel.
+// `iteratee` is called in parallel.
 func PartitionBy[T any, K comparable](collection []T, iteratee func(x T) K) [][]T {
 	result := [][]T{}
 	seen := map[K]int{}
@@ -127,4 +127,36 @@ func PartitionBy[T any, K comparable](collection []T, iteratee func(x T) K) [][]
 	wg.Wait()
 
 	return result
+}
+
+// Find search an element in a slice based on a predicate. It returns element and true if element was found.
+// `predicate` is called in parallel. No order guaranteed, i.e. found element may be not first matching the predicate.
+func Find[T any](collection []T, predicate func(T) bool) (T, bool) {
+	found := make(chan T, len(collection))
+	finished := make(chan struct{}, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(len(collection))
+	go func() {
+		wg.Wait()
+		finished <- struct{}{}
+	}()
+
+	for _, item := range collection {
+		go func(item T) {
+			if predicate(item) {
+				found <- item
+			}
+
+			wg.Done()
+		}(item)
+	}
+
+	var result T
+	select {
+	case result = <-found:
+		return result, true
+	case <-finished:
+		return result, false
+	}
 }

--- a/parallel/slice_test.go
+++ b/parallel/slice_test.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -84,4 +85,26 @@ func TestPartitionBy(t *testing.T) {
 
 	is.ElementsMatch(result1, [][]int{{-2, -1}, {0, 2, 4}, {1, 3, 5}})
 	is.Equal(result2, [][]int{})
+}
+
+func TestFind(t *testing.T) {
+	is := assert.New(t)
+
+	start1 := time.Now()
+	result1, ok1 := Find([]string{"a", "b", "c", "d"}, func(i string) bool {
+		time.Sleep(100 * time.Millisecond)
+		return i == "b"
+	})
+	elapsed1 := time.Since(start1)
+
+	result2, ok2 := Find([]string{"foobar"}, func(i string) bool {
+		return i == "b"
+	})
+
+	is.Equal(ok1, true)
+	is.Equal(result1, "b")
+	is.Less(elapsed1, 400*time.Millisecond)
+
+	is.Equal(ok2, false)
+	is.Equal(result2, "")
 }


### PR DESCRIPTION
Useful when you don't care about the order and need any matching element in collection ASAP.

For example, this snippet
```golang
func main() {
	start := time.Now()
	
	lo.Find([]string{"a", "b", "c", "d"}, func(letter string) bool {
		time.Sleep(1 * time.Second)
		
		return letter == "c"
	})
	
	fmt.Printf("finished Find in %s\n", time.Since(start).String())
}
```
finishes in ~3 seconds, while parallel one
```golang
func main() {
	start := time.Now()
	
	lop.Find([]string{"a", "b", "c", "d"}, func(letter string) bool {
		time.Sleep(1 * time.Second)
		
		return letter == "c"
	})
	
	fmt.Printf("finished Find in %s\n", time.Since(start).String())
}
```
in ~1 second.