### PR TITLE
`Uniq` turns nil slice to non-nil empty slice

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -98,6 +98,10 @@ func Times[T any](count int, iteratee func(int) T) []T {
 // Uniq returns a duplicate-free version of an array, in which only the first occurrence of each element is kept.
 // The order of result values is determined by the order they occur in the array.
 func Uniq[T comparable](collection []T) []T {
+	if len(collection) == 0 {
+		return nil
+	}
+
 	result := make([]T, 0, len(collection))
 	seen := make(map[T]struct{}, len(collection))
 

--- a/slice_test.go
+++ b/slice_test.go
@@ -149,9 +149,11 @@ func TestUniq(t *testing.T) {
 	is := assert.New(t)
 
 	result1 := Uniq([]int{1, 2, 2, 1})
+	result2 := Uniq([]int{})
 
 	is.Equal(len(result1), 2)
 	is.Equal(result1, []int{1, 2})
+	is.Nil(result2)
 }
 
 func TestUniqBy(t *testing.T) {


### PR DESCRIPTION
fix: https://github.com/samber/lo/issues/192