### PR TITLE
Add wrapper functions to simplify creating iteratees

### DIFF
--- a/func.go
+++ b/func.go
@@ -39,3 +39,59 @@ func Partial5[T1, T2, T3, T4, T5, T6, R any](f func(T1, T2, T3, T4, T5, T6) R, a
 		return f(arg1, t2, t3, t4, t5, t6)
 	}
 }
+
+// Partial returns new function that, when called, has its last argument set to the provided value.
+func PartialRight[T1, T2, R any](f func(a T1, b T2) R, lastArg T2) func(T1) R {
+	return func(t1 T1) R {
+		return f(t1, lastArg)
+	}
+}
+
+// PartialRight1 returns new function that, when called, has its last argument set to the provided value.
+func PartialRight1[T1, T2, R any](f func(T1, T2) R, lastArg T2) func(T1) R {
+	return PartialRight(f, lastArg)
+}
+
+// PartialRight2 returns new function that, when called, has its last argument set to the provided value.
+func PartialRight2[T1, T2, T3, R any](f func(T1, T2, T3) R, lastArg T3) func(T1, T2) R {
+	return func(t1 T1, t2 T2) R {
+		return f(t1, t2, lastArg)
+	}
+}
+
+// PartialRight3 returns new function that, when called, has its last argument set to the provided value.
+func PartialRight3[T1, T2, T3, T4, R any](f func(T1, T2, T3, T4) R, lastArg T4) func(T1, T2, T3) R {
+	return func(t1 T1, t2 T2, t3 T3) R {
+		return f(t1, t2, t3, lastArg)
+	}
+}
+
+// PartialRight4 returns new function that, when called, has its last argument set to the provided value.
+func PartialRight4[T1, T2, T3, T4, T5, R any](f func(T1, T2, T3, T4, T5) R, lastArg T5) func(T1, T2, T3, T4) R {
+	return func(t1 T1, t2 T2, t3 T3, t4 T4) R {
+		return f(t1, t2, t3, t4, lastArg)
+	}
+}
+
+// PartialRight5 returns new function that, when called, has its last argument set to the provided value
+func PartialRight5[T1, T2, T3, T4, T5, T6, R any](f func(T1, T2, T3, T4, T5, T6) R, lastArg T6) func(T1, T2, T3, T4, T5) R {
+	return func(t1 T1, t2 T2, t3 T3, t4 T4, t5 T5) R {
+		return f(t1, t2, t3, t4, t5, lastArg)
+	}
+}
+
+// Not returns a function which is the logical inverse of the provided function
+func Not[T any](f func(T) bool) func(T) bool {
+	return func(t T) bool {
+		return !f(t)
+	}
+}
+
+// Not2 returns a function which is the logical inverse of the provided function
+func Not2[T1, T2 any](f func(T1, T2) bool) func(T1, T2) bool {
+	return func(t1 T1, t2 T2) bool {
+		return !f(t1, t2)
+	}
+}
+
+// Do we need to support more than 2 parameters? I struggle to think of meaningful examples.

