### PR TITLE
style: no extra any type parameter

### DIFF
--- a/concurrency.go
+++ b/concurrency.go
@@ -50,7 +50,7 @@ func Async1[A any](f func() A) <-chan A {
 }
 
 // Async2 has the same behavior as Async, but returns the 2 results as a tuple inside the channel.
-func Async2[A any, B any](f func() (A, B)) <-chan Tuple2[A, B] {
+func Async2[A, B any](f func() (A, B)) <-chan Tuple2[A, B] {
 	ch := make(chan Tuple2[A, B], 1)
 	go func() {
 		ch <- T2(f())
@@ -59,7 +59,7 @@ func Async2[A any, B any](f func() (A, B)) <-chan Tuple2[A, B] {
 }
 
 // Async3 has the same behavior as Async, but returns the 3 results as a tuple inside the channel.
-func Async3[A any, B any, C any](f func() (A, B, C)) <-chan Tuple3[A, B, C] {
+func Async3[A, B, C any](f func() (A, B, C)) <-chan Tuple3[A, B, C] {
 	ch := make(chan Tuple3[A, B, C], 1)
 	go func() {
 		ch <- T3(f())
@@ -68,7 +68,7 @@ func Async3[A any, B any, C any](f func() (A, B, C)) <-chan Tuple3[A, B, C] {
 }
 
 // Async4 has the same behavior as Async, but returns the 4 results as a tuple inside the channel.
-func Async4[A any, B any, C any, D any](f func() (A, B, C, D)) <-chan Tuple4[A, B, C, D] {
+func Async4[A, B, C, D any](f func() (A, B, C, D)) <-chan Tuple4[A, B, C, D] {
 	ch := make(chan Tuple4[A, B, C, D], 1)
 	go func() {
 		ch <- T4(f())
@@ -77,7 +77,7 @@ func Async4[A any, B any, C any, D any](f func() (A, B, C, D)) <-chan Tuple4[A, 
 }
 
 // Async5 has the same behavior as Async, but returns the 5 results as a tuple inside the channel.
-func Async5[A any, B any, C any, D any, E any](f func() (A, B, C, D, E)) <-chan Tuple5[A, B, C, D, E] {
+func Async5[A, B, C, D, E any](f func() (A, B, C, D, E)) <-chan Tuple5[A, B, C, D, E] {
 	ch := make(chan Tuple5[A, B, C, D, E], 1)
 	go func() {
 		ch <- T5(f())
@@ -86,7 +86,7 @@ func Async5[A any, B any, C any, D any, E any](f func() (A, B, C, D, E)) <-chan 
 }
 
 // Async6 has the same behavior as Async, but returns the 6 results as a tuple inside the channel.
-func Async6[A any, B any, C any, D any, E any, F any](f func() (A, B, C, D, E, F)) <-chan Tuple6[A, B, C, D, E, F] {
+func Async6[A, B, C, D, E, F any](f func() (A, B, C, D, E, F)) <-chan Tuple6[A, B, C, D, E, F] {
 	ch := make(chan Tuple6[A, B, C, D, E, F], 1)
 	go func() {
 		ch <- T6(f())

--- a/errors.go
+++ b/errors.go
@@ -80,35 +80,35 @@ func Must1[T any](val T, err any, messageArgs ...interface{}) T {
 
 // Must2 has the same behavior as Must, but callback returns 2 variables.
 // Play: https://go.dev/play/p/TMoWrRp3DyC
-func Must2[T1 any, T2 any](val1 T1, val2 T2, err any, messageArgs ...interface{}) (T1, T2) {
+func Must2[T1, T2 any](val1 T1, val2 T2, err any, messageArgs ...interface{}) (T1, T2) {
 	must(err, messageArgs...)
 	return val1, val2
 }
 
 // Must3 has the same behavior as Must, but callback returns 3 variables.
 // Play: https://go.dev/play/p/TMoWrRp3DyC
-func Must3[T1 any, T2 any, T3 any](val1 T1, val2 T2, val3 T3, err any, messageArgs ...interface{}) (T1, T2, T3) {
+func Must3[T1, T2, T3 any](val1 T1, val2 T2, val3 T3, err any, messageArgs ...interface{}) (T1, T2, T3) {
 	must(err, messageArgs...)
 	return val1, val2, val3
 }
 
 // Must4 has the same behavior as Must, but callback returns 4 variables.
 // Play: https://go.dev/play/p/TMoWrRp3DyC
-func Must4[T1 any, T2 any, T3 any, T4 any](val1 T1, val2 T2, val3 T3, val4 T4, err any, messageArgs ...interface{}) (T1, T2, T3, T4) {
+func Must4[T1, T2, T3, T4 any](val1 T1, val2 T2, val3 T3, val4 T4, err any, messageArgs ...interface{}) (T1, T2, T3, T4) {
 	must(err, messageArgs...)
 	return val1, val2, val3, val4
 }
 
 // Must5 has the same behavior as Must, but callback returns 5 variables.
 // Play: https://go.dev/play/p/TMoWrRp3DyC
-func Must5[T1 any, T2 any, T3 any, T4 any, T5 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 T5, err any, messageArgs ...interface{}) (T1, T2, T3, T4, T5) {
+func Must5[T1, T2, T3, T4, T5 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 T5, err any, messageArgs ...interface{}) (T1, T2, T3, T4, T5) {
 	must(err, messageArgs...)
 	return val1, val2, val3, val4, val5
 }
 
 // Must6 has the same behavior as Must, but callback returns 6 variables.
 // Play: https://go.dev/play/p/TMoWrRp3DyC
-func Must6[T1 any, T2 any, T3 any, T4 any, T5 any, T6 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 T5, val6 T6, err any, messageArgs ...interface{}) (T1, T2, T3, T4, T5, T6) {
+func Must6[T1, T2, T3, T4, T5, T6 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 T5, val6 T6, err any, messageArgs ...interface{}) (T1, T2, T3, T4, T5, T6) {
 	must(err, messageArgs...)
 	return val1, val2, val3, val4, val5, val6
 }
@@ -215,7 +215,7 @@ func TryOr1[A any](callback func() (A, error), fallbackA A) (A, bool) {
 
 // TryOr2 has the same behavior as Must, but returns a default value in case of error.
 // Play: https://go.dev/play/p/B4F7Wg2Zh9X
-func TryOr2[A any, B any](callback func() (A, B, error), fallbackA A, fallbackB B) (A, B, bool) {
+func TryOr2[A, B any](callback func() (A, B, error), fallbackA A, fallbackB B) (A, B, bool) {
 	ok := false
 
 	Try0(func() {
@@ -232,7 +232,7 @@ func TryOr2[A any, B any](callback func() (A, B, error), fallbackA A, fallbackB 
 
 // TryOr3 has the same behavior as Must, but returns a default value in case of error.
 // Play: https://go.dev/play/p/B4F7Wg2Zh9X
-func TryOr3[A any, B any, C any](callback func() (A, B, C, error), fallbackA A, fallbackB B, fallbackC C) (A, B, C, bool) {
+func TryOr3[A, B, C any](callback func() (A, B, C, error), fallbackA A, fallbackB B, fallbackC C) (A, B, C, bool) {
 	ok := false
 
 	Try0(func() {
@@ -250,7 +250,7 @@ func TryOr3[A any, B any, C any](callback func() (A, B, C, error), fallbackA A, 
 
 // TryOr4 has the same behavior as Must, but returns a default value in case of error.
 // Play: https://go.dev/play/p/B4F7Wg2Zh9X
-func TryOr4[A any, B any, C any, D any](callback func() (A, B, C, D, error), fallbackA A, fallbackB B, fallbackC C, fallbackD D) (A, B, C, D, bool) {
+func TryOr4[A, B, C, D any](callback func() (A, B, C, D, error), fallbackA A, fallbackB B, fallbackC C, fallbackD D) (A, B, C, D, bool) {
 	ok := false
 
 	Try0(func() {
@@ -269,7 +269,7 @@ func TryOr4[A any, B any, C any, D any](callback func() (A, B, C, D, error), fal
 
 // TryOr5 has the same behavior as Must, but returns a default value in case of error.
 // Play: https://go.dev/play/p/B4F7Wg2Zh9X
-func TryOr5[A any, B any, C any, D any, E any](callback func() (A, B, C, D, E, error), fallbackA A, fallbackB B, fallbackC C, fallbackD D, fallbackE E) (A, B, C, D, E, bool) {
+func TryOr5[A, B, C, D, E any](callback func() (A, B, C, D, E, error), fallbackA A, fallbackB B, fallbackC C, fallbackD D, fallbackE E) (A, B, C, D, E, bool) {
 	ok := false
 
 	Try0(func() {
@@ -289,7 +289,7 @@ func TryOr5[A any, B any, C any, D any, E any](callback func() (A, B, C, D, E, e
 
 // TryOr6 has the same behavior as Must, but returns a default value in case of error.
 // Play: https://go.dev/play/p/B4F7Wg2Zh9X
-func TryOr6[A any, B any, C any, D any, E any, F any](callback func() (A, B, C, D, E, F, error), fallbackA A, fallbackB B, fallbackC C, fallbackD D, fallbackE E, fallbackF F) (A, B, C, D, E, F, bool) {
+func TryOr6[A, B, C, D, E, F any](callback func() (A, B, C, D, E, F, error), fallbackA A, fallbackB B, fallbackC C, fallbackD D, fallbackE E, fallbackF F) (A, B, C, D, E, F, bool) {
 	ok := false
 
 	Try0(func() {

--- a/tuples.go
+++ b/tuples.go
@@ -2,97 +2,97 @@ package lo
 
 // T2 creates a tuple from a list of values.
 // Play: https://go.dev/play/p/IllL3ZO4BQm
-func T2[A any, B any](a A, b B) Tuple2[A, B] {
+func T2[A, B any](a A, b B) Tuple2[A, B] {
 	return Tuple2[A, B]{A: a, B: b}
 }
 
 // T3 creates a tuple from a list of values.
 // Play: https://go.dev/play/p/IllL3ZO4BQm
-func T3[A any, B any, C any](a A, b B, c C) Tuple3[A, B, C] {
+func T3[A, B, C any](a A, b B, c C) Tuple3[A, B, C] {
 	return Tuple3[A, B, C]{A: a, B: b, C: c}
 }
 
 // T4 creates a tuple from a list of values.
 // Play: https://go.dev/play/p/IllL3ZO4BQm
-func T4[A any, B any, C any, D any](a A, b B, c C, d D) Tuple4[A, B, C, D] {
+func T4[A, B, C, D any](a A, b B, c C, d D) Tuple4[A, B, C, D] {
 	return Tuple4[A, B, C, D]{A: a, B: b, C: c, D: d}
 }
 
 // T5 creates a tuple from a list of values.
 // Play: https://go.dev/play/p/IllL3ZO4BQm
-func T5[A any, B any, C any, D any, E any](a A, b B, c C, d D, e E) Tuple5[A, B, C, D, E] {
+func T5[A, B, C, D, E any](a A, b B, c C, d D, e E) Tuple5[A, B, C, D, E] {
 	return Tuple5[A, B, C, D, E]{A: a, B: b, C: c, D: d, E: e}
 }
 
 // T6 creates a tuple from a list of values.
 // Play: https://go.dev/play/p/IllL3ZO4BQm
-func T6[A any, B any, C any, D any, E any, F any](a A, b B, c C, d D, e E, f F) Tuple6[A, B, C, D, E, F] {
+func T6[A, B, C, D, E, F any](a A, b B, c C, d D, e E, f F) Tuple6[A, B, C, D, E, F] {
 	return Tuple6[A, B, C, D, E, F]{A: a, B: b, C: c, D: d, E: e, F: f}
 }
 
 // T7 creates a tuple from a list of values.
 // Play: https://go.dev/play/p/IllL3ZO4BQm
-func T7[A any, B any, C any, D any, E any, F any, G any](a A, b B, c C, d D, e E, f F, g G) Tuple7[A, B, C, D, E, F, G] {
+func T7[A, B, C, D, E, F, G any](a A, b B, c C, d D, e E, f F, g G) Tuple7[A, B, C, D, E, F, G] {
 	return Tuple7[A, B, C, D, E, F, G]{A: a, B: b, C: c, D: d, E: e, F: f, G: g}
 }
 
 // T8 creates a tuple from a list of values.
 // Play: https://go.dev/play/p/IllL3ZO4BQm
-func T8[A any, B any, C any, D any, E any, F any, G any, H any](a A, b B, c C, d D, e E, f F, g G, h H) Tuple8[A, B, C, D, E, F, G, H] {
+func T8[A, B, C, D, E, F, G, H any](a A, b B, c C, d D, e E, f F, g G, h H) Tuple8[A, B, C, D, E, F, G, H] {
 	return Tuple8[A, B, C, D, E, F, G, H]{A: a, B: b, C: c, D: d, E: e, F: f, G: g, H: h}
 }
 
 // T9 creates a tuple from a list of values.
 // Play: https://go.dev/play/p/IllL3ZO4BQm
-func T9[A any, B any, C any, D any, E any, F any, G any, H any, I any](a A, b B, c C, d D, e E, f F, g G, h H, i I) Tuple9[A, B, C, D, E, F, G, H, I] {
+func T9[A, B, C, D, E, F, G, H, I any](a A, b B, c C, d D, e E, f F, g G, h H, i I) Tuple9[A, B, C, D, E, F, G, H, I] {
 	return Tuple9[A, B, C, D, E, F, G, H, I]{A: a, B: b, C: c, D: d, E: e, F: f, G: g, H: h, I: i}
 }
 
 // Unpack2 returns values contained in tuple.
 // Play: https://go.dev/play/p/xVP_k0kJ96W
-func Unpack2[A any, B any](tuple Tuple2[A, B]) (A, B) {
+func Unpack2[A, B any](tuple Tuple2[A, B]) (A, B) {
 	return tuple.A, tuple.B
 }
 
 // Unpack3 returns values contained in tuple.
 // Play: https://go.dev/play/p/xVP_k0kJ96W
-func Unpack3[A any, B any, C any](tuple Tuple3[A, B, C]) (A, B, C) {
+func Unpack3[A, B, C any](tuple Tuple3[A, B, C]) (A, B, C) {
 	return tuple.A, tuple.B, tuple.C
 }
 
 // Unpack4 returns values contained in tuple.
 // Play: https://go.dev/play/p/xVP_k0kJ96W
-func Unpack4[A any, B any, C any, D any](tuple Tuple4[A, B, C, D]) (A, B, C, D) {
+func Unpack4[A, B, C, D any](tuple Tuple4[A, B, C, D]) (A, B, C, D) {
 	return tuple.A, tuple.B, tuple.C, tuple.D
 }
 
 // Unpack5 returns values contained in tuple.
 // Play: https://go.dev/play/p/xVP_k0kJ96W
-func Unpack5[A any, B any, C any, D any, E any](tuple Tuple5[A, B, C, D, E]) (A, B, C, D, E) {
+func Unpack5[A, B, C, D, E any](tuple Tuple5[A, B, C, D, E]) (A, B, C, D, E) {
 	return tuple.A, tuple.B, tuple.C, tuple.D, tuple.E
 }
 
 // Unpack6 returns values contained in tuple.
 // Play: https://go.dev/play/p/xVP_k0kJ96W
-func Unpack6[A any, B any, C any, D any, E any, F any](tuple Tuple6[A, B, C, D, E, F]) (A, B, C, D, E, F) {
+func Unpack6[A, B, C, D, E, F any](tuple Tuple6[A, B, C, D, E, F]) (A, B, C, D, E, F) {
 	return tuple.A, tuple.B, tuple.C, tuple.D, tuple.E, tuple.F
 }
 
 // Unpack7 returns values contained in tuple.
 // Play: https://go.dev/play/p/xVP_k0kJ96W
-func Unpack7[A any, B any, C any, D any, E any, F any, G any](tuple Tuple7[A, B, C, D, E, F, G]) (A, B, C, D, E, F, G) {
+func Unpack7[A, B, C, D, E, F, G any](tuple Tuple7[A, B, C, D, E, F, G]) (A, B, C, D, E, F, G) {
 	return tuple.A, tuple.B, tuple.C, tuple.D, tuple.E, tuple.F, tuple.G
 }
 
 // Unpack8 returns values contained in tuple.
 // Play: https://go.dev/play/p/xVP_k0kJ96W
-func Unpack8[A any, B any, C any, D any, E any, F any, G any, H any](tuple Tuple8[A, B, C, D, E, F, G, H]) (A, B, C, D, E, F, G, H) {
+func Unpack8[A, B, C, D, E, F, G, H any](tuple Tuple8[A, B, C, D, E, F, G, H]) (A, B, C, D, E, F, G, H) {
 	return tuple.A, tuple.B, tuple.C, tuple.D, tuple.E, tuple.F, tuple.G, tuple.H
 }
 
 // Unpack9 returns values contained in tuple.
 // Play: https://go.dev/play/p/xVP_k0kJ96W
-func Unpack9[A any, B any, C any, D any, E any, F any, G any, H any, I any](tuple Tuple9[A, B, C, D, E, F, G, H, I]) (A, B, C, D, E, F, G, H, I) {
+func Unpack9[A, B, C, D, E, F, G, H, I any](tuple Tuple9[A, B, C, D, E, F, G, H, I]) (A, B, C, D, E, F, G, H, I) {
 	return tuple.A, tuple.B, tuple.C, tuple.D, tuple.E, tuple.F, tuple.G, tuple.H, tuple.I
 }
 
@@ -100,7 +100,7 @@ func Unpack9[A any, B any, C any, D any, E any, F any, G any, H any, I any](tupl
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
 // When collections have different size, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
-func Zip2[A any, B any](a []A, b []B) []Tuple2[A, B] {
+func Zip2[A, B any](a []A, b []B) []Tuple2[A, B] {
 	size := Max([]int{len(a), len(b)})
 
 	result := make([]Tuple2[A, B], 0, size)
@@ -122,7 +122,7 @@ func Zip2[A any, B any](a []A, b []B) []Tuple2[A, B] {
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
 // When collections have different size, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
-func Zip3[A any, B any, C any](a []A, b []B, c []C) []Tuple3[A, B, C] {
+func Zip3[A, B, C any](a []A, b []B, c []C) []Tuple3[A, B, C] {
 	size := Max([]int{len(a), len(b), len(c)})
 
 	result := make([]Tuple3[A, B, C], 0, size)
@@ -146,7 +146,7 @@ func Zip3[A any, B any, C any](a []A, b []B, c []C) []Tuple3[A, B, C] {
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
 // When collections have different size, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
-func Zip4[A any, B any, C any, D any](a []A, b []B, c []C, d []D) []Tuple4[A, B, C, D] {
+func Zip4[A, B, C, D any](a []A, b []B, c []C, d []D) []Tuple4[A, B, C, D] {
 	size := Max([]int{len(a), len(b), len(c), len(d)})
 
 	result := make([]Tuple4[A, B, C, D], 0, size)
@@ -172,7 +172,7 @@ func Zip4[A any, B any, C any, D any](a []A, b []B, c []C, d []D) []Tuple4[A, B,
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
 // When collections have different size, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
-func Zip5[A any, B any, C any, D any, E any](a []A, b []B, c []C, d []D, e []E) []Tuple5[A, B, C, D, E] {
+func Zip5[A, B, C, D, E any](a []A, b []B, c []C, d []D, e []E) []Tuple5[A, B, C, D, E] {
 	size := Max([]int{len(a), len(b), len(c), len(d), len(e)})
 
 	result := make([]Tuple5[A, B, C, D, E], 0, size)
@@ -200,7 +200,7 @@ func Zip5[A any, B any, C any, D any, E any](a []A, b []B, c []C, d []D, e []E) 
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
 // When collections have different size, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
-func Zip6[A any, B any, C any, D any, E any, F any](a []A, b []B, c []C, d []D, e []E, f []F) []Tuple6[A, B, C, D, E, F] {
+func Zip6[A, B, C, D, E, F any](a []A, b []B, c []C, d []D, e []E, f []F) []Tuple6[A, B, C, D, E, F] {
 	size := Max([]int{len(a), len(b), len(c), len(d), len(e), len(f)})
 
 	result := make([]Tuple6[A, B, C, D, E, F], 0, size)
@@ -230,7 +230,7 @@ func Zip6[A any, B any, C any, D any, E any, F any](a []A, b []B, c []C, d []D, 
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
 // When collections have different size, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
-func Zip7[A any, B any, C any, D any, E any, F any, G any](a []A, b []B, c []C, d []D, e []E, f []F, g []G) []Tuple7[A, B, C, D, E, F, G] {
+func Zip7[A, B, C, D, E, F, G any](a []A, b []B, c []C, d []D, e []E, f []F, g []G) []Tuple7[A, B, C, D, E, F, G] {
 	size := Max([]int{len(a), len(b), len(c), len(d), len(e), len(f), len(g)})
 
 	result := make([]Tuple7[A, B, C, D, E, F, G], 0, size)
@@ -262,7 +262,7 @@ func Zip7[A any, B any, C any, D any, E any, F any, G any](a []A, b []B, c []C, 
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
 // When collections have different size, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
-func Zip8[A any, B any, C any, D any, E any, F any, G any, H any](a []A, b []B, c []C, d []D, e []E, f []F, g []G, h []H) []Tuple8[A, B, C, D, E, F, G, H] {
+func Zip8[A, B, C, D, E, F, G, H any](a []A, b []B, c []C, d []D, e []E, f []F, g []G, h []H) []Tuple8[A, B, C, D, E, F, G, H] {
 	size := Max([]int{len(a), len(b), len(c), len(d), len(e), len(f), len(g), len(h)})
 
 	result := make([]Tuple8[A, B, C, D, E, F, G, H], 0, size)
@@ -296,7 +296,7 @@ func Zip8[A any, B any, C any, D any, E any, F any, G any, H any](a []A, b []B, 
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
 // When collections have different size, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
-func Zip9[A any, B any, C any, D any, E any, F any, G any, H any, I any](a []A, b []B, c []C, d []D, e []E, f []F, g []G, h []H, i []I) []Tuple9[A, B, C, D, E, F, G, H, I] {
+func Zip9[A, B, C, D, E, F, G, H, I any](a []A, b []B, c []C, d []D, e []E, f []F, g []G, h []H, i []I) []Tuple9[A, B, C, D, E, F, G, H, I] {
 	size := Max([]int{len(a), len(b), len(c), len(d), len(e), len(f), len(g), len(h), len(i)})
 
 	result := make([]Tuple9[A, B, C, D, E, F, G, H, I], 0, size)
@@ -331,7 +331,7 @@ func Zip9[A any, B any, C any, D any, E any, F any, G any, H any, I any](a []A, 
 // Unzip2 accepts an array of grouped elements and creates an array regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/ciHugugvaAW
-func Unzip2[A any, B any](tuples []Tuple2[A, B]) ([]A, []B) {
+func Unzip2[A, B any](tuples []Tuple2[A, B]) ([]A, []B) {
 	size := len(tuples)
 	r1 := make([]A, 0, size)
 	r2 := make([]B, 0, size)
@@ -347,7 +347,7 @@ func Unzip2[A any, B any](tuples []Tuple2[A, B]) ([]A, []B) {
 // Unzip3 accepts an array of grouped elements and creates an array regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/ciHugugvaAW
-func Unzip3[A any, B any, C any](tuples []Tuple3[A, B, C]) ([]A, []B, []C) {
+func Unzip3[A, B, C any](tuples []Tuple3[A, B, C]) ([]A, []B, []C) {
 	size := len(tuples)
 	r1 := make([]A, 0, size)
 	r2 := make([]B, 0, size)
@@ -365,7 +365,7 @@ func Unzip3[A any, B any, C any](tuples []Tuple3[A, B, C]) ([]A, []B, []C) {
 // Unzip4 accepts an array of grouped elements and creates an array regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/ciHugugvaAW
-func Unzip4[A any, B any, C any, D any](tuples []Tuple4[A, B, C, D]) ([]A, []B, []C, []D) {
+func Unzip4[A, B, C, D any](tuples []Tuple4[A, B, C, D]) ([]A, []B, []C, []D) {
 	size := len(tuples)
 	r1 := make([]A, 0, size)
 	r2 := make([]B, 0, size)
@@ -385,7 +385,7 @@ func Unzip4[A any, B any, C any, D any](tuples []Tuple4[A, B, C, D]) ([]A, []B, 
 // Unzip5 accepts an array of grouped elements and creates an array regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/ciHugugvaAW
-func Unzip5[A any, B any, C any, D any, E any](tuples []Tuple5[A, B, C, D, E]) ([]A, []B, []C, []D, []E) {
+func Unzip5[A, B, C, D, E any](tuples []Tuple5[A, B, C, D, E]) ([]A, []B, []C, []D, []E) {
 	size := len(tuples)
 	r1 := make([]A, 0, size)
 	r2 := make([]B, 0, size)
@@ -407,7 +407,7 @@ func Unzip5[A any, B any, C any, D any, E any](tuples []Tuple5[A, B, C, D, E]) (
 // Unzip6 accepts an array of grouped elements and creates an array regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/ciHugugvaAW
-func Unzip6[A any, B any, C any, D any, E any, F any](tuples []Tuple6[A, B, C, D, E, F]) ([]A, []B, []C, []D, []E, []F) {
+func Unzip6[A, B, C, D, E, F any](tuples []Tuple6[A, B, C, D, E, F]) ([]A, []B, []C, []D, []E, []F) {
 	size := len(tuples)
 	r1 := make([]A, 0, size)
 	r2 := make([]B, 0, size)
@@ -431,7 +431,7 @@ func Unzip6[A any, B any, C any, D any, E any, F any](tuples []Tuple6[A, B, C, D
 // Unzip7 accepts an array of grouped elements and creates an array regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/ciHugugvaAW
-func Unzip7[A any, B any, C any, D any, E any, F any, G any](tuples []Tuple7[A, B, C, D, E, F, G]) ([]A, []B, []C, []D, []E, []F, []G) {
+func Unzip7[A, B, C, D, E, F, G any](tuples []Tuple7[A, B, C, D, E, F, G]) ([]A, []B, []C, []D, []E, []F, []G) {
 	size := len(tuples)
 	r1 := make([]A, 0, size)
 	r2 := make([]B, 0, size)
@@ -457,7 +457,7 @@ func Unzip7[A any, B any, C any, D any, E any, F any, G any](tuples []Tuple7[A, 
 // Unzip8 accepts an array of grouped elements and creates an array regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/ciHugugvaAW
-func Unzip8[A any, B any, C any, D any, E any, F any, G any, H any](tuples []Tuple8[A, B, C, D, E, F, G, H]) ([]A, []B, []C, []D, []E, []F, []G, []H) {
+func Unzip8[A, B, C, D, E, F, G, H any](tuples []Tuple8[A, B, C, D, E, F, G, H]) ([]A, []B, []C, []D, []E, []F, []G, []H) {
 	size := len(tuples)
 	r1 := make([]A, 0, size)
 	r2 := make([]B, 0, size)
@@ -485,7 +485,7 @@ func Unzip8[A any, B any, C any, D any, E any, F any, G any, H any](tuples []Tup
 // Unzip9 accepts an array of grouped elements and creates an array regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/ciHugugvaAW
-func Unzip9[A any, B any, C any, D any, E any, F any, G any, H any, I any](tuples []Tuple9[A, B, C, D, E, F, G, H, I]) ([]A, []B, []C, []D, []E, []F, []G, []H, []I) {
+func Unzip9[A, B, C, D, E, F, G, H, I any](tuples []Tuple9[A, B, C, D, E, F, G, H, I]) ([]A, []B, []C, []D, []E, []F, []G, []H, []I) {
 	size := len(tuples)
 	r1 := make([]A, 0, size)
 	r2 := make([]B, 0, size)

--- a/types.go
+++ b/types.go
@@ -7,7 +7,7 @@ type Entry[K comparable, V any] struct {
 }
 
 // Tuple2 is a group of 2 elements (pair).
-type Tuple2[A any, B any] struct {
+type Tuple2[A, B any] struct {
 	A A
 	B B
 }
@@ -18,7 +18,7 @@ func (t Tuple2[A, B]) Unpack() (A, B) {
 }
 
 // Tuple3 is a group of 3 elements.
-type Tuple3[A any, B any, C any] struct {
+type Tuple3[A, B, C any] struct {
 	A A
 	B B
 	C C
@@ -30,7 +30,7 @@ func (t Tuple3[A, B, C]) Unpack() (A, B, C) {
 }
 
 // Tuple4 is a group of 4 elements.
-type Tuple4[A any, B any, C any, D any] struct {
+type Tuple4[A, B, C, D any] struct {
 	A A
 	B B
 	C C
@@ -43,7 +43,7 @@ func (t Tuple4[A, B, C, D]) Unpack() (A, B, C, D) {
 }
 
 // Tuple5 is a group of 5 elements.
-type Tuple5[A any, B any, C any, D any, E any] struct {
+type Tuple5[A, B, C, D, E any] struct {
 	A A
 	B B
 	C C
@@ -57,7 +57,7 @@ func (t Tuple5[A, B, C, D, E]) Unpack() (A, B, C, D, E) {
 }
 
 // Tuple6 is a group of 6 elements.
-type Tuple6[A any, B any, C any, D any, E any, F any] struct {
+type Tuple6[A, B, C, D, E, F any] struct {
 	A A
 	B B
 	C C
@@ -72,7 +72,7 @@ func (t Tuple6[A, B, C, D, E, F]) Unpack() (A, B, C, D, E, F) {
 }
 
 // Tuple7 is a group of 7 elements.
-type Tuple7[A any, B any, C any, D any, E any, F any, G any] struct {
+type Tuple7[A, B, C, D, E, F, G any] struct {
 	A A
 	B B
 	C C
@@ -88,7 +88,7 @@ func (t Tuple7[A, B, C, D, E, F, G]) Unpack() (A, B, C, D, E, F, G) {
 }
 
 // Tuple8 is a group of 8 elements.
-type Tuple8[A any, B any, C any, D any, E any, F any, G any, H any] struct {
+type Tuple8[A, B, C, D, E, F, G, H any] struct {
 	A A
 	B B
 	C C
@@ -105,7 +105,7 @@ func (t Tuple8[A, B, C, D, E, F, G, H]) Unpack() (A, B, C, D, E, F, G, H) {
 }
 
 // Tuple9 is a group of 9 elements.
-type Tuple9[A any, B any, C any, D any, E any, F any, G any, H any, I any] struct {
+type Tuple9[A, B, C, D, E, F, G, H, I any] struct {
 	A A
 	B B
 	C C


### PR DESCRIPTION
Long lines are less long

One style with

https://github.com/samber/lo/blob/5777c5a3ee09f852d55a5bb5f585fcaeb5a0aedb/errors.go#L187

https://github.com/samber/lo/blob/5777c5a3ee09f852d55a5bb5f585fcaeb5a0aedb/func.go#L37

In the doc signature in the official vscode extension are also omitted
![image](https://github.com/samber/lo/assets/43112758/6c40fa16-f499-4473-a158-8054d1ed4773)


I would omit it here too, how does it do vscode, but it's not necessary
https://github.com/samber/lo/blob/5777c5a3ee09f852d55a5bb5f585fcaeb5a0aedb/slice.go#L25

![image](https://github.com/samber/lo/assets/43112758/6cd93dca-e9bd-4a89-abac-39393c544665)

