### PR TITLE
feat: add Compose and Pipe functions

### DIFF
--- a/func.go
+++ b/func.go
@@ -39,3 +39,9 @@ func Partial5[T1, T2, T3, T4, T5, T6, R any](f func(T1, T2, T3, T4, T5, T6) R, a
 		return f(arg1, t2, t3, t4, t5, t6)
 	}
 }
+
+func Compose[T, U, V any](f func(U) V, g func(T) U) func (T) V {
+	return func(t T) V {
+		return f(g(t))
+	}
+}

--- a/func.go
+++ b/func.go
@@ -40,8 +40,14 @@ func Partial5[T1, T2, T3, T4, T5, T6, R any](f func(T1, T2, T3, T4, T5, T6) R, a
 	}
 }
 
+// Compose returns new function that, when called, returns the result of calling g and then f with the result from g
 func Compose[T, U, V any](f func(U) V, g func(T) U) func (T) V {
 	return func(t T) V {
 		return f(g(t))
 	}
+}
+
+// Pipe returns new function that, when called, returns the result of calling f and then g with the result from f
+func Pipe[T, U, V any](f func(T) U, g func(U) V) func (T) V {
+	return Compose(g, f)
 }

--- a/func_test.go
+++ b/func_test.go
@@ -78,3 +78,19 @@ func TestPartial5(t *testing.T) {
 	is.Equal("26", f(10, 9, -3, 0, 5))
 	is.Equal("21", f(-5, 8, 7, -1, 7))
 }
+
+func TestCompose(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	sumBy2 := func(x int) int { return x + 2 }
+
+	mulBy3 := func(x int) int { return x * 3 }
+
+	sumBy2AndMulBy3 := Compose(mulBy3, sumBy2)
+	mulBy3AndSumBy2 := Compose(sumBy2, mulBy3)
+
+	val := 1
+	is.Equal(9, sumBy2AndMulBy3(val))
+	is.Equal(5, mulBy3AndSumBy2(val))
+}

--- a/func_test.go
+++ b/func_test.go
@@ -79,16 +79,27 @@ func TestPartial5(t *testing.T) {
 	is.Equal("21", f(-5, 8, 7, -1, 7))
 }
 
+func sumBy2(x int) int { return x + 2 }
+func mulBy3(x int) int { return x * 3 }
+
 func TestCompose(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	sumBy2 := func(x int) int { return x + 2 }
-
-	mulBy3 := func(x int) int { return x * 3 }
-
 	sumBy2AndMulBy3 := Compose(mulBy3, sumBy2)
 	mulBy3AndSumBy2 := Compose(sumBy2, mulBy3)
+
+	val := 1
+	is.Equal(9, sumBy2AndMulBy3(val))
+	is.Equal(5, mulBy3AndSumBy2(val))
+}
+
+func TestPipe(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	sumBy2AndMulBy3 := Pipe(sumBy2, mulBy3)
+	mulBy3AndSumBy2 := Pipe(mulBy3, sumBy2)
 
 	val := 1
 	is.Equal(9, sumBy2AndMulBy3(val))


### PR DESCRIPTION
Hello!

This PR adds functions Compose and Pipe (which is requested in #299), that respectively compose two functions and pipes the application of two functions.
These are common functions in utility libraries such as Ramda and Lodash.

Something worth noting is that these functions receive just two functions as arguments, which is not exactly what happens in their counterparts in Ramda/Lodash, where you can pass a variadic number of functions. I think this couldn't be replicated in Golang in a type safe way, but something like the PartialN functions and create ComposeN and PipeN functions.

A way to mitigate this is to create counterpart functions for different sizes of arguments, like Compose3/Pipe3 for composing/piping three functions, Compose4/Pipe4 for four functions, and so on.

PS: I know that the repo's README mentions that for contributing, one should talk with @samuelberthe on twitter. I tried doing so and got no response, so I decided to create this here anyway since there's an issue for something similar to this PR's contribution (#299). My apologies if this is not desired, but if this is not of the interest of the maintainers, no worries at all :)