### PR TITLE
add FromPtrOrF

### DIFF
--- a/type_manipulation.go
+++ b/type_manipulation.go
@@ -37,6 +37,15 @@ func FromPtrOr[T any](x *T, fallback T) T {
 	return *x
 }
 
+// FromPtrOrF returns the pointer value or the value returned by callback.
+func FromPtrOrF[T any](x *T, callback func() T) T {
+	if x == nil {
+		return callback()
+	}
+
+	return *x
+}
+
 // ToSlicePtr returns a slice of pointer copy of value.
 func ToSlicePtr[T any](collection []T) []*T {
 	return Map(collection, func(x T, _ int) *T {

--- a/type_manipulation_test.go
+++ b/type_manipulation_test.go
@@ -65,6 +65,30 @@ func TestFromPtrOr(t *testing.T) {
 	is.Equal(fallbackInt, FromPtrOr(nil, fallbackInt))
 }
 
+func TestFromPtrOrF(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	const fallbackStr = "fallback"
+	callbackStr := func() string {
+		return fallbackStr
+	}
+	str := "foo"
+	ptrStr := &str
+
+	const fallbackInt = -1
+	callbackInt := func() int {
+		return fallbackInt
+	}
+	i := 9
+	ptrInt := &i
+
+	is.Equal(str, FromPtrOrF(ptrStr, callbackStr))
+	is.Equal(fallbackStr, FromPtrOrF(nil, callbackStr))
+	is.Equal(i, FromPtrOrF(ptrInt, callbackInt))
+	is.Equal(fallbackInt, FromPtrOrF(nil, callbackInt))
+}
+
 func TestToSlicePtr(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)


### PR DESCRIPTION
## Motivation
There is a pitfall in existing `FromPtrOf` that fallback value must be provided even if it is expensive to create.
For example, assume `SecureRandStr` that generates secure random string:
```
func foo(token *string){
	v := lo.FromPtrOf(token, SecureRandStr())
	..
}
```

Even if `token` is not `nil`, `SecureRandStr` is always called.

## Proposal
Proposed `FromPtrOfF` accepts function that returns fallback value, rather than accept a fallback value itself:
```
func foo(token *string){
	v := lo.FromPtrOfF(token, SecureRandStr)
	..
}
```
Now `SecureRandStr` is called only if `token` is nil, saving cost to generate secure random token.