### PR TITLE
Equality testing for comparable slices and maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Supported helpers for slices:
 - [Compact](#compact)
 - [IsSorted](#issorted)
 - [IsSortedByKey](#issortedbykey)
+- [Equal](#equal)
 
 Supported helpers for maps:
 
@@ -112,6 +113,7 @@ Supported helpers for maps:
 - [MapKeys](#mapkeys)
 - [MapValues](#mapvalues)
 - [MapToSlice](#maptoslice)
+- [MapEqual](mapequal)
 
 Supported math helpers:
 
@@ -734,6 +736,17 @@ slice := lo.IsSortedByKey([]string{"a", "bb", "ccc"}, func(s string) int {
 // true
 ```
 
+### Equal
+
+Checks if two given slices of comparable elements are equal.
+
+```go
+slice1 := []int{1, 2, 3}
+slice2 := []int{1*1, 1+1, 6/2}
+eq := lo.Equal(slice1, slice2)
+// true
+```
+
 ### Keys
 
 Creates an array of the map keys.
@@ -906,6 +919,21 @@ s := lo.MapToSlice(m, func(k int, v int64) string {
 })
 // []string{"1_4", "2_5", "3_6"}
 ```
+
+### MapEqual
+
+Checks if two given maps are equal, i.e each key is contained in both and is mapped to the same value.
+
+```go
+map1 := map[int]int{0: 0, 1: 1, 2: 4, 3: 9, 4: 16, 5: 25}
+map2 := make(map[int]int)
+for k := range map1 {
+    map2[k] = k*k
+}
+eq := lo.MapEqual(map1, map2)
+// true
+```
+
 
 ### Range / RangeFrom / RangeWithSteps
 

--- a/map.go
+++ b/map.go
@@ -183,3 +183,16 @@ func MapToSlice[K comparable, V any, R any](in map[K]V, iteratee func(K, V) R) [
 
 	return result
 }
+
+// MapEqual checks if the maps contain the same keys and values with the same mapping between them.
+func MapEqual[K, V comparable](a, b map[K]V) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, va := range a {
+		if vb, ok := b[k]; !ok || vb != va {
+			return false
+		}
+	}
+	return true
+}

--- a/map_test.go
+++ b/map_test.go
@@ -184,3 +184,14 @@ func TestMapToSlice(t *testing.T) {
 	is.ElementsMatch(result1, []string{"1_5", "2_6", "3_7", "4_8"})
 	is.ElementsMatch(result2, []string{"1", "2", "3", "4"})
 }
+
+func TestMapEqual(t *testing.T) {
+	is := assert.New(t)
+
+	is.True(MapEqual(map[int]string{}, map[int]string{}))
+	is.True(MapEqual(map[int]string{1: "foo", 2: "bar"}, map[int]string{2: "bar", 1: "foo"}))
+
+	is.False(MapEqual(map[int]string{1: "foo", 2: "bar"}, map[int]string{1: "foo"}))
+	is.False(MapEqual(map[int]string{1: "foo", 2: "bar"}, map[int]string{1: "foo", 2: "bar", 3: "bazz"}))
+	is.False(MapEqual(map[int]string{1: "foo", 2: "bar"}, map[int]string{2: "foo", 1: "bar"}))
+}

--- a/slice.go
+++ b/slice.go
@@ -494,3 +494,16 @@ func IsSortedByKey[T any, K constraints.Ordered](collection []T, iteratee func(T
 
 	return true
 }
+
+// Equal checks if the slices contain exactly the same elements and have the same length.
+func Equal[T comparable](a, b []T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/slice_test.go
+++ b/slice_test.go
@@ -603,3 +603,16 @@ func TestIsSortedByKey(t *testing.T) {
 		return ret
 	}))
 }
+
+func TestEqual(t *testing.T) {
+	is := assert.New(t)
+
+	is.True(Equal([]int{}, []int{}))
+	is.True(Equal([]int{1}, []int{1}))
+	is.True(Equal([]int{1, 2, 3, 4}, []int{1, 2, 3, 4}))
+
+	is.False(Equal([]int{1, 2, 3}, []int{}))
+	is.False(Equal([]int{1}, []int{1, 2, 3}))
+	is.False(Equal([]int{1, 2, 3}, []int{1, 3, 2}))
+	is.False(Equal([]int{1, 1}, []int{1}))
+}


### PR DESCRIPTION
Implemented as `Equal()` and `MapEqual()`.