### PR TITLE
Update FlatMap docs to talk about nil case

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ matching := lo.FilterMap[string, string]([]string{"cpu", "gpu", "mouse", "keyboa
 
 ### FlatMap
 
-Manipulates a slice and transforms and flattens it to a slice of another type.
+Manipulates a slice and transforms and flattens it to a slice of another type. The transform function can either return a slice or a `nil`, and in the `nil` case no value is added to the final slice.
 
 ```go
 lo.FlatMap[int, string]([]int{0, 1, 2}, func(x int, _ int) []string {


### PR DESCRIPTION
One interesting use case of `FlatMap` that isn't intuitively obvious from the docs is the ability to return `nil`. For example,

```golang
var key = map[string][]string{"a": ["b","c"], "d": ["e","f"]}
var myKeys = []string{"a","c","d","g"}

lo.FlatMap(key, func(s string, _ int) []string { return key[s] })
// returns []string{"b","c","e","f"}
```

The docs should explicitly mention what happens if you return `nil`, so a user would be able to deduce this use case themselves.
