### PR TITLE
Fix: up to 80% speed and memory optimizations for slices

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -154,17 +154,19 @@ func Chunk[T any](collection []T, size int) [][]T {
 		panic("Second parameter must be greater than 0")
 	}
 
-	result := make([][]T, 0, len(collection)/2+1)
-	length := len(collection)
+	chunksNum := len(collection) / size
+	if len(collection)%size != 0 {
+		chunksNum += 1
+	}
 
-	for i := 0; i < length; i++ {
-		chunk := i / size
+	result := make([][]T, 0, chunksNum)
 
-		if i%size == 0 {
-			result = append(result, make([]T, 0, size))
+	for i := 0; i < chunksNum; i++ {
+		last := (i + 1) * size
+		if last > len(collection) {
+			last = len(collection)
 		}
-
-		result[chunk] = append(result[chunk], collection[i])
+		result = append(result, collection[i*size:last])
 	}
 
 	return result
@@ -198,11 +200,18 @@ func PartitionBy[T any, K comparable](collection []T, iteratee func(x T) K) [][]
 }
 
 // Flatten returns an array a single level deep.
-func Flatten[T any](collection [][]T) (result []T) {
-	for _, item := range collection {
-		result = append(result, item...)
+func Flatten[T any](collection [][]T) []T {
+	totalLen := 0
+	for i := range collection {
+		totalLen += len(collection[i])
 	}
-	return
+
+	result := make([]T, 0, totalLen)
+	for i := range collection {
+		result = append(result, collection[i]...)
+	}
+
+	return result
 }
 
 // Shuffle returns an array of shuffled values. Uses the Fisher-Yates shuffle algorithm.
@@ -329,15 +338,11 @@ func DropWhile[T any](collection []T, predicate func(T) bool) []T {
 // DropRight drops n elements from the end of a slice or array.
 func DropRight[T any](collection []T, n int) []T {
 	if len(collection) <= n {
-		return make([]T, 0)
+		return []T{}
 	}
 
-	result := make([]T, len(collection)-n)
-	for i := len(collection) - 1 - n; i >= 0; i-- {
-		result[i] = collection[i]
-	}
-
-	return result
+	result := make([]T, 0, len(collection)-n)
+	return append(result, collection[:len(collection)-n]...)
 }
 
 // DropRightWhile drops elements from the end of a slice or array while the predicate returns true.
@@ -436,15 +441,13 @@ func Slice[T comparable](collection []T, start int, end int) []T {
 
 // Replace returns a copy of the slice with the first n non-overlapping instances of old replaced by new.
 func Replace[T comparable](collection []T, old T, new T, n int) []T {
-	size := len(collection)
-	result := make([]T, 0, size)
+	result := make([]T, 0, len(collection))
+	copy(result, collection)
 
-	for _, item := range collection {
-		if item == old && n != 0 {
-			result = append(result, new)
+	for i := range result {
+		if result[i] == old && n != 0 {
+			result[i] = new
 			n--
-		} else {
-			result = append(result, item)
 		}
 	}
 

--- a/slice.go
+++ b/slice.go
@@ -309,12 +309,9 @@ func Drop[T any](collection []T, n int) []T {
 		return make([]T, 0)
 	}
 
-	result := make([]T, len(collection)-n)
-	for i := n; i < len(collection); i++ {
-		result[i-n] = collection[i]
-	}
+	result := make([]T, 0, len(collection)-n)
 
-	return result
+	return append(result, collection[n:]...)
 }
 
 // DropWhile drops elements from the beginning of a slice or array while the predicate returns true.
@@ -326,13 +323,8 @@ func DropWhile[T any](collection []T, predicate func(T) bool) []T {
 		}
 	}
 
-	result := make([]T, len(collection)-i)
-
-	for j := 0; i < len(collection); i, j = i+1, j+1 {
-		result[j] = collection[i]
-	}
-
-	return result
+	result := make([]T, 0, len(collection)-i)
+	return append(result, collection[i:]...)
 }
 
 // DropRight drops n elements from the end of a slice or array.
@@ -354,13 +346,8 @@ func DropRightWhile[T any](collection []T, predicate func(T) bool) []T {
 		}
 	}
 
-	result := make([]T, i+1)
-
-	for ; i >= 0; i-- {
-		result[i] = collection[i]
-	}
-
-	return result
+	result := make([]T, 0, i+1)
+	return append(result, collection[:i+1]...)
 }
 
 // Reject is the opposite of Filter, this method returns the elements of collection that predicate does not return truthy for.
@@ -441,7 +428,7 @@ func Slice[T comparable](collection []T, start int, end int) []T {
 
 // Replace returns a copy of the slice with the first n non-overlapping instances of old replaced by new.
 func Replace[T comparable](collection []T, old T, new T, n int) []T {
-	result := make([]T, 0, len(collection))
+	result := make([]T, len(collection))
 	copy(result, collection)
 
 	for i := range result {

--- a/slice_benchmark_test.go
+++ b/slice_benchmark_test.go
@@ -1,0 +1,133 @@
+package lo
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"testing"
+)
+
+var lengths = []int{10, 100, 1000}
+
+func BenchmarkChunk(b *testing.B) {
+	for _, n := range lengths {
+		strs := genSliceString(n)
+		b.Run(fmt.Sprintf("strings_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = Chunk(strs, 5)
+			}
+		})
+	}
+
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = Chunk(ints, 5)
+			}
+		})
+	}
+}
+
+func genSliceString(n int) []string {
+	res := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		res = append(res, strconv.Itoa(rand.Intn(100_000)))
+	}
+	return res
+}
+
+func genSliceInt(n int) []int {
+	res := make([]int, 0, n)
+	for i := 0; i < n; i++ {
+		res = append(res, rand.Intn(100_000))
+	}
+	return res
+}
+
+func BenchmarkFlatten(b *testing.B) {
+	for _, n := range lengths {
+		ints := make([][]int, 0, n)
+		for i := 0; i < n; i++ {
+			ints = append(ints, genSliceInt(n))
+		}
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = Flatten(ints)
+			}
+		})
+	}
+
+	for _, n := range lengths {
+		strs := make([][]string, 0, n)
+		for i := 0; i < n; i++ {
+			strs = append(strs, genSliceString(n))
+		}
+		b.Run(fmt.Sprintf("strings_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = Flatten(strs)
+			}
+		})
+	}
+}
+
+func BenchmarkDrop(b *testing.B) {
+	for _, n := range lengths {
+		strs := genSliceString(n)
+		b.Run(fmt.Sprintf("strings_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = Drop(strs, n/4)
+			}
+		})
+	}
+
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = Drop(ints, n/4)
+			}
+		})
+	}
+}
+
+func BenchmarkDropRight(b *testing.B) {
+	for _, n := range lengths {
+		strs := genSliceString(n)
+		b.Run(fmt.Sprintf("strings_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = DropRight(strs, n/4)
+			}
+		})
+	}
+
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = DropRight(ints, n/4)
+			}
+		})
+	}
+}
+
+func BenchmarkReplace(b *testing.B) {
+	lengths := []int{1_000, 10_000, 100_000}
+	for _, n := range lengths {
+		strs := genSliceString(n)
+		b.Run(fmt.Sprintf("strings_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = Replace(strs, strs[n/4], "123123", 10)
+			}
+		})
+	}
+
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = Replace(ints, ints[n/4], 123123, 10)
+			}
+		})
+	}
+}

