### PR TITLE
Add `MergeMaps` Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Supported helpers for maps:
 - [MapValues](#mapvalues)
 - [MapEntries](#mapentries)
 - [MapToSlice](#maptoslice)
-- [MergeMaps] (#mergemaps)
+- [MergeMaps](#mergemaps)
 
 Supported math helpers:
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Supported helpers for maps:
 - [MapValues](#mapvalues)
 - [MapEntries](#mapentries)
 - [MapToSlice](#maptoslice)
+- [MergeMaps] (#mergemaps)
 
 Supported math helpers:
 
@@ -1154,6 +1155,29 @@ s := lo.MapToSlice(m, func(k int, v int64) string {
 ```
 
 [[play](https://go.dev/play/p/ZuiCZpDt6LD)]
+
+### MergeMaps
+
+Transforms a map into a slice based on specific iteratee.
+
+```go
+left := map[string]float64{
+    "a": 1,
+    "b": 2.1,
+}
+
+right := map[string]int{
+    "b": 1,
+    "c": 3,
+}
+
+s := lo.MergeMaps(func(_ string, existing float64, new int) float64 {
+    return existing + float64(new)
+}, func(_ string, new int) float64 {
+    return float64(new)
+}, left, right)
+// map[string]float64{"a": 1, "b": 3.1, "c": 3}
+```
 
 ### Range / RangeFrom / RangeWithSteps
 

--- a/map.go
+++ b/map.go
@@ -222,3 +222,22 @@ func MapToSlice[K comparable, V any, R any](in map[K]V, iteratee func(key K, val
 
 	return result
 }
+
+type MapMergeFunc[K comparable, T, S any] func(key K, existing T, new S) T
+type MapInitFunc[K comparable, T, S any] func(key K, new S) T
+
+// MergeMaps updates the left map with values from the right maps,
+// using custom merge and initialisation logic.
+func MergeMaps[K comparable, T, S any](mergeFunc MapMergeFunc[K, T, S], initFunc MapInitFunc[K, T, S], left map[K]T, right ...map[K]S) map[K]T {
+	for _, m := range right {
+		for k, v := range m {
+			if existing, ok := left[k]; ok {
+				left[k] = mergeFunc(k, existing, v)
+			} else {
+				left[k] = initFunc(k, v)
+			}
+		}
+	}
+
+	return left
+}

--- a/map_test.go
+++ b/map_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKeys(t *testing.T) {
@@ -340,8 +341,8 @@ type mergeTestCase[K comparable, T, S any] struct {
 	name      string
 	left      map[K]T
 	right     []map[K]S
-	mergeFunc MapMergeFunc
-	initFunc  MapInitFunc
+	mergeFunc MapMergeFunc[K, T, S]
+	initFunc  MapInitFunc[K, T, S]
 	expected  map[K]T
 }
 


### PR DESCRIPTION
It supports merging multiple maps using custom merge logic, where the value type of the left and right maps can differ.