### PR TITLE
feat: return nil for slice operations that received nil

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -9,6 +9,10 @@ import (
 // Filter iterates over elements of collection, returning an array of all elements predicate returns truthy for.
 // Play: https://go.dev/play/p/Apjg3WeSi7K
 func Filter[V any](collection []V, predicate func(item V, index int) bool) []V {
+	if collection == nil {
+		return nil
+	}
+
 	result := make([]V, 0, len(collection))
 
 	for i, item := range collection {
@@ -23,6 +27,10 @@ func Filter[V any](collection []V, predicate func(item V, index int) bool) []V {
 // Map manipulates a slice and transforms it to a slice of another type.
 // Play: https://go.dev/play/p/OkPcYAhBo0D
 func Map[T any, R any](collection []T, iteratee func(item T, index int) R) []R {
+	if collection == nil {
+		return nil
+	}
+
 	result := make([]R, len(collection))
 
 	for i, item := range collection {
@@ -39,6 +47,10 @@ func Map[T any, R any](collection []T, iteratee func(item T, index int) R) []R {
 //
 // Play: https://go.dev/play/p/-AuYXfy7opz
 func FilterMap[T any, R any](collection []T, callback func(item T, index int) (R, bool)) []R {
+	if collection == nil {
+		return nil
+	}
+
 	result := []R{}
 
 	for i, item := range collection {
@@ -55,6 +67,10 @@ func FilterMap[T any, R any](collection []T, callback func(item T, index int) (R
 // no value is added to the final slice.
 // Play: https://go.dev/play/p/YSoYmQTA8-U
 func FlatMap[T any, R any](collection []T, iteratee func(item T, index int) []R) []R {
+	if collection == nil {
+		return nil
+	}
+
 	result := make([]R, 0, len(collection))
 
 	for i, item := range collection {
@@ -110,6 +126,10 @@ func Times[T any](count int, iteratee func(index int) T) []T {
 // The order of result values is determined by the order they occur in the array.
 // Play: https://go.dev/play/p/DTzbeXZ6iEN
 func Uniq[T comparable](collection []T) []T {
+	if collection == nil {
+		return nil
+	}
+
 	result := make([]T, 0, len(collection))
 	seen := make(map[T]struct{}, len(collection))
 
@@ -130,6 +150,10 @@ func Uniq[T comparable](collection []T) []T {
 // invoked for each element in array to generate the criterion by which uniqueness is computed.
 // Play: https://go.dev/play/p/g42Z3QSb53u
 func UniqBy[T any, U comparable](collection []T, iteratee func(item T) U) []T {
+	if collection == nil {
+		return nil
+	}
+
 	result := make([]T, 0, len(collection))
 	seen := make(map[U]struct{}, len(collection))
 
@@ -169,6 +193,10 @@ func Chunk[T any](collection []T, size int) [][]T {
 		panic("Second parameter must be greater than 0")
 	}
 
+	if collection == nil {
+		return nil
+	}
+
 	chunksNum := len(collection) / size
 	if len(collection)%size != 0 {
 		chunksNum += 1
@@ -192,6 +220,10 @@ func Chunk[T any](collection []T, size int) [][]T {
 // of running each element of collection through iteratee.
 // Play: https://go.dev/play/p/NfQ_nGjkgXW
 func PartitionBy[T any, K comparable](collection []T, iteratee func(item T) K) [][]T {
+	if collection == nil {
+		return nil
+	}
+
 	result := [][]T{}
 	seen := map[K]int{}
 
@@ -218,6 +250,10 @@ func PartitionBy[T any, K comparable](collection []T, iteratee func(item T) K) [
 // Flatten returns an array a single level deep.
 // Play: https://go.dev/play/p/rbp9ORaMpjw
 func Flatten[T any](collection [][]T) []T {
+	if collection == nil {
+		return nil
+	}
+
 	totalLen := 0
 	for i := range collection {
 		totalLen += len(collection[i])
@@ -282,6 +318,10 @@ func Shuffle[T any](collection []T) []T {
 // Reverse reverses array so that the first element becomes the last, the second element becomes the second to last, and so on.
 // Play: https://go.dev/play/p/fhUMLvZ7vS6
 func Reverse[T any](collection []T) []T {
+	if collection == nil {
+		return nil
+	}
+
 	length := len(collection)
 	half := length / 2
 
@@ -296,6 +336,10 @@ func Reverse[T any](collection []T) []T {
 // Fill fills elements of array with `initial` value.
 // Play: https://go.dev/play/p/VwR34GzqEub
 func Fill[T Clonable[T]](collection []T, initial T) []T {
+	if collection == nil {
+		return nil
+	}
+
 	result := make([]T, 0, len(collection))
 
 	for range collection {
@@ -369,6 +413,10 @@ func SliceToMap[T any, K comparable, V any](collection []T, transform func(item 
 // Drop drops n elements from the beginning of a slice or array.
 // Play: https://go.dev/play/p/JswS7vXRJP2
 func Drop[T any](collection []T, n int) []T {
+	if collection == nil {
+		return nil
+	}
+
 	if len(collection) <= n {
 		return make([]T, 0)
 	}
@@ -381,6 +429,10 @@ func Drop[T any](collection []T, n int) []T {
 // DropRight drops n elements from the end of a slice or array.
 // Play: https://go.dev/play/p/GG0nXkSJJa3
 func DropRight[T any](collection []T, n int) []T {
+	if collection == nil {
+		return nil
+	}
+
 	if len(collection) <= n {
 		return []T{}
 	}
@@ -392,6 +444,10 @@ func DropRight[T any](collection []T, n int) []T {
 // DropWhile drops elements from the beginning of a slice or array while the predicate returns true.
 // Play: https://go.dev/play/p/7gBPYw2IK16
 func DropWhile[T any](collection []T, predicate func(item T) bool) []T {
+	if collection == nil {
+		return nil
+	}
+
 	i := 0
 	for ; i < len(collection); i++ {
 		if !predicate(collection[i]) {
@@ -406,6 +462,10 @@ func DropWhile[T any](collection []T, predicate func(item T) bool) []T {
 // DropRightWhile drops elements from the end of a slice or array while the predicate returns true.
 // Play: https://go.dev/play/p/3-n71oEC0Hz
 func DropRightWhile[T any](collection []T, predicate func(item T) bool) []T {
+	if collection == nil {
+		return nil
+	}
+
 	i := len(collection) - 1
 	for ; i >= 0; i-- {
 		if !predicate(collection[i]) {
@@ -420,6 +480,10 @@ func DropRightWhile[T any](collection []T, predicate func(item T) bool) []T {
 // Reject is the opposite of Filter, this method returns the elements of collection that predicate does not return truthy for.
 // Play: https://go.dev/play/p/YkLMODy1WEL
 func Reject[V any](collection []V, predicate func(item V, index int) bool) []V {
+	if collection == nil {
+		return nil
+	}
+
 	result := []V{}
 
 	for i, item := range collection {
@@ -483,6 +547,10 @@ func CountValuesBy[T any, U comparable](collection []T, mapper func(item T) U) m
 // Subset returns a copy of a slice from `offset` up to `length` elements. Like `slice[start:start+length]`, but does not panic on overflow.
 // Play: https://go.dev/play/p/tOQu1GhFcog
 func Subset[T any](collection []T, offset int, length uint) []T {
+	if collection == nil {
+		return nil
+	}
+
 	size := len(collection)
 
 	if offset < 0 {
@@ -506,6 +574,10 @@ func Subset[T any](collection []T, offset int, length uint) []T {
 // Slice returns a copy of a slice from `start` up to, but not including `end`. Like `slice[start:end]`, but does not panic on overflow.
 // Play: https://go.dev/play/p/8XWYhfMMA1h
 func Slice[T any](collection []T, start int, end int) []T {
+	if collection == nil {
+		return nil
+	}
+
 	size := len(collection)
 
 	if start >= end {
@@ -532,6 +604,10 @@ func Slice[T any](collection []T, start int, end int) []T {
 // Replace returns a copy of the slice with the first n non-overlapping instances of old replaced by new.
 // Play: https://go.dev/play/p/XfPzmf9gql6
 func Replace[T comparable](collection []T, old T, new T, n int) []T {
+	if collection == nil {
+		return nil
+	}
+
 	result := make([]T, len(collection))
 	copy(result, collection)
 
@@ -554,6 +630,10 @@ func ReplaceAll[T comparable](collection []T, old T, new T) []T {
 // Compact returns a slice of all non-zero elements.
 // Play: https://go.dev/play/p/tXiy-iK6PAc
 func Compact[T comparable](collection []T) []T {
+	if collection == nil {
+		return nil
+	}
+
 	var zero T
 
 	result := make([]T, 0, len(collection))

--- a/slice_test.go
+++ b/slice_test.go
@@ -19,13 +19,25 @@ func TestFilter(t *testing.T) {
 		return x%2 == 0
 	})
 
-	is.Equal(r1, []int{2, 4})
+	is.Equal([]int{2, 4}, r1)
 
 	r2 := Filter([]string{"", "foo", "", "bar", ""}, func(x string, _ int) bool {
 		return len(x) > 0
 	})
 
-	is.Equal(r2, []string{"foo", "bar"})
+	is.Equal([]string{"foo", "bar"}, r2)
+
+	r3 := Filter([]string{}, func(x string, _ int) bool {
+		return true
+	})
+
+	is.Equal([]string{}, r3)
+
+	r4 := Filter(nil, func(x string, _ int) bool {
+		return true
+	})
+
+	is.Nil(r4)
 }
 
 func TestMap(t *testing.T) {
@@ -38,11 +50,19 @@ func TestMap(t *testing.T) {
 	result2 := Map([]int64{1, 2, 3, 4}, func(x int64, _ int) string {
 		return strconv.FormatInt(x, 10)
 	})
+	result3 := Map([]int64{}, func(x int64, _ int) string {
+		return strconv.FormatInt(x, 10)
+	})
+	result4 := Map(nil, func(x int64, _ int) string {
+		return strconv.FormatInt(x, 10)
+	})
 
 	is.Equal(len(result1), 4)
 	is.Equal(len(result2), 4)
-	is.Equal(result1, []string{"Hello", "Hello", "Hello", "Hello"})
-	is.Equal(result2, []string{"1", "2", "3", "4"})
+	is.Equal([]string{"Hello", "Hello", "Hello", "Hello"}, result1)
+	is.Equal([]string{"1", "2", "3", "4"}, result2)
+	is.Equal([]string{}, result3)
+	is.Nil(result4)
 }
 
 func TestFilterMap(t *testing.T) {
@@ -61,11 +81,19 @@ func TestFilterMap(t *testing.T) {
 		}
 		return "", false
 	})
+	r3 := FilterMap([]string{}, func(x string, _ int) (string, bool) {
+		return "", false
+	})
+	r4 := FilterMap(nil, func(x string, _ int) (string, bool) {
+		return "", false
+	})
 
 	is.Equal(len(r1), 2)
 	is.Equal(len(r2), 2)
-	is.Equal(r1, []string{"2", "4"})
-	is.Equal(r2, []string{"xpu", "xpu"})
+	is.Equal([]string{"2", "4"}, r1)
+	is.Equal([]string{"xpu", "xpu"}, r2)
+	is.Equal([]string{}, r3)
+	is.Nil(r4)
 }
 
 func TestFlatMap(t *testing.T) {
@@ -82,11 +110,19 @@ func TestFlatMap(t *testing.T) {
 		}
 		return result
 	})
+	result3 := FlatMap([]int{}, func(x int, _ int) []string {
+		return []string{"Hello"}
+	})
+	result4 := FlatMap(nil, func(x int, _ int) []string {
+		return []string{"Hello"}
+	})
 
 	is.Equal(len(result1), 5)
 	is.Equal(len(result2), 10)
-	is.Equal(result1, []string{"Hello", "Hello", "Hello", "Hello", "Hello"})
-	is.Equal(result2, []string{"1", "2", "2", "3", "3", "3", "4", "4", "4", "4"})
+	is.Equal([]string{"Hello", "Hello", "Hello", "Hello", "Hello"}, result1)
+	is.Equal([]string{"1", "2", "2", "3", "3", "3", "4", "4", "4", "4"}, result2)
+	is.Equal([]string{}, result3)
+	is.Nil(result4)
 }
 
 func TestTimes(t *testing.T) {
@@ -151,9 +187,13 @@ func TestUniq(t *testing.T) {
 	is := assert.New(t)
 
 	result1 := Uniq([]int{1, 2, 2, 1})
+	result2 := Uniq([]int{})
+	result3 := Uniq([]int(nil))
 
 	is.Equal(len(result1), 2)
-	is.Equal(result1, []int{1, 2})
+	is.Equal([]int{1, 2}, result1)
+	is.Equal([]int{}, result2)
+	is.Nil(result3)
 }
 
 func TestUniqBy(t *testing.T) {
@@ -163,9 +203,17 @@ func TestUniqBy(t *testing.T) {
 	result1 := UniqBy([]int{0, 1, 2, 3, 4, 5}, func(i int) int {
 		return i % 3
 	})
+	result2 := UniqBy([]int{}, func(i int) int {
+		return i % 3
+	})
+	result3 := UniqBy([]int(nil), func(i int) int {
+		return i % 3
+	})
 
 	is.Equal(len(result1), 3)
-	is.Equal(result1, []int{0, 1, 2})
+	is.Equal([]int{0, 1, 2}, result1)
+	is.Equal([]int{}, result2)
+	is.Nil(result3)
 }
 
 func TestGroupBy(t *testing.T) {
@@ -192,11 +240,13 @@ func TestChunk(t *testing.T) {
 	result2 := Chunk([]int{0, 1, 2, 3, 4, 5, 6}, 2)
 	result3 := Chunk([]int{}, 2)
 	result4 := Chunk([]int{0}, 2)
+	result5 := Chunk([]int(nil), 2)
 
-	is.Equal(result1, [][]int{{0, 1}, {2, 3}, {4, 5}})
-	is.Equal(result2, [][]int{{0, 1}, {2, 3}, {4, 5}, {6}})
-	is.Equal(result3, [][]int{})
-	is.Equal(result4, [][]int{{0}})
+	is.Equal([][]int{{0, 1}, {2, 3}, {4, 5}}, result1)
+	is.Equal([][]int{{0, 1}, {2, 3}, {4, 5}, {6}}, result2)
+	is.Equal([][]int{}, result3)
+	is.Equal([][]int{{0}}, result4)
+	is.Nil(result5)
 	is.PanicsWithValue("Second parameter must be greater than 0", func() {
 		Chunk([]int{0}, 0)
 	})
@@ -217,9 +267,11 @@ func TestPartitionBy(t *testing.T) {
 
 	result1 := PartitionBy([]int{-2, -1, 0, 1, 2, 3, 4, 5}, oddEven)
 	result2 := PartitionBy([]int{}, oddEven)
+	result3 := PartitionBy([]int(nil), oddEven)
 
 	is.Equal(result1, [][]int{{-2, -1}, {0, 2, 4}, {1, 3, 5}})
 	is.Equal(result2, [][]int{})
+	is.Nil(result3)
 }
 
 func TestFlatten(t *testing.T) {
@@ -227,8 +279,12 @@ func TestFlatten(t *testing.T) {
 	is := assert.New(t)
 
 	result1 := Flatten([][]int{{0, 1}, {2, 3, 4, 5}})
+	result2 := Flatten([][]int{})
+	result3 := Flatten([][]int(nil))
 
-	is.Equal(result1, []int{0, 1, 2, 3, 4, 5})
+	is.Equal([]int{0, 1, 2, 3, 4, 5}, result1)
+	is.Equal([]int{}, result2)
+	is.Nil(result3)
 }
 
 func TestInterleave(t *testing.T) {
@@ -283,9 +339,11 @@ func TestShuffle(t *testing.T) {
 
 	result1 := Shuffle([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
 	result2 := Shuffle([]int{})
+	result3 := Shuffle([]int(nil))
 
-	is.NotEqual(result1, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
-	is.Equal(result2, []int{})
+	is.NotEqual([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, result1)
+	is.Equal([]int{}, result2)
+	is.Nil(result3)
 }
 
 func TestReverse(t *testing.T) {
@@ -295,10 +353,12 @@ func TestReverse(t *testing.T) {
 	result1 := Reverse([]int{0, 1, 2, 3, 4, 5})
 	result2 := Reverse([]int{0, 1, 2, 3, 4, 5, 6})
 	result3 := Reverse([]int{})
+	result4 := Reverse([]int(nil))
 
-	is.Equal(result1, []int{5, 4, 3, 2, 1, 0})
-	is.Equal(result2, []int{6, 5, 4, 3, 2, 1, 0})
-	is.Equal(result3, []int{})
+	is.Equal([]int{5, 4, 3, 2, 1, 0}, result1)
+	is.Equal([]int{6, 5, 4, 3, 2, 1, 0}, result2)
+	is.Equal([]int{}, result3)
+	is.Nil(result4)
 }
 
 func TestFill(t *testing.T) {
@@ -307,9 +367,11 @@ func TestFill(t *testing.T) {
 
 	result1 := Fill([]foo{{"a"}, {"a"}}, foo{"b"})
 	result2 := Fill([]foo{}, foo{"a"})
+	result3 := Fill([]foo(nil), foo{"a"})
 
-	is.Equal(result1, []foo{{"b"}, {"b"}})
-	is.Equal(result2, []foo{})
+	is.Equal([]foo{{"b"}, {"b"}}, result1)
+	is.Equal([]foo{}, result2)
+	is.Nil(result3)
 }
 
 func TestRepeat(t *testing.T) {
@@ -388,7 +450,7 @@ func TestAssociate(t *testing.T) {
 
 func TestSliceToMap(t *testing.T) {
 	t.Parallel()
-	
+
 	type foo struct {
 		baz string
 		bar int
@@ -431,6 +493,8 @@ func TestDrop(t *testing.T) {
 	is.Equal([]int{4}, Drop([]int{0, 1, 2, 3, 4}, 4))
 	is.Equal([]int{}, Drop([]int{0, 1, 2, 3, 4}, 5))
 	is.Equal([]int{}, Drop([]int{0, 1, 2, 3, 4}, 6))
+	is.Equal([]int{}, Drop([]int{}, 1))
+	is.Nil(Drop([]int(nil), 1))
 }
 
 func TestDropRight(t *testing.T) {
@@ -443,6 +507,8 @@ func TestDropRight(t *testing.T) {
 	is.Equal([]int{0}, DropRight([]int{0, 1, 2, 3, 4}, 4))
 	is.Equal([]int{}, DropRight([]int{0, 1, 2, 3, 4}, 5))
 	is.Equal([]int{}, DropRight([]int{0, 1, 2, 3, 4}, 6))
+	is.Equal([]int{}, DropRight([]int{}, 1))
+	is.Nil(DropRight([]int(nil), 1))
 }
 
 func TestDropWhile(t *testing.T) {
@@ -459,6 +525,14 @@ func TestDropWhile(t *testing.T) {
 
 	is.Equal([]int{0, 1, 2, 3, 4, 5, 6}, DropWhile([]int{0, 1, 2, 3, 4, 5, 6}, func(t int) bool {
 		return t == 10
+	}))
+
+	is.Equal([]int{}, DropWhile([]int{}, func(t int) bool {
+		return false
+	}))
+
+	is.Nil(DropWhile([]int(nil), func(t int) bool {
+		return false
 	}))
 }
 
@@ -481,6 +555,14 @@ func TestDropRightWhile(t *testing.T) {
 	is.Equal([]int{}, DropRightWhile([]int{0, 1, 2, 3, 4, 5, 6}, func(t int) bool {
 		return t != 10
 	}))
+
+	is.Equal([]int{}, DropRightWhile([]int{}, func(t int) bool {
+		return false
+	}))
+
+	is.Nil(DropRightWhile([]int(nil), func(t int) bool {
+		return false
+	}))
 }
 
 func TestReject(t *testing.T) {
@@ -491,13 +573,21 @@ func TestReject(t *testing.T) {
 		return x%2 == 0
 	})
 
-	is.Equal(r1, []int{1, 3})
+	is.Equal([]int{1, 3}, r1)
 
 	r2 := Reject([]string{"Smith", "foo", "Domin", "bar", "Olivia"}, func(x string, _ int) bool {
 		return len(x) > 3
 	})
 
-	is.Equal(r2, []string{"foo", "bar"})
+	is.Equal([]string{"foo", "bar"}, r2)
+
+	is.Equal([]int{}, Reject([]int{}, func(x int, _ int) bool {
+		return false
+	}))
+
+	is.Nil(Reject([]int(nil), func(x int, _ int) bool {
+		return false
+	}))
 }
 
 func TestCount(t *testing.T) {
@@ -587,6 +677,8 @@ func TestSubset(t *testing.T) {
 	out10 := Subset(in, -2, 4)
 	out11 := Subset(in, -4, 1)
 	out12 := Subset(in, -4, math.MaxUint)
+	out13 := Subset([]int{}, 0, 0)
+	out14 := Subset([]int(nil), 0, 0)
 
 	is.Equal([]int{}, out1)
 	is.Equal([]int{}, out2)
@@ -600,6 +692,8 @@ func TestSubset(t *testing.T) {
 	is.Equal([]int{3, 4}, out10)
 	is.Equal([]int{1}, out11)
 	is.Equal([]int{1, 2, 3, 4}, out12)
+	is.Equal([]int{}, out13)
+	is.Nil(out14)
 }
 
 func TestSlice(t *testing.T) {
@@ -626,7 +720,9 @@ func TestSlice(t *testing.T) {
 	out16 := Slice(in, -10, 1)
 	out17 := Slice(in, -1, 3)
 	out18 := Slice(in, -10, 7)
-	
+	out19 := Slice([]int{}, 0, 0)
+	out20 := Slice([]int(nil), 0, 0)
+
 	is.Equal([]int{}, out1)
 	is.Equal([]int{0}, out2)
 	is.Equal([]int{0, 1, 2, 3, 4}, out3)
@@ -645,6 +741,8 @@ func TestSlice(t *testing.T) {
 	is.Equal([]int{0}, out16)
 	is.Equal([]int{0, 1, 2}, out17)
 	is.Equal([]int{0, 1, 2, 3, 4}, out18)
+	is.Equal([]int{}, out19)
+	is.Nil(out20)
 }
 
 func TestReplace(t *testing.T) {
@@ -663,6 +761,8 @@ func TestReplace(t *testing.T) {
 	out8 := Replace(in, -1, 42, 0)
 	out9 := Replace(in, -1, 42, -1)
 	out10 := Replace(in, -1, 42, -1)
+	out11 := Replace([]int{}, -1, 42, -1)
+	out12 := Replace([]int(nil), -1, 42, -1)
 
 	is.Equal([]int{42, 1, 42, 1, 2, 3, 0}, out1)
 	is.Equal([]int{42, 1, 0, 1, 2, 3, 0}, out2)
@@ -674,6 +774,8 @@ func TestReplace(t *testing.T) {
 	is.Equal([]int{0, 1, 0, 1, 2, 3, 0}, out8)
 	is.Equal([]int{0, 1, 0, 1, 2, 3, 0}, out9)
 	is.Equal([]int{0, 1, 0, 1, 2, 3, 0}, out10)
+	is.Equal([]int{}, out11)
+	is.Nil(out12)
 }
 
 func TestReplaceAll(t *testing.T) {
@@ -684,26 +786,24 @@ func TestReplaceAll(t *testing.T) {
 
 	out1 := ReplaceAll(in, 0, 42)
 	out2 := ReplaceAll(in, -1, 42)
+	out3 := ReplaceAll([]int{}, -1, 42)
+	out4 := ReplaceAll([]int(nil), -1, 42)
 
 	is.Equal([]int{42, 1, 42, 1, 2, 3, 42}, out1)
 	is.Equal([]int{0, 1, 0, 1, 2, 3, 0}, out2)
+	is.Equal([]int{}, out3)
+	is.Nil(out4)
 }
 
 func TestCompact(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := Compact([]int{2, 0, 4, 0})
-
-	is.Equal(r1, []int{2, 4})
-
-	r2 := Compact([]string{"", "foo", "", "bar", ""})
-
-	is.Equal(r2, []string{"foo", "bar"})
-
-	r3 := Compact([]bool{true, false, true, false})
-
-	is.Equal(r3, []bool{true, true})
+	is.Equal([]int{2, 4}, Compact([]int{2, 0, 4, 0}))
+	is.Equal([]string{"foo", "bar"}, Compact([]string{"", "foo", "", "bar", ""}))
+	is.Equal([]bool{true, true}, Compact([]bool{true, false, true, false}))
+	is.Equal([]int{}, Compact([]int{}))
+	is.Nil(Compact([]int(nil)))
 
 	type foo struct {
 		bar int
@@ -712,23 +812,17 @@ func TestCompact(t *testing.T) {
 
 	// slice of structs
 	// If all fields of an element are zero values, Compact removes it.
-
-	r4 := Compact([]foo{
+	is.Equal([]foo{{bar: 1, baz: "a"}, {bar: 2, baz: ""}}, Compact([]foo{
 		{bar: 1, baz: "a"}, // all fields are non-zero values
 		{bar: 0, baz: ""},  // all fields are zero values
 		{bar: 2, baz: ""},  // bar is non-zero
-	})
-
-	is.Equal(r4, []foo{{bar: 1, baz: "a"}, {bar: 2, baz: ""}})
+	}))
 
 	// slice of pointers to structs
 	// If an element is nil, Compact removes it.
-
-	e1, e2, e3 := foo{bar: 1, baz: "a"}, foo{bar: 0, baz: ""}, foo{bar: 2, baz: ""}
 	// NOTE: e2 is a zero value of foo, but its pointer &e2 is not a zero value of *foo.
-	r5 := Compact([]*foo{&e1, &e2, nil, &e3})
-
-	is.Equal(r5, []*foo{&e1, &e2, &e3})
+	e1, e2, e3 := foo{bar: 1, baz: "a"}, foo{bar: 0, baz: ""}, foo{bar: 2, baz: ""}
+	is.Equal([]*foo{&e1, &e2, &e3}, Compact([]*foo{&e1, &e2, nil, &e3}))
 }
 
 func TestIsSorted(t *testing.T) {


### PR DESCRIPTION
Amend slice functions to return `nil` if the collection argument is `nil`.

This is a non-breaking change because all built-ins etc. treat nil slices the same as zero length slices.

I also fixed some of the tests as they had expected and actual in the wrong order.