### PR TITLE
tableToTree helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ Constraints:
 
 - Clonable
 
+Tree helpers:
+
+- [TableToTree](#tabletotree)
+
 ### Filter
 
 Iterates over a collection and returns an array of all the elements the predicate function returns `true` for.
@@ -2850,6 +2854,56 @@ if rateLimitErr, ok := lo.ErrorsAs[*RateLimitError](err); ok {
 ```
 
 [[play](https://go.dev/play/p/8wk5rH8UfrE)]
+
+
+### TableToTree
+
+TableToTree transforms database-like table into tree-structure
+
+```go
+type rowType struct {
+    id       int
+    parentId int
+    value    string
+}
+
+type leafType struct {
+    value string
+    leafs []leafType
+}
+
+table := []rowType{
+    {1, 0, "A"},
+    {2, 1, "AA"},
+    {3, 1, "AB"},
+    {4, 3, "ABA"},
+    {5, 1, "AC"},
+    {6, 0, "B"},
+}
+
+tree, _ := TableToTree(
+    table,
+    func(row *rowType, children []leafType) leafType {
+        return leafType{
+            value: row.value,
+            leafs: children,
+        }
+    },
+    func(row *rowType) (int, int, bool) {
+        return row.id, row.parentId, row.parentId == 0
+    },
+)
+// []leafType{
+//     {value: "A", leafs: []leafType{
+//         {value: "AA"},
+//         {value: "AB", leafs: []leafType{
+//             {value: "ABA"},
+//         }},
+//         {value: "AC"},
+//     }},
+//     {value: "B"},
+// }
+```
 
 ## 🛩 Benchmark
 

--- a/tree.go
+++ b/tree.go
@@ -1,0 +1,63 @@
+package lo
+
+import "fmt"
+
+// TableToTree transforms database-like table into tree-structure
+func TableToTree[R any, L any, K comparable](
+	rows []R,
+	rowToLeafFunc func(row *R, children []L) L,
+	getKeysFunc func(row *R) (id K, parentId K, isRoot bool),
+) ([]L, error) {
+
+	type nodeType struct {
+		payload  *R
+		children []*nodeType
+	}
+
+	// Make node map
+	nodeMap := make(map[K]*nodeType, len(rows))
+	for _, row := range rows {
+		row := row
+		id, _, _ := getKeysFunc(&row)
+		if _, exists := nodeMap[id]; exists {
+			return nil, fmt.Errorf("lo.TableToTree: duplicate primary id")
+		}
+		nodeMap[id] = &nodeType{
+			payload: &row,
+		}
+	}
+
+	// Connect children nodes
+	root := make([]*nodeType, 0)
+	for _, row := range rows {
+		id, parentId, isRoot := getKeysFunc(&row)
+		node := nodeMap[id]
+
+		if isRoot {
+			root = append(root, node)
+		} else {
+			parentNode, exists := nodeMap[parentId]
+			if !exists {
+				return nil, fmt.Errorf("lo.TableToTree: bad parent id")
+			}
+			parentNode.children = append(parentNode.children, node)
+		}
+	}
+
+	// Walk through the node tree and build leaf tree
+	var walkFunc func([]*nodeType) []L
+	walkFunc = func(nodes []*nodeType) []L {
+		if len(nodes) == 0 {
+			return nil
+		}
+
+		leafs := make([]L, 0, len(nodes))
+		for _, node := range nodes {
+			leaf := rowToLeafFunc(node.payload, walkFunc(node.children))
+			leafs = append(leafs, leaf)
+		}
+		return leafs
+	}
+
+	return walkFunc(root), nil
+}

--- a/tree_example_test.go
+++ b/tree_example_test.go
@@ -1,0 +1,79 @@
+package lo
+
+import (
+	"fmt"
+	"strings"
+)
+
+type exampleTreeRowType struct {
+	id       int
+	parentId int
+	slug     string
+	title    string
+}
+
+type exampleTreeLeafType struct {
+	slug     string
+	title    string
+	children []exampleTreeLeafType
+}
+
+func ExampleTree() {
+	table := []exampleTreeRowType{
+		{1, 0, "el", "Electronics"},
+		{2, 1, "ph", "Phones"},
+		{3, 2, "ios", "iOS"},
+		{4, 2, "and", "Android"},
+		{5, 1, "tab", "Tablets"},
+		{6, 1, "lap", "Laptops"},
+		{7, 0, "fnt", "Furniture"},
+		{8, 7, "kt", "Kitchen"},
+		{9, 7, "bd", "Bedroom"},
+		{10, 7, "lng", "Lounge"},
+		{11, 0, "car", "Car"},
+		{12, 11, "gps", "GPS"},
+		{13, 11, "au", "Audio"},
+		{14, 11, "al", "Alarm"},
+		{15, 0, "oth", "Other"},
+	}
+
+	tree, _ := TableToTree(
+		table,
+		func(row *exampleTreeRowType, children []exampleTreeLeafType) exampleTreeLeafType {
+			return exampleTreeLeafType{
+				slug:  row.slug,
+				title: row.title,
+
+				children: children,
+			}
+		},
+		func(row *exampleTreeRowType) (int, int, bool) {
+			return row.id, row.parentId, row.parentId == 0
+		},
+	)
+
+	printExmpleTree(tree, 0)
+	// Output:
+	// Electronics
+	// .Phones
+	// ..iOS
+	// ..Android
+	// .Tablets
+	// .Laptops
+	// Furniture
+	// .Kitchen
+	// .Bedroom
+	// .Lounge
+	// Car
+	// .GPS
+	// .Audio
+	// .Alarm
+	// Other
+}
+
+func printExmpleTree(leafs []exampleTreeLeafType, depth int) {
+	for _, leaf := range leafs {
+		fmt.Println(strings.Repeat(".", depth) + leaf.title)
+		printExmpleTree(leaf.children, depth+1)
+	}
+}

--- a/tree_test.go
+++ b/tree_test.go
@@ -1,0 +1,153 @@
+package lo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testTreeRowType struct {
+	id       string
+	parentId string
+	value    string
+}
+
+type testTreeLeafType struct {
+	value string
+	leafs []testTreeLeafType
+}
+
+func testTreeRowToLeaf(row *testTreeRowType, children []testTreeLeafType) testTreeLeafType {
+	return testTreeLeafType{
+		value: row.value,
+		leafs: children,
+	}
+}
+
+func testTreeGetKeys(row *testTreeRowType) (string, string, bool) {
+	return row.id, row.parentId, row.parentId == "<ROOT>"
+}
+
+func TestTree(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	table := []testTreeRowType{
+		{"a", "<ROOT>", "A"},
+		{"aa", "a", "AA"},
+		{"ab", "a", "AB"},
+		{"aba", "ab", "ABA"},
+		{"ac", "a", "AC"},
+		{"b", "<ROOT>", "B"},
+	}
+
+	tree, err := TableToTree(table, testTreeRowToLeaf, testTreeGetKeys)
+
+	is.NoError(err)
+	expected := []testTreeLeafType{
+		{value: "A", leafs: []testTreeLeafType{
+			{value: "AA"},
+			{value: "AB", leafs: []testTreeLeafType{
+				{value: "ABA"},
+			}},
+			{value: "AC"},
+		}},
+		{value: "B"},
+	}
+	is.Equal(expected, tree)
+}
+
+func TestEmptyTree(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	{
+		table := []testTreeRowType{}
+		tree, err := TableToTree(table, testTreeRowToLeaf, testTreeGetKeys)
+		is.NoError(err)
+		is.Nil(tree)
+	}
+
+	{
+		tree, err := TableToTree(nil, testTreeRowToLeaf, testTreeGetKeys)
+		is.NoError(err)
+		is.Nil(tree)
+	}
+}
+
+func TestDuplicatePrimaryId(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	table := []testTreeRowType{
+		{"a", "", "A"},
+		{"a", "", "A2"},
+	}
+
+	_, err := TableToTree(table, testTreeRowToLeaf, testTreeGetKeys)
+	is.ErrorContains(err, "lo.TableToTree: duplicate primary id")
+}
+
+func TestBadParentId(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	table := []testTreeRowType{
+		{"a", "", "A"},
+		{"b", "x", "X"},
+	}
+
+	_, err := TableToTree(table, testTreeRowToLeaf, testTreeGetKeys)
+	is.ErrorContains(err, "lo.TableToTree: bad parent id")
+}
+
+func TestTreeFromDoc(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	type rowType struct {
+		id       int
+		parentId int
+		value    string
+	}
+
+	type leafType struct {
+		value string
+		leafs []leafType
+	}
+
+	table := []rowType{
+		{1, 0, "A"},
+		{2, 1, "AA"},
+		{3, 1, "AB"},
+		{4, 3, "ABA"},
+		{5, 1, "AC"},
+		{6, 0, "B"},
+	}
+
+	tree, err := TableToTree(
+		table,
+		func(row *rowType, children []leafType) leafType {
+			return leafType{
+				value: row.value,
+				leafs: children,
+			}
+		},
+		func(row *rowType) (int, int, bool) {
+			return row.id, row.parentId, row.parentId == 0
+		},
+	)
+
+	is.NoError(err)
+	expected := []leafType{
+		{value: "A", leafs: []leafType{
+			{value: "AA"},
+			{value: "AB", leafs: []leafType{
+				{value: "ABA"},
+			}},
+			{value: "AC"},
+		}},
+		{value: "B"},
+	}
+	is.Equal(expected, tree)
+}


### PR DESCRIPTION
A helper that transforms database-like tables
```go
{1, 0, "A"},
{2, 1, "AA"},
{3, 1, "AB"},
{4, 3, "ABA"},
{5, 1, "AC"},
{6, 0, "B"},
```
 into tree-structures
```go
[]{
    {value: "A", leafs: []{
        {value: "AA"},
        {value: "AB", leafs: []{
             {value: "ABA"},
        }},
        {value: "AC"},
    }},
    {value: "B"}
}
```
For example: table of content, shop categories or any other hierarchy