### PR TITLE
feat: add `FromPtr` function

### DIFF
--- a/type_manipulation.go
+++ b/type_manipulation.go
@@ -5,6 +5,15 @@ func ToPtr[T any](x T) *T {
 	return &x
 }
 
+// FromPtr returns a value copy of a pointer.
+func FromPtr[T any](x *T) T {
+	if x == nil {
+		return Empty[T]()
+	}
+
+	return *x
+}
+
 // ToSlicePtr returns a slice of pointer copy of value.
 func ToSlicePtr[T any](collection []T) []*T {
 	return Map(collection, func(x T, _ int) *T {

--- a/type_manipulation_test.go
+++ b/type_manipulation_test.go
@@ -14,6 +14,15 @@ func TestToPtr(t *testing.T) {
 	is.Equal(*result1, []int{1, 2})
 }
 
+func TestFromPtr(t *testing.T) {
+	is := assert.New(t)
+
+	str1 := "foo"
+	result1 := FromPtr(&str1)
+
+	is.Equal(result1, str1)
+}
+
 func TestToSlicePtr(t *testing.T) {
 	is := assert.New(t)
 


### PR DESCRIPTION
Hey,
wanted to add a basic function that returns the value of a pointer.

When the pointer is `nil` it returns the default value of the type. I.e. for a `nil` string pointer, it would return an empty string `""`.