### PR TITLE
feat: Add Associate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Supported helpers for slices:
 - [Replace](#replace)
 - [ReplaceAll](#replaceall)
 - [Compact](#compact)
+- [Associate](#associate)
 
 Supported helpers for maps:
 
@@ -678,6 +679,20 @@ in := []string{"", "foo", "", "bar", ""}
 
 slice := lo.Compact[string](in)
 // []string{"foo", "bar"}
+```
+
+### Associate
+
+Returns a map containing key-value pairs provided by transform function applied to elements of the given slice.
+If any of two pairs would have the same key the last one gets added to the map.
+The returned map preserves the entry iteration order of the original array.
+
+```go
+in := []*foo{{baz: "apple", bar: 1}, {baz: "banana", bar: 2}},
+aMap := Associate[*foo, string, int](in, func (f *foo) (string, int) { 
+	return f.baz, f.bar
+})
+// map[string][int]{ "apple":1, "banana":2 }
 ```
 
 ### Keys

--- a/slice.go
+++ b/slice.go
@@ -437,3 +437,17 @@ func Compact[T comparable](collection []T) []T {
 
 	return result
 }
+
+// Associate returns a map containing key-value pairs provided by transform function applied to elements of the given slice.
+// If any of two pairs would have the same key the last one gets added to the map.
+// The returned map preserves the entry iteration order of the original array.
+func Associate[T any, K comparable, V any](collection []T, transform func(T) (K, V)) map[K]V {
+	result := make(map[K]V)
+
+	for _, t := range collection {
+		k, v := transform(t)
+		result[k] = v
+	}
+
+	return result
+}

--- a/slice_test.go
+++ b/slice_test.go
@@ -1,6 +1,7 @@
 package lo
 
 import (
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -531,4 +532,37 @@ func TestCompact(t *testing.T) {
 	r5 := Compact([]*foo{&e1, &e2, nil, &e3})
 
 	is.Equal(r5, []*foo{&e1, &e2, &e3})
+}
+
+func TestAssociate(t *testing.T) {
+	type foo struct {
+		baz string
+		bar int
+	}
+	transform := func(f *foo) (string, int) {
+		return f.baz, f.bar
+	}
+	testCases := []struct {
+		in     []*foo
+		expect map[string]int
+	}{
+		{
+			in:     []*foo{{baz: "apple", bar: 1}},
+			expect: map[string]int{"apple": 1},
+		},
+		{
+			in:     []*foo{{baz: "apple", bar: 1}, {baz: "banana", bar: 2}},
+			expect: map[string]int{"apple": 1, "banana": 2},
+		},
+		{
+			in:     []*foo{{baz: "apple", bar: 1}, {baz: "apple", bar: 2}},
+			expect: map[string]int{"apple": 2},
+		},
+	}
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
+			is := assert.New(t)
+			is.Equal(Associate(testCase.in, transform), testCase.expect)
+		})
+	}
 }


### PR DESCRIPTION
Associate returns a map containing key-value pairs provided by transform function applied to elements of the given slice.

If any of two pairs would have the same key the last one gets added to the map.

The returned map preserves the entry iteration order of the original array.