### PR TITLE
feat: add In[T]([]T, T)bool func in find package

### DIFF
--- a/find.go
+++ b/find.go
@@ -35,6 +35,16 @@ func LastIndexOf[T comparable](collection []T, element T) int {
 	return -1
 }
 
+// In return if element is in collection
+func In[T comparable](collection []T, element T) bool {
+	for _, item := range collection {
+		if item == element {
+			return true
+		}
+	}
+	return false
+}
+
 // Find search an element in a slice based on a predicate. It returns element and true if element was found.
 func Find[T any](collection []T, predicate func(item T) bool) (T, bool) {
 	for _, item := range collection {

--- a/find_test.go
+++ b/find_test.go
@@ -32,6 +32,16 @@ func TestLastIndexOf(t *testing.T) {
 	is.Equal(result2, -1)
 }
 
+func TestIn(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	result1 := In([]string{"a", "b", "c", "d"}, "a")
+	result2 := In([]string{"a", "b", "c"}, "d")
+	is.Equal(true, result1)
+	is.Equal(false, result2)
+}
+
 func TestFind(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)


### PR DESCRIPTION
add `func In[T comparable](collection []T, element T) bool ` in find package.

It is more brief and efficient than `func Find[T any](collection []T, predicate func(item T) bool) (T, bool) `