### PR TITLE
Allow Union to take many lists

### DIFF
--- a/intersect.go
+++ b/intersect.go
@@ -143,7 +143,12 @@ func Difference[T comparable](list1 []T, list2 []T) ([]T, []T) {
 
 // Union returns all distinct elements from both collections.
 // result returns will not change the order of elements relatively.
-func Union[T comparable](list1 []T, list2 []T) []T {
+func Union[T comparable](list1 []T, list2 []T, lists ...[]T) []T {
+	if len(lists) > 0 {
+		l := Union(list2, lists[0])
+		return Union(list1, l, lists[1:]...)
+	}
+
 	result := []T{}
 
 	seen := map[T]struct{}{}

--- a/intersect_test.go
+++ b/intersect_test.go
@@ -203,11 +203,15 @@ func TestUnion(t *testing.T) {
 	result3 := Union([]int{0, 1, 2, 3, 4, 5}, []int{})
 	result4 := Union([]int{0, 1, 2}, []int{0, 1, 2})
 	result5 := Union([]int{}, []int{})
+	result6 := Union([]int{1, 2}, []int{2, 3}, []int{3, 4})
+	result7 := Union([]int{1, 2}, []int{2, 3}, []int{3, 4}, []int{4, 5})
 	is.Equal(result1, []int{0, 1, 2, 3, 4, 5, 10})
 	is.Equal(result2, []int{0, 1, 2, 3, 4, 5, 6, 7})
 	is.Equal(result3, []int{0, 1, 2, 3, 4, 5})
 	is.Equal(result4, []int{0, 1, 2})
 	is.Equal(result5, []int{})
+	is.Equal(result6, []int{1, 2, 3, 4})
+	is.Equal(result7, []int{1, 2, 3, 4, 5})
 }
 
 func TestWithout(t *testing.T) {


### PR DESCRIPTION
Allow a union of any number of lists.

Note: similar code could be written for a number of functions, but I wanted to open this up for discussion. 

I also thought about changing the API to for more flexibility: 

```go
func Union[T comparable](lists ...[]T) []T 
```

This would be backward compatible, but would change the required number of arguments, so left it as it was for now. Happy to change it. 