### PR TITLE
Adding the Unwind function

### DIFF
--- a/unwind.go
+++ b/unwind.go
@@ -1,0 +1,41 @@
+package lo
+
+import (
+	"sort"
+
+	"golang.org/x/exp/constraints"
+)
+
+// Unwind is a function that orders a collection based on predefined order and returns the sorted collection plus the previous order of the items, making it possible to reverse the process
+func Unwind[T constraints.Integer, R any](order []T, collection []R) (sortedCollection []R, stochasticTenet []T) {
+	if len(collection) <= 0 {
+		sortedCollection = make([]R, 0)
+		stochasticTenet = make([]T, 0)
+		return
+	}
+
+	intermediary := []struct {
+		x     T
+		y     T
+		value R
+	}{}
+
+	for i, v := range collection {
+		intermediary = append(intermediary, struct {
+			x     T
+			y     T
+			value R
+		}{x: order[i], y: T(i), value: v})
+	}
+
+	sort.Slice(intermediary, func(i, j int) bool {
+		return intermediary[i].x < intermediary[j].x
+	})
+
+	for _, v := range intermediary {
+		sortedCollection = append(sortedCollection, v.value)
+		stochasticTenet = append(stochasticTenet, v.y)
+	}
+
+	return
+}

--- a/unwind_test.go
+++ b/unwind_test.go
@@ -1,0 +1,73 @@
+package lo
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUnwind(t *testing.T) {
+	type args struct {
+		order      []int
+		collection []string
+	}
+	tests := []struct {
+		name                 string
+		args                 args
+		wantSortedCollection []string
+		wantStochasticTenet  []int
+	}{
+		{
+			name:                 "accepts zero items",
+			args:                 args{order: []int{}, collection: []string{}},
+			wantSortedCollection: []string{},
+			wantStochasticTenet:  []int{},
+		},
+		{
+			name:                 "accepts 1 item",
+			args:                 args{order: []int{0}, collection: []string{"a"}},
+			wantSortedCollection: []string{"a"},
+			wantStochasticTenet:  []int{0},
+		},
+		{
+			name:                 "accepts 2 items",
+			args:                 args{order: []int{1, 0}, collection: []string{"b", "a"}},
+			wantSortedCollection: []string{"a", "b"},
+			wantStochasticTenet:  []int{1, 0},
+		},
+		{
+			name:                 "accepts 3 items",
+			args:                 args{order: []int{1, 2, 0}, collection: []string{"b", "c", "a"}},
+			wantSortedCollection: []string{"a", "b", "c"},
+			wantStochasticTenet:  []int{2, 0, 1},
+		},
+		{
+			name:                 "accepts 4 items",
+			args:                 args{order: []int{1, 3, 2, 0}, collection: []string{"b", "d", "c", "a"}},
+			wantSortedCollection: []string{"a", "b", "c", "d"},
+			wantStochasticTenet:  []int{3, 0, 2, 1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSortedCollection, gotStochasticTenet := Unwind(tt.args.order, tt.args.collection)
+			if !reflect.DeepEqual(gotSortedCollection, tt.wantSortedCollection) {
+				t.Errorf("Unwind() gotSortedCollection = %v, want %v", gotSortedCollection, tt.wantSortedCollection)
+			}
+			if !reflect.DeepEqual(gotStochasticTenet, tt.wantStochasticTenet) {
+				t.Errorf("Unwind() gotStochasticTenet = %v, want %v", gotStochasticTenet, tt.wantStochasticTenet)
+			}
+		})
+	}
+	t.Run("is a reversible operation", func(t *testing.T) {
+		baseOrder, baseCollection := []int{1, 3, 2, 0}, []string{"b", "d", "c", "a"}
+		midSortedCollection, midStochasticTenet := Unwind(baseOrder, baseCollection)
+		gotSortedCollection, gotStochasticTenet := Unwind(midStochasticTenet, midSortedCollection)
+
+		if !reflect.DeepEqual(gotSortedCollection, baseCollection) {
+			t.Errorf("Unwind() gotSortedCollection = %v, want %v", gotSortedCollection, baseCollection)
+		}
+		if !reflect.DeepEqual(gotStochasticTenet, baseOrder) {
+			t.Errorf("Unwind() gotStochasticTenet = %v, want %v", gotStochasticTenet, baseOrder)
+		}
+	})
+}


### PR DESCRIPTION
Adds an Unwind  function based on the NPM package [sort-unwind](https://www.npmjs.com/package/sort-unwind).

The reasoning behind this PR, is that I'm porting the Weng-Lin Rating algorithm to Go, and the original Typescript implementation makes use of this Unwind function. Since I didn't find any other implementation of this function, and since I was already using this package to handle a lot of slice manipulation, I've decided to share this piece of code with the rest of the user base through this repository.