### PR TITLE
feat : adding ValueOr

### DIFF
--- a/map.go
+++ b/map.go
@@ -96,6 +96,14 @@ func OmitByValues[K comparable, V comparable](in map[K]V, values []V) map[K]V {
 	return r
 }
 
+// ValueOr returns the value of the given key or the fallback value if the key is not present.
+func ValueOr[K comparable, V any](in map[K]V, key K, fallback V) V {
+	if v, ok := in[key]; ok {
+		return v
+	}
+	return fallback
+}
+
 // Entries transforms a map into array of key/value pairs.
 // Play:
 func Entries[K comparable, V any](in map[K]V) []Entry[K, V] {

--- a/map_test.go
+++ b/map_test.go
@@ -87,6 +87,17 @@ func TestOmitByValues(t *testing.T) {
 	is.Equal(r1, map[string]int{"bar": 2})
 }
 
+func TestValueOr(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	r1 := ValueOr(map[string]int{"foo": 1}, "bar", 2)
+	is.Equal(r1, 2)
+
+	r2 := ValueOr(map[string]int{"foo": 1}, "foo", 2)
+	is.Equal(r2, 1)
+}
+
 func TestEntries(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -111,9 +122,9 @@ func TestEntries(t *testing.T) {
 func TestToPairs(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
-	
+
 	r1 := ToPairs(map[string]int{"baz": 3, "qux": 4})
-	
+
 	sort.Slice(r1, func(i, j int) bool {
 		return r1[i].Value < r1[j].Value
 	})
@@ -132,7 +143,7 @@ func TestToPairs(t *testing.T) {
 func TestFromEntries(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
-	
+
 	r1 := FromEntries([]Entry[string, int]{
 		{
 			Key:   "foo",
@@ -152,7 +163,7 @@ func TestFromEntries(t *testing.T) {
 func TestFromPairs(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
-	
+
 	r1 := FromPairs([]Entry[string, int]{
 		{
 			Key:   "baz",
@@ -163,7 +174,7 @@ func TestFromPairs(t *testing.T) {
 			Value: 4,
 		},
 	})
-	
+
 	is.Len(r1, 2)
 	is.Equal(r1["baz"], 3)
 	is.Equal(r1["qux"], 4)
@@ -172,7 +183,7 @@ func TestFromPairs(t *testing.T) {
 func TestInvert(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
-	
+
 	r1 := Invert(map[string]int{"a": 1, "b": 2})
 	r2 := Invert(map[string]int{"a": 1, "b": 2, "c": 1})
 


### PR DESCRIPTION
Motivation : reducing boilerplate when setting sensible defaults when a key is not found in a map

```go
func ValueOr[K comparable, V any](in map[K]V, key K, fallback V) V 
```

<hr/>

```go
r1 := ValueOr(map[string]int{"foo": 1}, "bar", 2)
is.Equal(r1, 2)
```