### PR TITLE
feat: add MapToSlice method

### DIFF
--- a/map.go
+++ b/map.go
@@ -160,3 +160,14 @@ func MapValues[K comparable, V any, R any](in map[K]V, iteratee func(V, K) R) ma
 
 	return result
 }
+
+// MapToSlice transforms a map into a slice based on specific iteratee
+func MapToSlice[K comparable, V any, R any](in map[K]V, iteratee func(V, K) R) []R {
+	result := make([]R, 0, len(in))
+
+	for k, v := range in {
+		result = append(result, iteratee(v, k))
+	}
+
+	return result
+}

--- a/map_test.go
+++ b/map_test.go
@@ -1,6 +1,7 @@
 package lo
 
 import (
+	"fmt"
 	"sort"
 	"strconv"
 	"testing"
@@ -166,4 +167,20 @@ func TestMapValues(t *testing.T) {
 	is.Equal(len(result2), 4)
 	is.Equal(result1, map[int]string{1: "Hello", 2: "Hello", 3: "Hello", 4: "Hello"})
 	is.Equal(result2, map[int]string{1: "1", 2: "2", 3: "3", 4: "4"})
+}
+
+func TestMapToSlice(t *testing.T) {
+	is := assert.New(t)
+
+	result1 := MapToSlice(map[int]int{1: 1, 2: 2, 3: 3, 4: 4}, func(x int, v int) string {
+		return fmt.Sprintf("%d_%d", x, v)
+	})
+	result2 := MapToSlice(map[int]int{1: 1, 2: 2, 3: 3, 4: 4}, func(x int, _ int) string {
+		return strconv.FormatInt(int64(x), 10)
+	})
+
+	is.Equal(len(result1), 4)
+	is.Equal(len(result2), 4)
+	is.ElementsMatch(result1, []string{"1_1", "2_2", "3_3", "4_4"})
+	is.ElementsMatch(result2, []string{"1", "2", "3", "4"})
 }


### PR DESCRIPTION
Add a method to transform map[x]y to slice according to given func.

somthing like :

    	result1 := MapToSlice(map[int]int{1: 1, 2: 2, 3: 3, 4: 4}, func(x int, v int) string {
		return fmt.Sprintf("%d_%d", x, v)
        })
