### PR TITLE
fix: utf8 input `Substring`

### DIFF
--- a/string.go
+++ b/string.go
@@ -35,7 +35,8 @@ func RandomString(size int, charset []rune) string {
 
 // Substring return part of a string.
 // Play: https://go.dev/play/p/TQlxQi82Lu1
-func Substring[T ~string](str T, offset int, length uint) T {
+func Substring[T ~string](s T, offset int, length uint) T {
+	str := []rune(s)
 	size := len(str)
 
 	if offset < 0 {
@@ -53,7 +54,7 @@ func Substring[T ~string](str T, offset int, length uint) T {
 		length = uint(size - offset)
 	}
 
-	return str[offset : offset+int(length)]
+	return T(str[offset : offset+int(length)])
 }
 
 // ChunkString returns an array of strings split into groups the length of size. If array can't be split evenly,

--- a/string.go
+++ b/string.go
@@ -35,26 +35,8 @@ func RandomString(size int, charset []rune) string {
 
 // Substring return part of a string.
 // Play: https://go.dev/play/p/TQlxQi82Lu1
-func Substring[T ~string](s T, offset int, length uint) T {
-	str := []rune(s)
-	size := len(str)
-
-	if offset < 0 {
-		offset = size + offset
-		if offset < 0 {
-			offset = 0
-		}
-	}
-
-	if offset > size {
-		return Empty[T]()
-	}
-
-	if length > uint(size)-uint(offset) {
-		length = uint(size - offset)
-	}
-
-	return T(str[offset : offset+int(length)])
+func Substring[T ~string](str T, offset int, length uint) T {
+	return T(Subset([]rune(str), offset, length))
 }
 
 // ChunkString returns an array of strings split into groups the length of size. If array can't be split evenly,

--- a/string_example_test.go
+++ b/string_example_test.go
@@ -9,14 +9,17 @@ func ExampleSubstring() {
 	result1 := Substring("hello", 2, 3)
 	result2 := Substring("hello", -4, 3)
 	result3 := Substring("hello", -2, math.MaxUint)
+	result4 := Substring("你好，世界", 0, 3)
 
 	fmt.Printf("%v\n", result1)
 	fmt.Printf("%v\n", result2)
 	fmt.Printf("%v\n", result3)
+	fmt.Printf("%v\n", result4)
 	// Output:
 	// llo
 	// ell
 	// lo
+	// 你好，
 }
 
 func ExampleChunkString() {

--- a/string_test.go
+++ b/string_test.go
@@ -74,6 +74,7 @@ func TestSubstring(t *testing.T) {
 	str10 := Substring("hello", -2, 4)
 	str11 := Substring("hello", -4, 1)
 	str12 := Substring("hello", -4, math.MaxUint)
+	str13 := Substring("你好，世界", 0, 3)
 
 	is.Equal("", str1)
 	is.Equal("", str2)
@@ -87,6 +88,7 @@ func TestSubstring(t *testing.T) {
 	is.Equal("lo", str10)
 	is.Equal("e", str11)
 	is.Equal("ello", str12)
+	is.Equal("你好，", str13)
 }
 
 func TestRuneLength(t *testing.T) {

--- a/string_test.go
+++ b/string_test.go
@@ -75,6 +75,7 @@ func TestSubstring(t *testing.T) {
 	str11 := Substring("hello", -4, 1)
 	str12 := Substring("hello", -4, math.MaxUint)
 	str13 := Substring("你好，世界", 0, 3)
+	str14 := Substring("1👩23", 0, 2)
 
 	is.Equal("", str1)
 	is.Equal("", str2)
@@ -89,6 +90,7 @@ func TestSubstring(t *testing.T) {
 	is.Equal("e", str11)
 	is.Equal("ello", str12)
 	is.Equal("你好，", str13)
+	is.Equal("1👩", str14)
 }
 
 func TestRuneLength(t *testing.T) {


### PR DESCRIPTION
fix https://github.com/samber/lo/issues/286

potential breaking change, because previously `lo.Substring` didn't handle utf8 input correctly.

`ChunkString` works because  `for i := string(...)` behave like `for i := []rune(string(...))`,  but we didn't convert `~string` to `[]rune` in `Substring`, `string(...)[start:end]` doesn't handle utf8.