### PR TITLE
Adding SliceToMap2->SliceToMap9 + Tuples2ToMap->Tuples9ToMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 @samber: I sometimes forget to update this file. Ping me on [Twitter](https://twitter.com/samuelberthe) or open an issue in case of error. We need to keep a clear changelog for easier lib upgrade.
 
+## 1.28.0 (2022-08-xx)
+
+Adding:
+
+- lo.SliceToMap2 -> lo.SliceToMap9
+- lo.Tuples2ToMap -> lo.Tuples9ToMap
+
 ## 1.27.0 (2022-07-29)
 
 Breaking:

--- a/README.md
+++ b/README.md
@@ -563,7 +563,27 @@ in := []*foo{
 aMap := lo.Associate[*foo, string, int](in, func (f *foo) (string, int) {
 	return f.baz, f.bar
 })
-// map[string][int]{ "apple":1, "banana":2 }
+// map[string]int{
+//     "apple": 1,
+//     "banana": 2,
+// }
+```
+
+Converting a slice into a map of keys, can increase lookup time.
+
+```go
+in := []string{"a", "b", "c", "a"}
+
+aMap := lo.Associate[*foo, string, struct{}](in, func (item string) (string, struct{}) {
+	return item, struct{}{}
+})
+// map[string]int{
+//     "a": struct{}{},
+//     "b": struct{}{},
+//     "c": struct{}{},
+// }
+
+_, ok := aMap["b"]
 ```
 
 ### SliceToMap2 -> SliceToMap9

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Supported helpers for slices:
 - [RepeatBy](#repeatby)
 - [KeyBy](#keyby)
 - [Associate / SliceToMap](#associate-alias-slicetomap)
+- [SliceToMap2 -> SliceToMap9](#slicetomap2---slicetomap9)
 - [Drop](#drop)
 - [DropRight](#dropright)
 - [DropWhile](#dropwhile)
@@ -131,6 +132,7 @@ Supported helpers for tuples:
 - [Unpack2 -> Unpack9](#unpack2---unpack9)
 - [Zip2 -> Zip9](#zip2---zip9)
 - [Unzip2 -> Unzip9](#unzip2---unzip9)
+- [Tuples2ToMap -> Tuples9ToMap](#tuples2tomap---tuples9tomap)
 
 Supported intersection helpers:
 
@@ -553,12 +555,43 @@ If any of two pairs would have the same key the last one gets added to the map.
 The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
 
 ```go
-in := []*foo{{baz: "apple", bar: 1}, {baz: "banana", bar: 2}},
+in := []*foo{
+    {baz: "apple", bar: 1},
+    {baz: "banana", bar: 2},
+}
 
 aMap := lo.Associate[*foo, string, int](in, func (f *foo) (string, int) {
 	return f.baz, f.bar
 })
 // map[string][int]{ "apple":1, "banana":2 }
+```
+
+### SliceToMap2 -> SliceToMap9
+
+Returns a map containing key-value tuples provided by transform function applied to elements of the given slice.
+If any of two tuples would have the same key the last one gets added to the map.
+
+The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+
+```go
+in := []*foo{
+    {baz: "apple", bar: 1},
+    {baz: "apple", bar: 42},
+    {baz: "banana", bar: 2},
+}
+
+aMap := lo.SliceToMap3[*foo, string, int, string](in, func (f *foo) (string, int, string) {
+	return f.baz, f.bar, fmt.Sprintf("%s_%d", f.baz, f.bar)
+})
+// map[string][int]string{
+//     "apple": map[int]string{
+//         1: "apple_1",
+//         42: "apple_42",
+//     },
+//     "banana": map[int]string{
+//         2: "banana_2",
+//     },
+// }
 ```
 
 ### Drop
@@ -1051,6 +1084,32 @@ Unzip accepts an array of grouped elements and creates an array regrouping the e
 a, b := lo.Unzip2[string, int]([]Tuple2[string, int]{{A: "a", B: 1}, {A: "b", B: 2}})
 // []string{"a", "b"}
 // []int{1, 2}
+```
+
+### Tuples2ToMap -> Tuples9ToMap
+
+Returns a map containing key-value tuples.
+If any of two tuples would have the same key the last one gets added to the map.
+
+The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+
+```go
+in := []lo.Tuple3[string, int, string]{
+    lo.T3("apple", 1, "foobar"),
+    lo.T3("apple", 42, "foobar"),
+    lo.T3("banana", 1, "hello world"),
+}
+
+m := lo.Tuples3ToMap[string, int, string](in)
+// map[string][int]string{
+//     "apple": map[int]string{
+//         1: "foobar",
+//         42: "foobar",
+//     },
+//     "banana": map[int]string{
+//         1: "hello world",
+//     },
+// }
 ```
 
 ### Contains

--- a/slice.go
+++ b/slice.go
@@ -272,10 +272,10 @@ func KeyBy[K comparable, V any](collection []V, iteratee func(V) K) map[K]V {
 	return result
 }
 
-// Associate returns a map containing key-value pairs provided by transform function applied to elements of the given slice.
+// SliceToMap2 returns a map containing key-value pairs provided by transform function applied to elements of the given slice.
 // If any of two pairs would have the same key the last one gets added to the map.
 // The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
-func Associate[T any, K comparable, V any](collection []T, transform func(T) (K, V)) map[K]V {
+func SliceToMap2[T any, K comparable, V any](collection []T, transform func(T) (K, V)) map[K]V {
 	result := make(map[K]V)
 
 	for _, t := range collection {
@@ -286,12 +286,237 @@ func Associate[T any, K comparable, V any](collection []T, transform func(T) (K,
 	return result
 }
 
+// SliceToMap3 returns a map containing key-value tuples provided by transform function applied to elements of the given slice.
+// If any of two tuples would have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+func SliceToMap3[T any, K1 comparable, K2 comparable, V any](collection []T, transform func(T) (K1, K2, V)) map[K1]map[K2]V {
+	result := map[K1]map[K2]V{}
+
+	for _, t := range collection {
+		k1, k2, v := transform(t)
+
+		if _, ok := result[k1]; !ok {
+			result[k1] = map[K2]V{}
+		}
+
+		result[k1][k2] = v
+	}
+
+	return result
+}
+
+// SliceToMap4 returns a map containing key-value tuples provided by transform function applied to elements of the given slice.
+// If any of two tuples would have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+func SliceToMap4[T any, K1 comparable, K2 comparable, K3 comparable, V any](collection []T, transform func(T) (K1, K2, K3, V)) map[K1]map[K2]map[K3]V {
+	result := map[K1]map[K2]map[K3]V{}
+
+	for _, t := range collection {
+		k1, k2, k3, v := transform(t)
+
+		if _, ok := result[k1]; !ok {
+			result[k1] = map[K2]map[K3]V{}
+		}
+
+		if _, ok := result[k1][k2]; !ok {
+			result[k1][k2] = map[K3]V{}
+		}
+
+		result[k1][k2][k3] = v
+	}
+
+	return result
+}
+
+// SliceToMap5 returns a map containing key-value tuples provided by transform function applied to elements of the given slice.
+// If any of two tuples would have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+func SliceToMap5[T any, K1 comparable, K2 comparable, K3 comparable, K4 comparable, V any](collection []T, transform func(T) (K1, K2, K3, K4, V)) map[K1]map[K2]map[K3]map[K4]V {
+	result := map[K1]map[K2]map[K3]map[K4]V{}
+
+	for _, t := range collection {
+		k1, k2, k3, k4, v := transform(t)
+
+		if _, ok := result[k1]; !ok {
+			result[k1] = map[K2]map[K3]map[K4]V{}
+		}
+
+		if _, ok := result[k1][k2]; !ok {
+			result[k1][k2] = map[K3]map[K4]V{}
+		}
+
+		if _, ok := result[k1][k2][k3]; !ok {
+			result[k1][k2][k3] = map[K4]V{}
+		}
+
+		result[k1][k2][k3][k4] = v
+	}
+
+	return result
+}
+
+// SliceToMap6 returns a map containing key-value tuples provided by transform function applied to elements of the given slice.
+// If any of two tuples would have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+func SliceToMap6[T any, K1 comparable, K2 comparable, K3 comparable, K4 comparable, K5 comparable, V any](collection []T, transform func(T) (K1, K2, K3, K4, K5, V)) map[K1]map[K2]map[K3]map[K4]map[K5]V {
+	result := map[K1]map[K2]map[K3]map[K4]map[K5]V{}
+
+	for _, t := range collection {
+		k1, k2, k3, k4, k5, v := transform(t)
+
+		if _, ok := result[k1]; !ok {
+			result[k1] = map[K2]map[K3]map[K4]map[K5]V{}
+		}
+
+		if _, ok := result[k1][k2]; !ok {
+			result[k1][k2] = map[K3]map[K4]map[K5]V{}
+		}
+
+		if _, ok := result[k1][k2][k3]; !ok {
+			result[k1][k2][k3] = map[K4]map[K5]V{}
+		}
+
+		if _, ok := result[k1][k2][k3][k4]; !ok {
+			result[k1][k2][k3][k4] = map[K5]V{}
+		}
+
+		result[k1][k2][k3][k4][k5] = v
+	}
+
+	return result
+}
+
+// SliceToMap7 returns a map containing key-value tuples provided by transform function applied to elements of the given slice.
+// If any of two tuples would have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+func SliceToMap7[T any, K1 comparable, K2 comparable, K3 comparable, K4 comparable, K5 comparable, K6 comparable, V any](collection []T, transform func(T) (K1, K2, K3, K4, K5, K6, V)) map[K1]map[K2]map[K3]map[K4]map[K5]map[K6]V {
+	result := map[K1]map[K2]map[K3]map[K4]map[K5]map[K6]V{}
+
+	for _, t := range collection {
+		k1, k2, k3, k4, k5, k6, v := transform(t)
+
+		if _, ok := result[k1]; !ok {
+			result[k1] = map[K2]map[K3]map[K4]map[K5]map[K6]V{}
+		}
+
+		if _, ok := result[k1][k2]; !ok {
+			result[k1][k2] = map[K3]map[K4]map[K5]map[K6]V{}
+		}
+
+		if _, ok := result[k1][k2][k3]; !ok {
+			result[k1][k2][k3] = map[K4]map[K5]map[K6]V{}
+		}
+
+		if _, ok := result[k1][k2][k3][k4]; !ok {
+			result[k1][k2][k3][k4] = map[K5]map[K6]V{}
+		}
+
+		if _, ok := result[k1][k2][k3][k4][k5]; !ok {
+			result[k1][k2][k3][k4][k5] = map[K6]V{}
+		}
+
+		result[k1][k2][k3][k4][k5][k6] = v
+	}
+
+	return result
+}
+
+// SliceToMap8 returns a map containing key-value tuples provided by transform function applied to elements of the given slice.
+// If any of two tuples would have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+func SliceToMap8[T any, K1 comparable, K2 comparable, K3 comparable, K4 comparable, K5 comparable, K6 comparable, K7 comparable, V any](collection []T, transform func(T) (K1, K2, K3, K4, K5, K6, K7, V)) map[K1]map[K2]map[K3]map[K4]map[K5]map[K6]map[K7]V {
+	result := map[K1]map[K2]map[K3]map[K4]map[K5]map[K6]map[K7]V{}
+
+	for _, t := range collection {
+		k1, k2, k3, k4, k5, k6, k7, v := transform(t)
+
+		if _, ok := result[k1]; !ok {
+			result[k1] = map[K2]map[K3]map[K4]map[K5]map[K6]map[K7]V{}
+		}
+
+		if _, ok := result[k1][k2]; !ok {
+			result[k1][k2] = map[K3]map[K4]map[K5]map[K6]map[K7]V{}
+		}
+
+		if _, ok := result[k1][k2][k3]; !ok {
+			result[k1][k2][k3] = map[K4]map[K5]map[K6]map[K7]V{}
+		}
+
+		if _, ok := result[k1][k2][k3][k4]; !ok {
+			result[k1][k2][k3][k4] = map[K5]map[K6]map[K7]V{}
+		}
+
+		if _, ok := result[k1][k2][k3][k4][k5]; !ok {
+			result[k1][k2][k3][k4][k5] = map[K6]map[K7]V{}
+		}
+
+		if _, ok := result[k1][k2][k3][k4][k5][k6]; !ok {
+			result[k1][k2][k3][k4][k5][k6] = map[K7]V{}
+		}
+
+		result[k1][k2][k3][k4][k5][k6][k7] = v
+	}
+
+	return result
+}
+
+// SliceToMap9 returns a map containing key-value tuples provided by transform function applied to elements of the given slice.
+// If any of two tuples would have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+func SliceToMap9[T any, K1 comparable, K2 comparable, K3 comparable, K4 comparable, K5 comparable, K6 comparable, K7 comparable, K8 comparable, V any](collection []T, transform func(T) (K1, K2, K3, K4, K5, K6, K7, K8, V)) map[K1]map[K2]map[K3]map[K4]map[K5]map[K6]map[K7]map[K8]V {
+	result := map[K1]map[K2]map[K3]map[K4]map[K5]map[K6]map[K7]map[K8]V{}
+
+	for _, t := range collection {
+		k1, k2, k3, k4, k5, k6, k7, k8, v := transform(t)
+
+		if _, ok := result[k1]; !ok {
+			result[k1] = map[K2]map[K3]map[K4]map[K5]map[K6]map[K7]map[K8]V{}
+		}
+
+		if _, ok := result[k1][k2]; !ok {
+			result[k1][k2] = map[K3]map[K4]map[K5]map[K6]map[K7]map[K8]V{}
+		}
+
+		if _, ok := result[k1][k2][k3]; !ok {
+			result[k1][k2][k3] = map[K4]map[K5]map[K6]map[K7]map[K8]V{}
+		}
+
+		if _, ok := result[k1][k2][k3][k4]; !ok {
+			result[k1][k2][k3][k4] = map[K5]map[K6]map[K7]map[K8]V{}
+		}
+
+		if _, ok := result[k1][k2][k3][k4][k5]; !ok {
+			result[k1][k2][k3][k4][k5] = map[K6]map[K7]map[K8]V{}
+		}
+
+		if _, ok := result[k1][k2][k3][k4][k5][k6]; !ok {
+			result[k1][k2][k3][k4][k5][k6] = map[K7]map[K8]V{}
+		}
+
+		if _, ok := result[k1][k2][k3][k4][k5][k6][k7]; !ok {
+			result[k1][k2][k3][k4][k5][k6][k7] = map[K8]V{}
+		}
+
+		result[k1][k2][k3][k4][k5][k6][k7][k8] = v
+	}
+
+	return result
+}
+
+// SliceToMap returns a map containing key-value pairs provided by transform function applied to elements of the given slice.
+// If any of two pairs would have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+// Alias of SliceToMap2().
+func SliceToMap[T any, K comparable, V any](collection []T, transform func(T) (K, V)) map[K]V {
+	return SliceToMap2(collection, transform)
+}
+
 // Associate returns a map containing key-value pairs provided by transform function applied to elements of the given slice.
 // If any of two pairs would have the same key the last one gets added to the map.
 // The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
