### PR TITLE
feat : adding AssignByPartition

### DIFF
--- a/map.go
+++ b/map.go
@@ -173,6 +173,25 @@ func Assign[K comparable, V any](maps ...map[K]V) map[K]V {
 	return out
 }
 
+// AssignByPartition merges multiple maps from left to right and
+// splits them into groups. The grouping is generated from the results
+// of running each element of collection through iteratee.
+func AssignByPartition[K comparable, V any, T comparable](iteratee func(key K, value V) T, maps ...map[K]V) map[T]map[K]V {
+	out := map[T]map[K]V{}
+
+	for _, m := range maps {
+		for k, v := range m {
+			partition := iteratee(k, v)
+			if _, ok := out[partition]; !ok {
+				out[partition] = map[K]V{}
+			}
+			out[partition][k] = v
+		}
+	}
+
+	return out
+}
+
 // MapKeys manipulates a map keys and transforms it to a map of another type.
 // Play: https://go.dev/play/p/9_4WPIqOetJ
 func MapKeys[K comparable, V any, R comparable](in map[K]V, iteratee func(value V, key K) R) map[R]V {

--- a/map_test.go
+++ b/map_test.go
@@ -202,6 +202,32 @@ func TestAssign(t *testing.T) {
 	is.Equal(result1, map[string]int{"a": 1, "b": 3, "c": 4})
 }
 
+func TestAssignByPartition(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	oddEvenValue := func(key string, value int) string {
+		if value%2 == 0 {
+			return "even"
+		}
+		return "odd"
+	}
+
+	result1 := AssignByPartition(
+		oddEvenValue,
+		map[string]int{"a": 1, "b": 2},
+		map[string]int{"b": 3, "c": 4},
+	)
+	result2 := AssignByPartition(
+		oddEvenValue,
+	)
+
+	is.Len(result1, 2)
+	is.Equal(result1["even"], map[string]int{"b": 2, "c": 4})
+	is.Equal(result1["odd"], map[string]int{"a": 1, "b": 3})
+	is.Len(result2, 0)
+}
+
 func TestMapKeys(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)


### PR DESCRIPTION
Motivation : merging maps from left to right with grouping

```go
func AssignByPartition[K comparable, V any, T comparable](iteratee func(key K, value V) T, maps ...map[K]V) map[T]map[K]V 
```

<hr/>

```go
oddEvenValue := func(key string, value int) string {
  if value%2 == 0 {
    return "even"
  }
  return "odd"
}
partitions := AssignByPartition(
  oddEvenValue,
  map[string]int{"a": 1, "b": 2},
  map[string]int{"b": 3, "c": 4},
)
is.Len(partitions, 2)
is.Equal(result1["even"], map[string]int{"b": 2, "c": 4})
is.Equal(result1["odd"], map[string]int{"a": 1, "b": 3})
```