### PR TITLE
Adding Mean and MeanBy

### DIFF
--- a/math.go
+++ b/math.go
@@ -92,3 +92,13 @@ func Mean[T constraints.Float | constraints.Integer](collection []T) T {
 	var sum T = Sum(collection)
 	return sum / length
 }
+
+// MeanBy calculates the mean of a collection of numbers using the given return value from the iteration function.
+func MeanBy[T any, R constraints.Float | constraints.Integer](collection []T, iteratee func(item T) R) R {
+	var length R = R(len(collection))
+	if length == 0 {
+		return 0
+	}
+	var sum R = SumBy(collection, iteratee)
+	return sum / length
+}

--- a/math.go
+++ b/math.go
@@ -82,3 +82,13 @@ func SumBy[T any, R constraints.Float | constraints.Integer | constraints.Comple
 	}
 	return sum
 }
+
+// Mean calculates the mean of a collection of numbers.
+func Mean[T constraints.Float | constraints.Integer](collection []T) T {
+	var length T = T(len(collection))
+	if length == 0 {
+		return 0
+	}
+	var sum T = Sum(collection)
+	return sum / length
+}

--- a/math_example_test.go
+++ b/math_example_test.go
@@ -66,3 +66,21 @@ func ExampleSumBy() {
 	fmt.Printf("%v", result)
 	// Output: 6
 }
+
+func ExampleMean() {
+	list := []int{1, 2, 3, 4, 5}
+
+	result := Mean(list)
+
+	fmt.Printf("%v", result)
+}
+
+func ExampleMeanBy() {
+	list := []string{"foo", "bar"}
+
+	result := MeanBy(list, func(item string) int {
+		return len(item)
+	})
+
+	fmt.Printf("%v", result)
+}

--- a/math_test.go
+++ b/math_test.go
@@ -112,3 +112,18 @@ func TestMean(t *testing.T) {
 	is.Equal(result3, uint32(3))
 	is.Equal(result4, uint32(0))
 }
+
+func TestMeanBy(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	result1 := MeanBy([]float32{2.3, 3.3, 4, 5.3}, func(n float32) float32 { return n })
+	result2 := MeanBy([]int32{2, 3, 4, 5}, func(n int32) int32 { return n })
+	result3 := MeanBy([]uint32{2, 3, 4, 5}, func(n uint32) uint32 { return n })
+	result4 := MeanBy([]uint32{}, func(n uint32) uint32 { return n })
+
+	is.Equal(result1, float32(3.7250001))
+	is.Equal(result2, int32(3))
+	is.Equal(result3, uint32(3))
+	is.Equal(result4, uint32(0))
+}

--- a/math_test.go
+++ b/math_test.go
@@ -97,3 +97,18 @@ func TestSumBy(t *testing.T) {
 	is.Equal(result4, uint32(0))
 	is.Equal(result5, complex128(6_6))
 }
+
+func TestMean(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	result1 := Mean([]float32{2.3, 3.3, 4, 5.3})
+	result2 := Mean([]int32{2, 3, 4, 5})
+	result3 := Mean([]uint32{2, 3, 4, 5})
+	result4 := Mean([]uint32{})
+
+	is.Equal(result1, float32(3.7250001))
+	is.Equal(result2, int32(3))
+	is.Equal(result3, uint32(3))
+	is.Equal(result4, uint32(0))
+}


### PR DESCRIPTION
**Title:** Add Mean and MeanBy functions for ints and floats

**Issue:** https://github.com/samber/lo/issues/412

**Description:**

This PR adds two new functions to the math library:

- **Mean:** Calculates the mean of a collection of numbers.
- **MeanBy:** Calculates the mean of a collection of numbers using a provided iteratee function.

These functions are implemented using generics to support both integers and floats. They do not cater to complex types, as the concept of a mean for complex numbers can be misleading and requires specialized handling.

Thorough unit tests have been included to ensure the correctness of the functions.

**Code Changes:**

- Added two functions in _math.go_
- Added tests for the two functions in math_test.go


**Testing:**

All tests pass successfully.

**Reviewers, please provide any feedback or questions you may have.**
