### PR TITLE
feat: add Intersperse function

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Supported helpers for slices:
 - [Replace](#replace)
 - [ReplaceAll](#replaceall)
 - [Compact](#compact)
+- [Intersperse](#intersperse)
 
 Supported helpers for maps:
 
@@ -678,6 +679,16 @@ in := []string{"", "foo", "", "bar", ""}
 
 slice := lo.Compact[string](in)
 // []string{"foo", "bar"}
+```
+
+### Intersperse
+
+Returns a slice with a separator value between each element in the input.
+
+```go
+in := []int{1, 2, 3}
+slice := Intersperse[int](in, 100)
+// []int{1, 100, 2, 100, 3}
 ```
 
 ### Keys

--- a/slice.go
+++ b/slice.go
@@ -437,3 +437,24 @@ func Compact[T comparable](collection []T) []T {
 
 	return result
 }
+
+// Intersperse inserts a value between each element of a slice.
+func Intersperse[T any](collection []T, separator T) []T {
+	size := len(collection)
+
+	if size == 0 {
+		return []T{}
+	}
+
+	result := make([]T, 0, size+size-1)
+
+	for i, item := range collection {
+		result = append(result, item)
+
+		if i != len(collection)-1 {
+			result = append(result, separator)
+		}
+	}
+
+	return result
+}

--- a/slice_test.go
+++ b/slice_test.go
@@ -532,3 +532,13 @@ func TestCompact(t *testing.T) {
 
 	is.Equal(r5, []*foo{&e1, &e2, &e3})
 }
+
+func TestIntersperse(t *testing.T) {
+	is := assert.New(t)
+
+	r1 := Intersperse([]int{1, 2, 3}, 100)
+	is.Equal([]int{1, 100, 2, 100, 3}, r1)
+
+	r2 := Intersperse([]string{"fizz", "buzz", "fizzbuzz"}, "|")
+	is.Equal([]string{"fizz", "|", "buzz", "|", "fizzbuzz"}, r2)
+}


### PR DESCRIPTION
`Intersperse` inserts a value between each element of a slice. It can be very useful to join items using a common element. Inspired by [rust intersperse iterator method](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.intersperse).

```go
s1 = []int{1, 2, 3,}
s2 := Intersperse(slice, 100)
is.Equal([]int{1, 100, 2, 100, 3, 100}, s2)
```