### PR TITLE
Add FilterByType

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Supported helpers for slices:
 - [FlatMap](#flatmap)
 - [Reduce](#reduce)
 - [ReduceRight](#reduceright)
+- [FilterByType](#filterbytype)
 - [ForEach](#foreach)
 - [Times](#times)
 - [Uniq](#uniq)
@@ -360,6 +361,17 @@ result := lo.ReduceRight([][]int{{0, 1}, {2, 3}, {4, 5}}, func(agg []int, item [
 ```
 
 [[play](https://go.dev/play/p/Fq3W70l7wXF)]
+
+### FilterByType
+
+Returns the elements of collection that have the type given as the type parameter.
+
+```go
+result := lo.FilterByType[int]([]any{1, "foo", 2, true})
+// []int{1, 2}
+```
+
+[[play](https://go.dev/play/p/PPfuC__LoTG)]
 
 ### ForEach
 

--- a/slice.go
+++ b/slice.go
@@ -85,6 +85,21 @@ func ReduceRight[T any, R any](collection []T, accumulator func(agg R, item T, i
 	return initial
 }
 
+// FilterByType returns the elements of collection that have the type given as the type parameter.
+// Play: https://go.dev/play/p/PPfuC__LoTG
+func FilterByType[R, T any](elems []T) []R {
+	result := []R{}
+
+	for _, elem := range elems {
+		switch v := any(elem).(type) {
+		case R:
+			result = append(result, v)
+		}
+	}
+
+	return result
+}
+
 // ForEach iterates over elements of collection and invokes iteratee for each element.
 // Play: https://go.dev/play/p/oofyiUPRf8t
 func ForEach[T any](collection []T, iteratee func(item T, index int)) {

--- a/slice_test.go
+++ b/slice_test.go
@@ -127,6 +127,15 @@ func TestReduceRight(t *testing.T) {
 	is.Equal(result1, []int{4, 5, 2, 3, 0, 1})
 }
 
+func TestFilterByType(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	is.Equal([]int{1, 2}, FilterByType[int]([]any{1, "foo", 2, true}))
+	is.Equal([]any{1, "foo", 2, true}, FilterByType[any]([]any{1, "foo", 2, true}))
+	is.Equal([]float64{}, FilterByType[float64]([]any{1, "foo", 2, true}))
+}
+
 func TestForEach(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -388,7 +397,7 @@ func TestAssociate(t *testing.T) {
 
 func TestSliceToMap(t *testing.T) {
 	t.Parallel()
-	
+
 	type foo struct {
 		baz string
 		bar int
@@ -626,7 +635,7 @@ func TestSlice(t *testing.T) {
 	out16 := Slice(in, -10, 1)
 	out17 := Slice(in, -1, 3)
 	out18 := Slice(in, -10, 7)
-	
+
 	is.Equal([]int{}, out1)
 	is.Equal([]int{0}, out2)
 	is.Equal([]int{0, 1, 2, 3, 4}, out3)


### PR DESCRIPTION
added `FilterByType` function. This can skip type assertion after filtering.

Closes #339 