### PR TITLE
Add new method Concat

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Supported helpers for slices:
 - [CountValuesBy](#countvaluesby)
 - [Subset](#subset)
 - [Slice](#slice)
+- [Concat](#concat)
 - [Replace](#replace)
 - [ReplaceAll](#replaceall)
 - [Compact](#compact)
@@ -847,6 +848,21 @@ slice := lo.Slice(in, 4, 3)
 ```
 
 [[play](https://go.dev/play/p/8XWYhfMMA1h)]
+
+### Concat
+
+Returns a new slice containing all the elements in collections. Concat conserves the order of the elements.
+
+```go
+slice := lo.Concat([]int{1, 2}, []int{3, 4})
+// []int{1, 2, 3, 4}
+
+slice := lo.Concat(nil, []int{1, 2}, nil, []int{3, 4}, nil)
+// []int{1, 2, 3, 4}
+
+slice := lo.Concat[int]()
+// []int{}
+```
 
 ### Replace
 

--- a/slice.go
+++ b/slice.go
@@ -529,6 +529,23 @@ func Slice[T any](collection []T, start int, end int) []T {
 	return collection[start:end]
 }
 
+// Concat returns a new slice containing all the elements in
+// collections. Concat conserves the order of the elements.
+func Concat[T any](collections ...[]T) []T {
+	size := 0
+	for i := range collections {
+		size += len(collections[i])
+	}
+
+	result := make([]T, 0, size) // preallocate memory for the output slice
+	for i := 0; i < len(collections); i++ {
+		// `result` memory address is not expected to change, because we preallocated enough memory
+		result = append(result, collections[i]...)
+	}
+
+	return result
+}
+
 // Replace returns a copy of the slice with the first n non-overlapping instances of old replaced by new.
 // Play: https://go.dev/play/p/XfPzmf9gql6
 func Replace[T comparable](collection []T, old T, new T, n int) []T {
@@ -591,19 +608,4 @@ func IsSortedByKey[T any, K constraints.Ordered](collection []T, iteratee func(i
 	}
 
 	return true
-}
-
-// Concat returns a new slice containing all the elements in `collection` plus items
-func Concat[T any](collection []T, items ...T) []T {
-	result := make([]T, len(collection)+len(items))
-
-	for i := 0; i < len(collection); i++ {
-		result[i] = collection[i]
-	}
-
-	for i := 0; i < len(items); i++ {
-		result[len(collection)+i] = items[i]
-	}
-
-	return result
 }

--- a/slice.go
+++ b/slice.go
@@ -592,3 +592,18 @@ func IsSortedByKey[T any, K constraints.Ordered](collection []T, iteratee func(i
 
 	return true
 }
+
+// Concat returns a new slice containing all the elements in `collection` plus items
+func Concat[T any](collection []T, items ...T) []T {
+	result := make([]T, len(collection)+len(items))
+
+	for i := 0; i < len(collection); i++ {
+		result[i] = collection[i]
+	}
+
+	for i := 0; i < len(items); i++ {
+		result[len(collection)+i] = items[i]
+	}
+
+	return result
+}

--- a/slice_test.go
+++ b/slice_test.go
@@ -652,7 +652,7 @@ func TestConcat(t *testing.T) {
 	is := assert.New(t)
 
 	is.Equal([]int{1, 2, 3, 4}, Concat([]int{1, 2}, []int{3, 4}))
-	is.Equal([]int{1, 2, 3, 4}, Concat([]int{1, 2}, []int{3, 4}))
+	is.Equal([]int{1, 2, 3, 4}, Concat(nil, []int{1, 2}, nil, []int{3, 4}, nil))
 	is.Equal([]int{}, Concat[int](nil, nil))
 	is.Equal([]int{}, Concat[int]())
 }

--- a/slice_test.go
+++ b/slice_test.go
@@ -388,7 +388,7 @@ func TestAssociate(t *testing.T) {
 
 func TestSliceToMap(t *testing.T) {
 	t.Parallel()
-	
+
 	type foo struct {
 		baz string
 		bar int
@@ -626,7 +626,7 @@ func TestSlice(t *testing.T) {
 	out16 := Slice(in, -10, 1)
 	out17 := Slice(in, -1, 3)
 	out18 := Slice(in, -10, 7)
-	
+
 	is.Equal([]int{}, out1)
 	is.Equal([]int{0}, out2)
 	is.Equal([]int{0, 1, 2, 3, 4}, out3)
@@ -758,4 +758,12 @@ func TestIsSortedByKey(t *testing.T) {
 		ret, _ := strconv.Atoi(s)
 		return ret
 	}))
+}
+
+func TestConcat(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	is.Equal([]int{1, 2, 3, 4}, Concat([]int{1, 2}, 3, 4))
+	is.Equal([]int{1, 2}, Concat(nil, 1, 2))
 }

--- a/slice_test.go
+++ b/slice_test.go
@@ -647,6 +647,16 @@ func TestSlice(t *testing.T) {
 	is.Equal([]int{0, 1, 2, 3, 4}, out18)
 }
 
+func TestConcat(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	is.Equal([]int{1, 2, 3, 4}, Concat([]int{1, 2}, []int{3, 4}))
+	is.Equal([]int{1, 2, 3, 4}, Concat([]int{1, 2}, []int{3, 4}))
+	is.Equal([]int{}, Concat[int](nil, nil))
+	is.Equal([]int{}, Concat[int]())
+}
+
 func TestReplace(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -758,12 +768,4 @@ func TestIsSortedByKey(t *testing.T) {
 		ret, _ := strconv.Atoi(s)
 		return ret
 	}))
-}
-
-func TestConcat(t *testing.T) {
-	t.Parallel()
-	is := assert.New(t)
-
-	is.Equal([]int{1, 2, 3, 4}, Concat([]int{1, 2}, 3, 4))
-	is.Equal([]int{1, 2}, Concat(nil, 1, 2))
 }


### PR DESCRIPTION
Add a new method `Concat` similar to the one in lodash, it creates a concatenated slice which is independent of the original slice, unlike `append`. This comes in handy when you need to create multiple slices from one base slice