### PR TITLE
add ToQuery and FromQuery

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -1,0 +1,39 @@
+package lo
+
+import (
+	"fmt"
+	"strings"
+)
+
+// form query convert string to query string
+func ToQuery[K comparable, V any](in map[K]V) string {
+	res := ""
+
+	firstIteration := true
+	for k, v := range in {
+		if firstIteration {
+			res += fmt.Sprintf("%v=%v", k, v)
+			firstIteration = false
+		} else {
+			res += fmt.Sprintf("&%v=%v", k, v)
+		}
+	}
+
+	return res
+}
+
+// form query convert query string to string
+func FromQuery(s string) map[string]string {
+	result := make(map[string]string)
+
+	pairs := strings.Split(s, "&")
+
+	for _, pair := range pairs {
+		parts := strings.Split(pair, "=")
+		if len(parts) == 2 {
+			result[parts[0]] = parts[1]
+		}
+	}
+
+	return result
+}

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -1,0 +1,33 @@
+package lo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToQuery(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	result1 := ToQuery(map[string]string{"foo": "bar", "bar": "baz", "k": "v"})
+	result2 := ToQuery(map[string]string{"foo": "bar", "bar": "baz"})
+	result3 := ToQuery(map[string]string{"key": "value"})
+
+	is.Equal(result1, "foo=bar&bar=baz&k=v")
+	is.Equal(result2, "foo=bar&bar=baz")
+	is.Equal(result3, "key=value")
+}
+
+func TestFromQuery(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	result1 := FromQuery("foo=bar&bar=baz&k=v")
+	result2 := FromQuery("foo=bar&bar=baz")
+	result3 := FromQuery("key=value")
+
+	is.Equal(result1, map[string]string{"foo": "bar", "bar": "baz", "k": "v"})
+	is.Equal(result2, map[string]string{"foo": "bar", "bar": "baz"})
+	is.Equal(result3, map[string]string{"key": "value"})
+}


### PR DESCRIPTION
The ToQuery() function is a powerful utility in Go that facilitates the effortless conversion of a map into a well-formed query string. This functionality becomes particularly valuable when you need to create query strings for web requests or other scenarios where structured key-value pairs are essential.

The ToQuery() function streamlines the process of transforming a map into a query string by intelligently handling the concatenation of key-value pairs. Let's delve into how this function simplifies the generation of query strings with a concrete example.

Consider the following scenario where you have a map representing user information:

`map[email:joan@gmail.com token:jkbcqp1wu2b user:joan]`

The desired output is a well-formatted query string:

`user=joan&email=joan@gmail.com&token=jkbcqp1wu2b`
 
Complementing the ToQuery() function, the FromQuery() function seamlessly reverses the process. It transforms a well-formed query string back into a map, providing a versatile bidirectional solution for scenarios requiring both query string creation and parsing.

`user=joan&email=joan@gmail.com&token=jkbcqp1wu2b`

ere, the FromQuery() function adeptly parses the query string, reconstructing the original map:

`map[email:joan@gmail.com token:jkbcqp1wu2b user:joan]`