-// Alias of Associate().
-func SliceToMap[T any, K comparable, V any](collection []T, transform func(T) (K, V)) map[K]V {
-	return Associate(collection, transform)
+// Alias of SliceToMap().
+func Associate[T any, K comparable, V any](collection []T, transform func(T) (K, V)) map[K]V {
+	return SliceToMap(collection, transform)
 }
 
 // Drop drops n elements from the beginning of a slice or array.

--- a/slice_test.go
+++ b/slice_test.go
@@ -289,7 +289,7 @@ func TestKeyBy(t *testing.T) {
 	is.Equal(result1, map[int]string{1: "a", 2: "aa", 3: "aaa"})
 }
 
-func TestAssociate(t *testing.T) {
+func TestSliceToMap2(t *testing.T) {
 	type foo struct {
 		baz string
 		bar int
@@ -317,9 +317,32 @@ func TestAssociate(t *testing.T) {
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
 			is := assert.New(t)
-			is.Equal(Associate(testCase.in, transform), testCase.expect)
+			is.Equal(SliceToMap2(testCase.in, transform), testCase.expect)
 		})
 	}
+}
+
+func TestSliceToMapX(t *testing.T) {
+	is := assert.New(t)
+
+	slice := []int{0, 1, 2, 3, 4, 5, 6}
+	transform2 := func(int) (int, int) { return 1, 2 }
+	transform3 := func(int) (int, int, int) { return 1, 2, 3 }
+	transform4 := func(int) (int, int, int, int) { return 1, 2, 3, 4 }
+	transform5 := func(int) (int, int, int, int, int) { return 1, 2, 3, 4, 5 }
+	transform6 := func(int) (int, int, int, int, int, int) { return 1, 2, 3, 4, 5, 6 }
+	transform7 := func(int) (int, int, int, int, int, int, int) { return 1, 2, 3, 4, 5, 6, 7 }
+	transform8 := func(int) (int, int, int, int, int, int, int, int) { return 1, 2, 3, 4, 5, 6, 7, 8 }
+	transform9 := func(int) (int, int, int, int, int, int, int, int, int) { return 1, 2, 3, 4, 5, 6, 7, 8, 9 }
+
+	is.EqualValues(map[int]int{1: 2}, SliceToMap2(slice, transform2))
+	is.EqualValues(map[int]map[int]int{1: {2: 3}}, SliceToMap3(slice, transform3))
+	is.EqualValues(map[int]map[int]map[int]int{1: {2: {3: 4}}}, SliceToMap4(slice, transform4))
+	is.EqualValues(map[int]map[int]map[int]map[int]int{1: {2: {3: {4: 5}}}}, SliceToMap5(slice, transform5))
+	is.EqualValues(map[int]map[int]map[int]map[int]map[int]int{1: {2: {3: {4: {5: 6}}}}}, SliceToMap6(slice, transform6))
+	is.EqualValues(map[int]map[int]map[int]map[int]map[int]map[int]int{1: {2: {3: {4: {5: {6: 7}}}}}}, SliceToMap7(slice, transform7))
+	is.EqualValues(map[int]map[int]map[int]map[int]map[int]map[int]map[int]int{1: {2: {3: {4: {5: {6: {7: 8}}}}}}}, SliceToMap8(slice, transform8))
+	is.EqualValues(map[int]map[int]map[int]map[int]map[int]map[int]map[int]map[int]int{1: {2: {3: {4: {5: {6: {7: {8: 9}}}}}}}}, SliceToMap9(slice, transform9))
 }
 
 func TestDrop(t *testing.T) {

--- a/tuples.go
+++ b/tuples.go
@@ -479,3 +479,59 @@ func Unzip9[A any, B any, C any, D any, E any, F any, G any, H any, I any](tuple
 
 	return r1, r2, r3, r4, r5, r6, r7, r8, r9
 }
+
+// Tuples2ToMap returns a map containing key-value tuples.
+// If any of two tuples would have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+func Tuples2ToMap[A comparable, B any](tuples []Tuple2[A, B]) map[A]B {
+	return SliceToMap2(tuples, Unpack2[A, B])
+}
+
+// Tuples3ToMap returns a map containing key-value tuples.
+// If any of two tuples would have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+func Tuples3ToMap[A comparable, B comparable, C any](tuples []Tuple3[A, B, C]) map[A]map[B]C {
+	return SliceToMap3(tuples, Unpack3[A, B, C])
+}
+
+// Tuples4ToMap returns a map containing key-value tuples.
+// If any of two tuples would have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+func Tuples4ToMap[A comparable, B comparable, C comparable, D any](tuples []Tuple4[A, B, C, D]) map[A]map[B]map[C]D {
+	return SliceToMap4(tuples, Unpack4[A, B, C, D])
+}
+
+// Tuples5ToMap returns a map containing key-value tuples.
+// If any of two tuples would have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+func Tuples5ToMap[A comparable, B comparable, C comparable, D comparable, E any](tuples []Tuple5[A, B, C, D, E]) map[A]map[B]map[C]map[D]E {
+	return SliceToMap5(tuples, Unpack5[A, B, C, D, E])
+}
+
+// Tuples3ToMap returns a map containing key-value tuples.
+// If any of two tuples would have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+func Tuples6ToMap[A comparable, B comparable, C comparable, D comparable, E comparable, F any](tuples []Tuple6[A, B, C, D, E, F]) map[A]map[B]map[C]map[D]map[E]F {
+	return SliceToMap6(tuples, Unpack6[A, B, C, D, E, F])
+}
+
+// Tuples7ToMap returns a map containing key-value tuples.
+// If any of two tuples would have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+func Tuples7ToMap[A comparable, B comparable, C comparable, D comparable, E comparable, F comparable, G any](tuples []Tuple7[A, B, C, D, E, F, G]) map[A]map[B]map[C]map[D]map[E]map[F]G {
+	return SliceToMap7(tuples, Unpack7[A, B, C, D, E, F, G])
+}
+
+// Tuples8ToMap returns a map containing key-value tuples.
+// If any of two tuples would have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+func Tuples8ToMap[A comparable, B comparable, C comparable, D comparable, E comparable, F comparable, G comparable, H any](tuples []Tuple8[A, B, C, D, E, F, G, H]) map[A]map[B]map[C]map[D]map[E]map[F]map[G]H {
+	return SliceToMap8(tuples, Unpack8[A, B, C, D, E, F, G, H])
+}
+
+// Tuples9ToMap returns a map containing key-value tuples.
+// If any of two tuples would have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+func Tuples9ToMap[A comparable, B comparable, C comparable, D comparable, E comparable, F comparable, G comparable, H comparable, I any](tuples []Tuple9[A, B, C, D, E, F, G, H, I]) map[A]map[B]map[C]map[D]map[E]map[F]map[G]map[H]I {
+	return SliceToMap9(tuples, Unpack9[A, B, C, D, E, F, G, H, I])
+}

