### PR TITLE
feat: implement lo.Join

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -1,6 +1,7 @@
 package lo
 
 import (
+	"fmt"
 	"math/rand"
 
 	"golang.org/x/exp/constraints"
@@ -591,4 +592,20 @@ func IsSortedByKey[T any, K constraints.Ordered](collection []T, iteratee func(i
 	}
 
 	return true
+}
+
+// Join converts all elements in array into a string separated by separator.
+func Join[T any](collection []T, separator string) string {
+	size := len(collection)
+	result := ""
+
+	for i := 0; i < size; i++ {
+		if i == size-1 {
+			result += fmt.Sprintf("%v", collection[i])
+		} else {
+			result += fmt.Sprintf("%v%v", collection[i], separator)
+		}
+	}
+
+	return result
 }

--- a/slice_test.go
+++ b/slice_test.go
@@ -388,7 +388,7 @@ func TestAssociate(t *testing.T) {
 
 func TestSliceToMap(t *testing.T) {
 	t.Parallel()
-	
+
 	type foo struct {
 		baz string
 		bar int
@@ -626,7 +626,7 @@ func TestSlice(t *testing.T) {
 	out16 := Slice(in, -10, 1)
 	out17 := Slice(in, -1, 3)
 	out18 := Slice(in, -10, 7)
-	
+
 	is.Equal([]int{}, out1)
 	is.Equal([]int{0}, out2)
 	is.Equal([]int{0, 1, 2, 3, 4}, out3)
@@ -758,4 +758,19 @@ func TestIsSortedByKey(t *testing.T) {
 		ret, _ := strconv.Atoi(s)
 		return ret
 	}))
+}
+
+func TestJoin(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	r1 := Join([]int{1, 2, 3}, "-")
+	r2 := Join([]float64{1.1, 2.2, 3.3}, "-")
+	r3 := Join([]bool{true, false}, "-")
+	r4 := Join([]string{"a", "b", "c"}, "-")
+
+	is.Equal(r1, "1-2-3")
+	is.Equal(r2, "1.1-2.2-3.3")
+	is.Equal(r3, "true-false")
+	is.Equal(r4, "a-b-c")
 }


### PR DESCRIPTION
Converts all elements in array into a string separated by separator.

Reference Join in Lodash: https://lodash.com/docs/4.17.15#join

implement lo.Join for issue #351: https://github.com/samber/lo/issues/351