--- a/slice_benchmark_test.go
+++ b/slice_benchmark_test.go
@@ -111,6 +111,46 @@ func BenchmarkDropRight(b *testing.B) {
 	}
 }
 
+func BenchmarkDropWhile(b *testing.B) {
+	for _, n := range lengths {
+		strs := genSliceString(n)
+		b.Run(fmt.Sprintf("strings_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = DropWhile(strs, func(v string) bool { return len(v) < 4 })
+			}
+		})
+	}
+
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = DropWhile(ints, func(v int) bool { return i < 10_000 })
+			}
+		})
+	}
+}
+
+func BenchmarkDropRightWhile(b *testing.B) {
+	for _, n := range lengths {
+		strs := genSliceString(n)
+		b.Run(fmt.Sprintf("strings_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = DropRightWhile(strs, func(v string) bool { return len(v) < 4 })
+			}
+		})
+	}
+
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = DropRightWhile(ints, func(v int) bool { return i < 10_000 })
+			}
+		})
+	}
+}
+
 func BenchmarkReplace(b *testing.B) {
 	lengths := []int{1_000, 10_000, 100_000}
 	for _, n := range lengths {


### PR DESCRIPTION
Hello! 👋
I've made some optimizations for slices. There are also benchmarks to check the results.

And my results under:
```
go version go1.19 darwin/arm64
macbook air m1
goos: darwin
goarch: arm64
```

**Flatten**
```
name                    old time/op    new time/op    delta
Flatten/ints_10-8          294ns ± 1%     116ns ± 2%  -60.65%  (p=0.000 n=9+10)
Flatten/ints_100-8        23.7µs ± 0%     5.8µs ± 0%  -75.58%  (p=0.000 n=10+8)
Flatten/ints_1000-8       2.47ms ± 2%    0.63ms ± 1%  -74.58%  (p=0.000 n=10+8)
Flatten/strings_10-8       705ns ± 1%     227ns ± 0%  -67.83%  (p=0.000 n=10+9)
Flatten/strings_100-8     77.5µs ±15%    25.2µs ± 5%  -67.42%  (p=0.000 n=10+10)
Flatten/strings_1000-8    24.2ms ± 1%     5.5ms ± 2%  -77.46%  (p=0.000 n=10+10)

name                    old alloc/op   new alloc/op   delta
Flatten/ints_10-8         2.48kB ± 0%    0.90kB ± 0%  -63.87%  (p=0.000 n=10+10)
Flatten/ints_100-8         356kB ± 0%      82kB ± 0%  -77.00%  (p=0.000 n=10+10)
Flatten/ints_1000-8       44.9MB ± 0%     8.0MB ± 0%  -82.17%  (p=0.000 n=10+8)
Flatten/strings_10-8      5.09kB ± 0%    1.79kB ± 0%  -64.78%  (p=0.000 n=10+10)
Flatten/strings_100-8      683kB ± 0%     164kB ± 0%  -76.01%  (p=0.000 n=10+10)
Flatten/strings_1000-8    81.6MB ± 0%    16.0MB ± 0%  -80.39%  (p=0.000 n=9+10)
```

**Chunk**
```
name                  old time/op    new time/op    delta
Chunk/strings_10-8       120ns ± 0%      29ns ± 1%  -75.75%  (p=0.000 n=8+10)
Chunk/strings_100-8      880ns ± 0%     100ns ± 2%  -88.67%  (p=0.000 n=8+10)
Chunk/strings_1000-8    8.27µs ± 0%    0.68µs ± 1%  -91.81%  (p=0.000 n=9+9)
Chunk/ints10-8          88.5ns ± 0%    29.1ns ± 0%  -67.09%  (p=0.000 n=9+8)
Chunk/ints100-8          546ns ± 0%      99ns ± 0%  -81.96%  (p=0.000 n=8+9)
Chunk/ints1000-8        4.97µs ± 0%    0.67µs ± 1%  -86.43%  (p=0.000 n=10+10)
```

**Replace**
```
name                      old time/op    new time/op    delta
Replace/strings_1000-8      5.24µs ± 0%    1.29µs ± 0%  -75.46%  (p=0.008 n=5+5)
Replace/strings_10000-8     53.2µs ± 1%    13.1µs ± 1%  -75.37%  (p=0.008 n=5+5)
Replace/strings_100000-8     822µs ± 1%     127µs ± 2%  -84.50%  (p=0.016 n=5+4)
Replace/ints1000-8          1.50µs ± 0%    0.72µs ± 1%  -52.24%  (p=0.008 n=5+5)
Replace/ints10000-8         12.6µs ± 0%     3.8µs ± 5%  -69.93%  (p=0.016 n=4+5)
Replace/ints100000-8         126µs ± 1%      30µs ± 1%  -76.44%  (p=0.008 n=5+5)
```

**Drop** funcs - 10-30%