### PR TITLE
add SortAs method, sort a items slice by another keys slice

### DIFF
--- a/sort.go
+++ b/sort.go
@@ -1,0 +1,20 @@
+package lo
+
+import "sort"
+
+// IndexMap build a map[T]int which the map value was the element index
+func IndexMap[T comparable](collection []T) map[T]int {
+	m := make(map[T]int, len(collection))
+	for i, v := range collection {
+		m[v] = i
+	}
+	return m
+}
+
+// SortAs sort collection as index of key which extract by keyFn
+func SortAs[T any, K comparable](collection []T, keys []K, keyFn func(T) K) {
+	indexesMap := IndexMap(keys)
+	sort.Slice(collection, func(i, j int) bool {
+		return indexesMap[keyFn(collection[i])] < indexesMap[keyFn(collection[j])]
+	})
+}

--- a/sort_test.go
+++ b/sort_test.go
@@ -1,0 +1,44 @@
+package lo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIndexesMap(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	var items = []string{"a", "b", "c"}
+
+	indexMap := IndexMap(items)
+	is.Len(indexMap, len(items))
+	is.Equal(0, indexMap["a"])
+	is.Equal(1, indexMap["b"])
+	is.Equal(2, indexMap["c"])
+}
+
+func TestSortAs(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+	var items = []Tuple2[uint, string]{
+		{A: 1, B: "hello"},
+		{A: 2, B: "world"},
+		{A: 3, B: "happy"},
+		{A: 4, B: "new year"},
+	}
+	var keys = []uint{3, 4, 1, 2}
+
+	SortAs(items, keys, func(t Tuple2[uint, string]) uint {
+		return t.A
+	})
+
+	for i := range keys {
+		is.Equal(items[i].A, keys[i])
+	}
+	is.Equal(items[0].B, "happy")
+	is.Equal(items[1].B, "new year")
+	is.Equal(items[2].B, "hello")
+	is.Equal(items[3].B, "world")
+}


### PR DESCRIPTION
i have many case look like this

```golang
func FetchData() {
    var itemIDs = []int{3, 4, 1, 2}
    var items = db.Execute("select * from table where id in ?",  itemIDs).FindItems()
    return items
}
```
many times the keys was not in order (because it was sort by another table)

we need to build a map[id]item and sometimes map[id][]item  and then join it.

i think `SortAs` is a useful function.
