### PR TITLE
feat(emptyabletoptr): Optimize the performance of EmptyableToPtr()

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -60,3 +60,21 @@ func BenchmarkMap(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkEmptyableToPtr(b *testing.B) {
+	b.Run("lo.EmptyableToPtr", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_ = EmptyableToPtr("foobar")
+		}
+	})
+
+	b.Run("if", func(b *testing.B) {
+		val := "foobar"
+		for n := 0; n < b.N; n++ {
+			if val != "" {
+				_ = &val
+			}
+		}
+	})
+}

--- a/type_manipulation.go
+++ b/type_manipulation.go
@@ -1,6 +1,8 @@
 package lo
 
-import "reflect"
+import (
+	"unsafe"
+)
 
 // ToPtr returns a pointer copy of value.
 func ToPtr[T any](x T) *T {
@@ -10,13 +12,21 @@ func ToPtr[T any](x T) *T {
 // EmptyableToPtr returns a pointer copy of value if it's nonzero.
 // Otherwise, returns nil pointer.
 func EmptyableToPtr[T any](x T) *T {
-	// 🤮
-	isZero := reflect.ValueOf(&x).Elem().IsZero()
-	if isZero {
-		return nil
-	}
+	// You cannot directly use `==` to determine whether it is a zero value,
+	// because T is not constrained to be `comparable`
+	//   var zero T
+	//   if x == zero { ... } // error: T is not comparable
 
-	return &x
+	// If x is a zero value, all of its memory is 0.
+	// Leveraging this property, you can convert x into []uint8 to implement a zero-value check.
+	size := unsafe.Sizeof(x)
+	bytes := unsafe.Slice((*uint8)(unsafe.Pointer(&x)), size)
+	for _, b := range bytes {
+		if b != 0 {
+			return &x
+		}
+	}
+	return nil
 }
 
 // FromPtr returns the pointer value or empty.


### PR DESCRIPTION
Replace reflect operations with unsafe memory operations and add corresponding benchmark. Here are the comparison results of the benchmark(time consumption reduced by **97%**):

```
name                                 old time/op    new time/op    delta
EmptyableToPtr/lo.EmptyableToPtr-16    54.5ns ± 1%     1.5ns ± 0%   -97.16%  (p=0.016 n=5+4)
EmptyableToPtr/if-16                   0.39ns ± 0%    0.39ns ± 0%      ~     (p=0.254 n=5+5)

name                                 old alloc/op   new alloc/op   delta
EmptyableToPtr/lo.EmptyableToPtr-16     16.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)

name                                 old allocs/op  new allocs/op  delta
EmptyableToPtr/lo.EmptyableToPtr-16      1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
```