--- a/tuples_test.go
+++ b/tuples_test.go
@@ -279,3 +279,102 @@ func TestUnzip(t *testing.T) {
 	is.Equal(r1, []string{"a", "b"})
 	is.Equal(r2, []int{1, 2})
 }
+
+func TestTuplesToMap(t *testing.T) {
+	is := assert.New(t)
+
+	r2 := []Tuple2[string, string]{
+		T2("a", "b"),
+		T2("a", "bb"),
+		T2("aa", "bb"),
+	}
+	r3 := []Tuple3[string, string, string]{
+		T3("a", "b", "c"),
+		T3("a", "bb", "c"),
+		T3("aa", "bb", "cc"),
+	}
+	r4 := []Tuple4[string, string, string, string]{
+		T4("a", "b", "c", "d"),
+		T4("a", "bb", "c", "d"),
+		T4("aa", "bb", "cc", "dd"),
+	}
+	r5 := []Tuple5[string, string, string, string, string]{
+		T5("a", "b", "c", "d", "e"),
+		T5("a", "bb", "c", "d", "e"),
+		T5("aa", "bb", "cc", "dd", "ee"),
+	}
+	r6 := []Tuple6[string, string, string, string, string, string]{
+		T6("a", "b", "c", "d", "e", "f"),
+		T6("a", "bb", "c", "d", "e", "f"),
+		T6("aa", "bb", "cc", "dd", "ee", "ff"),
+	}
+	r7 := []Tuple7[string, string, string, string, string, string, string]{
+		T7("a", "b", "c", "d", "e", "f", "g"),
+		T7("a", "bb", "c", "d", "e", "f", "g"),
+		T7("aa", "bb", "cc", "dd", "ee", "ff", "gg"),
+	}
+	r8 := []Tuple8[string, string, string, string, string, string, string, string]{
+		T8("a", "b", "c", "d", "e", "f", "g", "h"),
+		T8("a", "bb", "c", "d", "e", "f", "g", "h"),
+		T8("aa", "bb", "cc", "dd", "ee", "ff", "gg", "hh"),
+	}
+	r9 := []Tuple9[string, string, string, string, string, string, string, string, string]{
+		T9("a", "b", "c", "d", "e", "f", "g", "h", "i"),
+		T9("a", "bb", "c", "d", "e", "f", "g", "h", "i"),
+		T9("aa", "bb", "cc", "dd", "ee", "ff", "gg", "hh", "ii"),
+	}
+
+	is.EqualValues(map[string]string{
+		"a":  "bb",
+		"aa": "bb",
+	}, Tuples2ToMap(r2))
+	is.EqualValues(map[string]map[string]string{
+		"a": {
+			"b":  "c",
+			"bb": "c",
+		},
+		"aa": {"bb": "cc"},
+	}, Tuples3ToMap(r3))
+	is.EqualValues(map[string]map[string]map[string]string{
+		"a": {
+			"b":  {"c": "d"},
+			"bb": {"c": "d"},
+		},
+		"aa": {"bb": {"cc": "dd"}},
+	}, Tuples4ToMap(r4))
+	is.EqualValues(map[string]map[string]map[string]map[string]string{
+		"a": {
+			"b":  {"c": {"d": "e"}},
+			"bb": {"c": {"d": "e"}},
+		},
+		"aa": {"bb": {"cc": {"dd": "ee"}}},
+	}, Tuples5ToMap(r5))
+	is.EqualValues(map[string]map[string]map[string]map[string]map[string]string{
+		"a": {
+			"b":  {"c": {"d": {"e": "f"}}},
+			"bb": {"c": {"d": {"e": "f"}}},
+		},
+		"aa": {"bb": {"cc": {"dd": {"ee": "ff"}}}},
+	}, Tuples6ToMap(r6))
+	is.EqualValues(map[string]map[string]map[string]map[string]map[string]map[string]string{
+		"a": {
+			"b":  {"c": {"d": {"e": {"f": "g"}}}},
+			"bb": {"c": {"d": {"e": {"f": "g"}}}},
+		},
+		"aa": {"bb": {"cc": {"dd": {"ee": {"ff": "gg"}}}}},
+	}, Tuples7ToMap(r7))
+	is.EqualValues(map[string]map[string]map[string]map[string]map[string]map[string]map[string]string{
+		"a": {
+			"b":  {"c": {"d": {"e": {"f": {"g": "h"}}}}},
+			"bb": {"c": {"d": {"e": {"f": {"g": "h"}}}}},
+		},
+		"aa": {"bb": {"cc": {"dd": {"ee": {"ff": {"gg": "hh"}}}}}},
+	}, Tuples8ToMap(r8))
+	is.EqualValues(map[string]map[string]map[string]map[string]map[string]map[string]map[string]map[string]string{
+		"a": {
+			"b":  {"c": {"d": {"e": {"f": {"g": {"h": "i"}}}}}},
+			"bb": {"c": {"d": {"e": {"f": {"g": {"h": "i"}}}}}},
+		},
+		"aa": {"bb": {"cc": {"dd": {"ee": {"ff": {"gg": {"hh": "ii"}}}}}}},
+	}, Tuples9ToMap(r9))
+}


### PR DESCRIPTION
@CorentinClabaut Can i ask for a quick review please ?

I don't really like the naming of these helpers. Do you have a better idea?

I think we can also write the following helpers:
- `lo.MapToTuplesX`
- `lo.MapXToSlice`

