### PR TITLE
fix: panic when Slice() accepts a negative index

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -513,9 +513,15 @@ func Slice[T any](collection []T, start int, end int) []T {
 	if start > size {
 		start = size
 	}
+	if start < 0 {
+		start = 0
+	}
 
 	if end > size {
 		end = size
+	}
+	if end < 0 {
+		end = 0
 	}
 
 	return collection[start:end]

--- a/slice_test.go
+++ b/slice_test.go
@@ -623,6 +623,9 @@ func TestSlice(t *testing.T) {
 	out13 := Slice(in, 5, 0)
 	out14 := Slice(in, 6, 4)
 	out15 := Slice(in, 6, 7)
+	out16 := Slice(in, -10, 1)
+	out17 := Slice(in, -1, 3)
+	out18 := Slice(in, -10, 7)
 	
 	is.Equal([]int{}, out1)
 	is.Equal([]int{0}, out2)
@@ -639,6 +642,9 @@ func TestSlice(t *testing.T) {
 	is.Equal([]int{}, out13)
 	is.Equal([]int{}, out14)
 	is.Equal([]int{}, out15)
+	is.Equal([]int{0}, out16)
+	is.Equal([]int{0, 1, 2}, out17)
+	is.Equal([]int{0, 1, 2, 3, 4}, out18)
 }
 
 func TestReplace(t *testing.T) {


### PR DESCRIPTION
Previous:
```go
lo.Slice(arr, -1, 10) // panic: runtime error: slice bounds out of range
```

After fixed:
```go
lo.Slice([]int{0, 1, 2, 3}, -10, -1) // []int{}
lo.Slice([]int{0, 1, 2, 3}, -100, 2) // []int{0, 1}
```

I think that compared to the native method(arr[1:10]), the meaning of lo.Slice() is to avoid panic caused by out-of-bounds as much as possible. So I fixed it.