### PR TITLE
 Add DifferenceBy And Edit Difference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -405,6 +405,7 @@ Supported intersection helpers:
 - Some
 - Intersect
 - Difference
+- DifferenceBy
 
 Supported search helpers:
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Supported intersection helpers:
 - [NoneBy](#noneby)
 - [Intersect](#intersect)
 - [Difference](#difference)
+- [DifferenceBy](#differenceby)
 - [Union](#union)
 - [Without](#without)
 - [WithoutEmpty](#withoutempty)
@@ -1712,12 +1713,32 @@ Returns the difference between two collections.
 - The second value is the collection of element absent of list1.
 
 ```go
-left, right := lo.Difference([]int{0, 1, 2, 3, 4, 5}, []int{0, 2, 6})
-// []int{1, 3, 4, 5}, []int{6}
+result := lo.Difference([]int{0, 1, 2, 3, 4, 5}, []int{0, 2, 6})
+// []int{1, 3, 4, 5}
 
-left, right := lo.Difference([]int{0, 1, 2, 3, 4, 5}, []int{0, 1, 2, 3, 4, 5})
-// []int{}, []int{}
+result := lo.Difference([]int{0, 1, 2, 3, 4, 5}, []int{0, 1, 2, 3, 4, 5})
+// []int{}
 ```
+
+### DifferenceBy
+
+Returns the difference between two collections.
+
+- The first value is the collection of element absent of list2.
+- The second value is the collection of element absent of list1.
+
+```go
+result := lo.DifferenceBy([]float64{3.1, 2.2, 1.3}, []float64{4.4, 2.5}, func(i float64) float64 {
+    return math.Floor(i)
+})
+// []float64{3.1, 1.3}
+
+result := lo.DifferenceBy([]map[string]int{{"x": 2}, {"x": 1}}, []map[string]int{{"x": 1}}, func(i map[string]int) int {
+    return i["x"]
+})
+// []map[string]int{{"x": 2}}
+```
+
 
 ### Union
 

--- a/intersect.go
+++ b/intersect.go
@@ -109,18 +109,11 @@ func Intersect[T comparable](list1 []T, list2 []T) []T {
 }
 
 // Difference returns the difference between two collections.
-// The first value is the collection of element absent of list2.
-// The second value is the collection of element absent of list1.
-func Difference[T comparable](list1 []T, list2 []T) ([]T, []T) {
-	left := []T{}
-	right := []T{}
+// the collection of element absent of list2.
+func Difference[T comparable](list1 []T, list2 []T) []T {
+	left := make([]T, 0)
 
-	seenLeft := map[T]struct{}{}
 	seenRight := map[T]struct{}{}
-
-	for _, elem := range list1 {
-		seenLeft[elem] = struct{}{}
-	}
 
 	for _, elem := range list2 {
 		seenRight[elem] = struct{}{}
@@ -132,13 +125,29 @@ func Difference[T comparable](list1 []T, list2 []T) ([]T, []T) {
 		}
 	}
 
+	return left
+}
+
+// DifferenceBy
+// This method is like _.difference except that it accepts iteratee which is invoked for each element of
+// collection and values to generate the criterion by which they're compared. The order and references of
+// result values are determined by the first collection.
+func DifferenceBy[T any, U comparable](list1 []T, list2 []T, iteratee func(item T) U) []T {
+	left := make([]T, 0)
+
+	seenRight := map[U]struct{}{}
+
 	for _, elem := range list2 {
-		if _, ok := seenLeft[elem]; !ok {
-			right = append(right, elem)
+		seenRight[iteratee(elem)] = struct{}{}
+	}
+
+	for _, elem := range list1 {
+		if _, ok := seenRight[iteratee(elem)]; !ok {
+			left = append(left, elem)
 		}
 	}
 
-	return left, right
+	return left
 }
 
 // Union returns all distinct elements from given collections.

--- a/intersect_test.go
+++ b/intersect_test.go
@@ -1,6 +1,7 @@
 package lo
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -193,17 +194,29 @@ func TestDifference(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	left1, right1 := Difference([]int{0, 1, 2, 3, 4, 5}, []int{0, 2, 6})
+	left1 := Difference([]int{0, 1, 2, 3, 4, 5}, []int{0, 2, 6})
 	is.Equal(left1, []int{1, 3, 4, 5})
-	is.Equal(right1, []int{6})
 
-	left2, right2 := Difference([]int{1, 2, 3, 4, 5}, []int{0, 6})
+	left2 := Difference([]int{1, 2, 3, 4, 5}, []int{0, 6})
 	is.Equal(left2, []int{1, 2, 3, 4, 5})
-	is.Equal(right2, []int{0, 6})
 
-	left3, right3 := Difference([]int{0, 1, 2, 3, 4, 5}, []int{0, 1, 2, 3, 4, 5})
+	left3 := Difference([]int{0, 1, 2, 3, 4, 5}, []int{0, 1, 2, 3, 4, 5})
 	is.Equal(left3, []int{})
-	is.Equal(right3, []int{})
+}
+
+func TestDifferenceBy(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	left1 := DifferenceBy([]float64{3.1, 2.2, 1.3}, []float64{4.4, 2.5}, func(i float64) float64 {
+		return math.Floor(i)
+	})
+	is.Equal(left1, []float64{3.1, 1.3})
+
+	left2 := DifferenceBy([]map[string]int{{"x": 2}, {"x": 1}}, []map[string]int{{"x": 1}}, func(i map[string]int) int {
+		return i["x"]
+	})
+	is.Equal(left2, []map[string]int{{"x": 2}})
 }
 
 func TestUnion(t *testing.T) {


### PR DESCRIPTION
Sometimes in business code, it's not necessary to return Right. I think it's a waste of performance. If necessary, you can swap the positions of list1 and list2. Then, I added DifferenceBy according to the example of lodash.js.