### PR TITLE
Adding lo.SafeClose(channel)

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -304,3 +304,17 @@ func FanOut[T any](count int, channelsBufferCap int, upstream <-chan T) []<-chan
 
 	return channelsToReadOnly(downstreams)
 }
+
+// SafeClose protects against double-close panic.
+// Returns true on first close, only.
+// May be equivalent to calling `sync.Once{}.Do(func() { close(ch) })`.`
+func SafeClose[T any](ch chan<- T) (justClosed bool) {
+	defer func() {
+		if recover() != nil {
+			justClosed = false
+		}
+	}()
+
+	close(ch) // may panic
+	return true
+}

--- a/channel_test.go
+++ b/channel_test.go
@@ -388,3 +388,13 @@ func TestFanOut(t *testing.T) {
 		is.Equal(0, msg)
 	}
 }
+
+func TestSafeClose(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	ch := make(chan int)
+
+	is.True(SafeClose(ch))
+	is.False(SafeClose(ch))
+}


### PR DESCRIPTION
Protect against double-close panic.

```go
ch := make(chan int)

closed := SafeClose(ch)
// true

closed = SafeClose(ch)
// false
```

Equivalent to `lo.Try0(func() { close(ch) })`
