### PR TITLE
Add support for merging multiple maps of arbitrary depth.

### DIFF
--- a/map.go
+++ b/map.go
@@ -165,6 +165,28 @@ func Assign[K comparable, V any](maps ...map[K]V) map[K]V {
 	return out
 }
 
+// Merge merges multiple maps of arbitrary depth and structure from left to right.
+func Merge[K comparable, V any](maps ...map[K]V) V {
+	out := map[K]V{}
+
+	for _, m := range maps {
+		for k, w := range m {
+			if v, ok := out[k]; ok {
+				switch v := any(v).(type) {
+				case map[K]V:
+					out[k] = Merge(v, any(w).(map[K]V))
+				default:
+					out[k] = w
+				}
+			} else {
+				out[k] = w
+			}
+		}
+	}
+
+	return any(out).(V)
+}
+
 // MapKeys manipulates a map keys and transforms it to a map of another type.
 // Play: https://go.dev/play/p/9_4WPIqOetJ
 func MapKeys[K comparable, V any, R comparable](in map[K]V, iteratee func(value V, key K) R) map[R]V {

--- a/map_test.go
+++ b/map_test.go
@@ -111,9 +111,9 @@ func TestEntries(t *testing.T) {
 func TestToPairs(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
-	
+
 	r1 := ToPairs(map[string]int{"baz": 3, "qux": 4})
-	
+
 	sort.Slice(r1, func(i, j int) bool {
 		return r1[i].Value < r1[j].Value
 	})
@@ -132,7 +132,7 @@ func TestToPairs(t *testing.T) {
 func TestFromEntries(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
-	
+
 	r1 := FromEntries([]Entry[string, int]{
 		{
 			Key:   "foo",
@@ -152,7 +152,7 @@ func TestFromEntries(t *testing.T) {
 func TestFromPairs(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
-	
+
 	r1 := FromPairs([]Entry[string, int]{
 		{
 			Key:   "baz",
@@ -163,7 +163,7 @@ func TestFromPairs(t *testing.T) {
 			Value: 4,
 		},
 	})
-	
+
 	is.Len(r1, 2)
 	is.Equal(r1["baz"], 3)
 	is.Equal(r1["qux"], 4)
@@ -172,7 +172,7 @@ func TestFromPairs(t *testing.T) {
 func TestInvert(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
-	
+
 	r1 := Invert(map[string]int{"a": 1, "b": 2})
 	r2 := Invert(map[string]int{"a": 1, "b": 2, "c": 1})
 
@@ -189,6 +189,46 @@ func TestAssign(t *testing.T) {
 
 	is.Len(result1, 3)
 	is.Equal(result1, map[string]int{"a": 1, "b": 3, "c": 4})
+}
+
+func TestMerge(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	m1 := map[string]interface{}{
+		"a": 1,
+		"b": map[string]interface{}{
+			"c": 2,
+			"d": map[string]interface{}{
+				"e": 3,
+				"f": 4,
+			},
+		},
+		"c": 5,
+	}
+	m2 := map[string]interface{}{
+		"a": 1,
+		"b": map[string]interface{}{
+			"c": 2,
+			"d": map[string]interface{}{
+				"e": 3,
+				"f": 5,
+			},
+			"e": map[string]interface{}{
+				"a": 1,
+				"b": 2,
+			},
+		},
+		"c": 6,
+	}
+	m3 := map[string]interface{}{
+		"d": 1,
+		"e": 2,
+	}
+
+	r1 := Merge(m1, m2, m3)
+	is.Len(r1, 5)
+	is.Equal(r1, map[string]interface{}{"a": 1, "b": map[string]interface{}{"c": 2, "d": map[string]interface{}{"e": 3, "f": 5}, "e": map[string]interface{}{"a": 1, "b": 2}}, "c": 6, "d": 1, "e": 2})
 }
 
 func TestMapKeys(t *testing.T) {


### PR DESCRIPTION
This PR addresses issue #306 by adding support for merging multiple maps of arbitrary depth and structure using generics. 

I decided to use generics for this rather than interfaces.

```go
func Merge(maps ...map[any]interface{}) map[any]interface{} {
	out := make(map[any]interface{})
	for _, m := range maps {
		for k, w := range m {
			if v, ok := out[k]; ok {
				switch v := v.(type) {
				case map[any]interface{}:
					out[k] = Merge(v, w.(map[any]interface{}))
				default:
					out[k] = w
				}
			} else {
				out[k] = w
			}
		}
	}
	return out
}
```

However, the shape of the API felt a bit constrained so I ultimately settled on generics.