### PR TITLE
feat: Optimize the performance of ForEach

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
-	lop "github.com/samber/lo/parallel"
 	"github.com/thoas/go-funk"
+
+	lop "github.com/samber/lo/parallel"
 )
 
 func sliceGenerator(size uint) []int64 {
@@ -56,6 +57,29 @@ func BenchmarkMap(b *testing.B) {
 			for i, item := range arr {
 				result := strconv.FormatInt(item, 10)
 				results[i] = result
+			}
+		}
+	})
+}
+
+func BenchmarkForEach(b *testing.B) {
+	arr := Times(1000, func(index int) time.Location {
+		return time.Location{}
+	})
+
+	b.Run("ForEach", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			ForEach(arr, func(item time.Location, index int) { _ = item })
+		}
+	})
+
+	b.Run("oldForEach", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			iteratee := func(item time.Location, index int) { _ = item }
+			for i, item := range arr {
+				iteratee(item, i)
 			}
 		}
 	})

--- a/slice.go
+++ b/slice.go
@@ -88,8 +88,8 @@ func ReduceRight[T any, R any](collection []T, accumulator func(agg R, item T, i
 // ForEach iterates over elements of collection and invokes iteratee for each element.
 // Play: https://go.dev/play/p/oofyiUPRf8t
 func ForEach[T any](collection []T, iteratee func(item T, index int)) {
-	for i, item := range collection {
-		iteratee(item, i)
+	for i := 0; i < len(collection); i++ {
+		iteratee(collection[i], i)
 	}
 }
 


### PR DESCRIPTION
Use index to avoid additional copy of elements in collection. Here are the comparison results of the benchmark(time consumption reduced by 91%, will reduce more if T is more complex.):
```
goos: darwin
goarch: amd64
pkg: github.com/samber/lo
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkForEach
BenchmarkForEach/ForEach
BenchmarkForEach/ForEach-12         	 4450746	       273.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkForEach/oldForEach
BenchmarkForEach/oldForEach-12      	  380451	      3109 ns/op	       0 B/op	       0 allocs/op
```