### PR TITLE
doc: fix formatting of deprecated notices

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -213,6 +213,7 @@ func Buffer[T any](ch <-chan T, size int) (collection []T, length int, readTime 
 }
 
 // Buffer creates a slice of n elements from a channel. Returns the slice and the slice length.
+//
 // Deprecated: Use lo.Buffer instead.
 func Batch[T any](ch <-chan T, size int) (collection []T, length int, readTime time.Duration, ok bool) {
 	return Buffer(ch, size)
@@ -246,6 +247,7 @@ func BufferWithTimeout[T any](ch <-chan T, size int, timeout time.Duration) (col
 }
 
 // BufferWithTimeout creates a slice of n elements from a channel, with timeout. Returns the slice and the slice length.
+//
 // Deprecated: Use lo.BufferWithTimeout instead.
 func BatchWithTimeout[T any](ch <-chan T, size int, timeout time.Duration) (collection []T, length int, readTime time.Duration, ok bool) {
 	return BufferWithTimeout(ch, size, timeout)
@@ -278,6 +280,7 @@ func FanIn[T any](channelBufferCap int, upstreams ...<-chan T) <-chan T {
 
 // ChannelMerge collects messages from multiple input channels into a single buffered channel.
 // Output messages has no priority. When all upstream channels reach EOF, downstream channel closes.
+//
 // Deprecated: Use lo.FanIn instead.
 func ChannelMerge[T any](channelBufferCap int, upstreams ...<-chan T) <-chan T {
 	return FanIn(channelBufferCap, upstreams...)

--- a/channel.go
+++ b/channel.go
@@ -214,7 +214,7 @@ func Buffer[T any](ch <-chan T, size int) (collection []T, length int, readTime 
 
 // Buffer creates a slice of n elements from a channel. Returns the slice and the slice length.
 //
-// Deprecated: Use lo.Buffer instead.
+// Deprecated: Use [Buffer] instead.
 func Batch[T any](ch <-chan T, size int) (collection []T, length int, readTime time.Duration, ok bool) {
 	return Buffer(ch, size)
 }
@@ -248,7 +248,7 @@ func BufferWithTimeout[T any](ch <-chan T, size int, timeout time.Duration) (col
 
 // BufferWithTimeout creates a slice of n elements from a channel, with timeout. Returns the slice and the slice length.
 //
-// Deprecated: Use lo.BufferWithTimeout instead.
+// Deprecated: Use [BufferWithTimeout] instead.
 func BatchWithTimeout[T any](ch <-chan T, size int, timeout time.Duration) (collection []T, length int, readTime time.Duration, ok bool) {
 	return BufferWithTimeout(ch, size, timeout)
 }
@@ -281,7 +281,7 @@ func FanIn[T any](channelBufferCap int, upstreams ...<-chan T) <-chan T {
 // ChannelMerge collects messages from multiple input channels into a single buffered channel.
 // Output messages has no priority. When all upstream channels reach EOF, downstream channel closes.
 //
-// Deprecated: Use lo.FanIn instead.
+// Deprecated: Use [FanIn] instead.
 func ChannelMerge[T any](channelBufferCap int, upstreams ...<-chan T) <-chan T {
 	return FanIn(channelBufferCap, upstreams...)
 }


### PR DESCRIPTION
Fix formatting of deprecation notices in Go doc comments:
* add missing empty line before the `Deprecated:` prefix. See https://github.com/golang/go/wiki/Deprecated
* add [doc links](https://go.dev/doc/comment#doclinks) to allow tooling (ex: pkg.go.dev) to link to the replacement