--- a/func_test.go
+++ b/func_test.go
@@ -2,6 +2,7 @@ package lo
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -77,4 +78,96 @@ func TestPartial5(t *testing.T) {
 	f := Partial5(add, 5)
 	is.Equal("26", f(10, 9, -3, 0, 5))
 	is.Equal("21", f(-5, 8, 7, -1, 7))
+}
+
+func TestPartialRight(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	add := func(x float64, y int) string {
+		return strconv.Itoa(int(x) + y)
+	}
+	f := PartialRight(add, 5)
+	is.Equal("15", f(10))
+	is.Equal("0", f(-5))
+}
+
+func TestPartialRight1(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	add := func(x float64, y int) string {
+		return strconv.Itoa(int(x) + y)
+	}
+	f := PartialRight1(add, 5)
+	is.Equal("15", f(10))
+	is.Equal("0", f(-5))
+}
+
+func TestPartialRight2(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	add := func(x float64, y int, z int) string {
+		return strconv.Itoa(int(x) + y + z)
+	}
+	f := PartialRight2(add, 5)
+	is.Equal("24", f(10, 9))
+	is.Equal("8", f(-5, 8))
+}
+
+func TestPartialRight3(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	add := func(x float64, y int, z int, a float32) string {
+		return strconv.Itoa(int(x) + y + z + int(a))
+	}
+	f := PartialRight3(add, 5)
+	is.Equal("21", f(10, 9, -3))
+	is.Equal("15", f(-5, 8, 7))
+}
+
+func TestPartialRight4(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	add := func(x float64, y int, z int, a float32, b int32) string {
+		return strconv.Itoa(int(x) + y + z + int(a) + int(b))
+	}
+	f := PartialRight4(add, 5)
+	is.Equal("21", f(10, 9, -3, 0))
+	is.Equal("14", f(-5, 8, 7, -1))
+}
+
+func TestPartialRight5(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	add := func(x float64, y int, z int, a float32, b int32, c int) string {
+		return strconv.Itoa(int(x) + y + z + int(a) + int(b) + c)
+	}
+	f := PartialRight5(add, 5)
+	is.Equal("26", f(10, 9, -3, 0, 5))
+	is.Equal("21", f(-5, 8, 7, -1, 7))
+}
+
+func TestNot(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	isOdd := func(i int) bool {
+		return i%2 == 1
+	}
+
+	is.False(Not(isOdd)(2))
+	is.True(Not(isOdd)(3))
+}
+
+func TestNot2(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	is.False(Not2(strings.Contains)("test", "t"))
+	is.True(Not2(strings.Contains)("test", "p"))
 }

--- a/slice.go
+++ b/slice.go
@@ -592,3 +592,12 @@ func IsSortedByKey[T any, K constraints.Ordered](collection []T, iteratee func(i
 
 	return true
 }
+
+// ToIteratee takes a unary function and returns a function with the same behavior but accepting an int as the second parameter.
+// This allows one to pass unary functions (e.g. strings.ToUpper) to slice operators which expect a func(T, int)
+// without having to wrap them explicitly
+func ToIteratee[V, R any](f func(V) R) func(V, int) R {
+	return func(v V, _ int) R {
+		return f(v)
+	}
+}

--- a/slice_example_test.go
+++ b/slice_example_test.go
@@ -456,3 +456,17 @@ func ExampleIsSortedByKey() {
 
 	// Output: true
 }
+
+func ExampleToIteratee() {
+	list := []float64{1, -2, 3, -4, math.NaN()}
+
+	result := Map(list, ToIteratee(math.Abs))
+	fmt.Printf("%v", result)
+
+	result = Filter(list, ToIteratee(math.IsNaN))
+	fmt.Printf("\n%v", result)
+
+	// Output:
+	// [1 2 3 4 NaN]
+	// [NaN]
+}

--- a/slice_test.go
+++ b/slice_test.go
@@ -388,7 +388,7 @@ func TestAssociate(t *testing.T) {
 
 func TestSliceToMap(t *testing.T) {
 	t.Parallel()
-	
+
 	type foo struct {
 		baz string
 		bar int
@@ -626,7 +626,7 @@ func TestSlice(t *testing.T) {
 	out16 := Slice(in, -10, 1)
 	out17 := Slice(in, -1, 3)
 	out18 := Slice(in, -10, 7)
-	
+
 	is.Equal([]int{}, out1)
 	is.Equal([]int{0}, out2)
 	is.Equal([]int{0, 1, 2, 3, 4}, out3)
@@ -758,4 +758,15 @@ func TestIsSortedByKey(t *testing.T) {
 		ret, _ := strconv.Atoi(s)
 		return ret
 	}))
+}
+
+func TestToIteratee(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	is.Equal("TEST", ToIteratee(strings.ToUpper)("test", 1))
+
+	// Use the complier to ensure the resulting function can be correctly passed to iterators.
+	_ = Map([]string{}, ToIteratee(strings.ToLower))
+	_ = Filter([]float64{}, ToIteratee(math.IsNaN))
 }


### PR DESCRIPTION
These three functions (`ToIteratee`, `PartialRight`, and `Not`) allow us to turn simple functions into effective iteratees without having to explicitly wrap them in another function declaration.

Closes issue #80