### PR TITLE
feat: circular slice selection

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -592,3 +592,36 @@ func IsSortedByKey[T any, K constraints.Ordered](collection []T, iteratee func(i
 
 	return true
 }
+
+// CircularSelection returns one element per index of a slice as if it were a circular linked list. Returns empty element if the slice is empty.
+// Play: https://go.dev/play/p/0IafnCqCVTu
+func CircularSelection[T any](collection []T, index int) T {
+	size := len(collection)
+	if size == 0 {
+		var zero T
+		return zero
+	}
+
+	index = index % size
+	if index < 0 {
+		index += size
+	}
+
+	return collection[index]
+}
+
+// CircularSelect returns one element per index of a slice as if it were a circular linked list. Panics if the slice is empty.
+// Play: https://go.dev/play/p/kbCF9f0TtvI
+func CircularSelect[T any](collection []T, index int) T {
+	size := len(collection)
+	if size == 0 {
+		panic("Collection is empty")
+	}
+
+	index = index % size
+	if index < 0 {
+		index += size
+	}
+
+	return collection[index]
+}

--- a/slice_test.go
+++ b/slice_test.go
@@ -388,7 +388,7 @@ func TestAssociate(t *testing.T) {
 
 func TestSliceToMap(t *testing.T) {
 	t.Parallel()
-	
+
 	type foo struct {
 		baz string
 		bar int
@@ -626,7 +626,7 @@ func TestSlice(t *testing.T) {
 	out16 := Slice(in, -10, 1)
 	out17 := Slice(in, -1, 3)
 	out18 := Slice(in, -10, 7)
-	
+
 	is.Equal([]int{}, out1)
 	is.Equal([]int{0}, out2)
 	is.Equal([]int{0, 1, 2, 3, 4}, out3)
@@ -758,4 +758,43 @@ func TestIsSortedByKey(t *testing.T) {
 		ret, _ := strconv.Atoi(s)
 		return ret
 	}))
+}
+
+func TestCircularSelect(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	in := []int{0, 1, 2, 3, 4}
+
+	is.Equal(4, CircularSelect(in, -6))
+	is.Equal(0, CircularSelect(in, -5))
+	is.Equal(1, CircularSelect(in, -4))
+	is.Equal(4, CircularSelect(in, -1))
+	is.Equal(0, CircularSelect(in, -0))
+	is.Equal(0, CircularSelect(in, 0))
+	is.Equal(1, CircularSelect(in, 1))
+	is.Equal(4, CircularSelect(in, 4))
+	is.Equal(0, CircularSelect(in, 5))
+	is.Equal(1, CircularSelect(in, 6))
+}
+
+func TestCircularSelection(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	in := []int{0, 1, 2, 3, 4}
+
+	is.Equal(4, CircularSelection(in, -6))
+	is.Equal(0, CircularSelection(in, -5))
+	is.Equal(1, CircularSelection(in, -4))
+	is.Equal(4, CircularSelection(in, -1))
+	is.Equal(0, CircularSelection(in, -0))
+	is.Equal(0, CircularSelection(in, 0))
+	is.Equal(1, CircularSelection(in, 1))
+	is.Equal(4, CircularSelection(in, 4))
+	is.Equal(0, CircularSelection(in, 5))
+	is.Equal(1, CircularSelection(in, 6))
+
+	in = []int{}
+	is.Equal(0, CircularSelection(in, 0))
 }


### PR DESCRIPTION
Adds two functions to select item by index of a slice as if it were a circular linked list. 
The difference between them is in the way they treat an empty slice, `CircularSelection` returns an empty instance while `CircularSelect` panics.
I belive `CircularSelection` is better, feel free to comment too. 
