### PR TITLE
feat: range-over-func POC

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -1,0 +1,77 @@
+//go:build goexperiment.rangefunc
+
+package lo
+
+// Iterator TODO
+type Iterator[V any] func(func(int, V) bool)
+
+// ToIterator TODO
+func ToIterator[V any](collection ...V) Iterator[V] {
+	return func(yield func(int, V) bool) {
+		for i, item := range collection {
+			yield(i, item)
+		}
+	}
+}
+
+// Len TODO
+func (iter Iterator[V]) Len() int {
+	var n int
+	for _, _ = range iter {
+		n++
+	}
+	return n
+}
+
+// Slice TODO
+func (iter Iterator[V]) Slice() []V {
+	var result []V
+	for _, item := range iter {
+		result = append(result, item)
+	}
+	return result
+}
+
+// FilterI returns an iterator of all elements that match the specified predicate callback.
+// Play: https://go.dev/play/p/TODO
+func FilterI[V any](iter Iterator[V], predicate func(item V, index int) bool) Iterator[V] {
+	return func(yield func(int, V) bool) {
+		for i, item := range iter {
+			if predicate(item, i) {
+				if !yield(i, item) {
+					break
+				}
+			}
+		}
+	}
+}
+
+// MapI transforms an iterator into an iterator of another type.
+// Play: https://go.dev/play/p/TODO
+func MapI[T any, R any](iter Iterator[T], iteratee func(item T, index int) R) Iterator[R] {
+	return func(yield func(int, R) bool) {
+		for i, item := range iter {
+			if !yield(i, iteratee(item, i)) {
+				break
+			}
+		}
+	}
+}
+
+// FilterMapI returns an iterator obtained after both filtering and mapping using the given callback function.
+// The callback function should return two values:
+//   - the result of the mapping operation and
+//   - whether the result element should be included or not.
+//
+// Play: https://go.dev/play/p/TODO
+func FilterMapI[T any, R any](iter Iterator[T], callback func(item T, index int) (R, bool)) Iterator[R] {
+	return func(yield func(int, R) bool) {
+		for i, item := range iter {
+			if r, ok := callback(item, i); ok {
+				if !yield(i, r) {
+					break
+				}
+			}
+		}
+	}
+}

--- a/iterator_example_test.go
+++ b/iterator_example_test.go
@@ -1,0 +1,41 @@
+//go:build goexperiment.rangefunc
+
+package lo
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func ExampleFilterI() {
+	iter := ToIterator(1, 2, 3, 4)
+
+	result := FilterI(iter, func(nbr int, index int) bool {
+		return nbr%2 == 0
+	})
+
+	fmt.Printf("%v", result.Slice())
+	// Output: [2 4]
+}
+
+func ExampleMapI() {
+	iter := ToIterator(1, 2, 3, 4)
+
+	result := MapI(iter, func(nbr int, index int) string {
+		return strconv.FormatInt(int64(nbr)*2, 10)
+	})
+
+	fmt.Printf("%v", result.Slice())
+	// Output: [2 4 6 8]
+}
+
+func ExampleFilterMapI() {
+	iter := ToIterator(1, 2, 3, 4)
+
+	result := FilterMapI(iter, func(nbr int, index int) (string, bool) {
+		return strconv.FormatInt(int64(nbr)*2, 10), nbr%2 == 0
+	})
+
+	fmt.Printf("%v", result.Slice())
+	// Output: [4 8]
+}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1,0 +1,68 @@
+//go:build goexperiment.rangefunc
+
+package lo
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterI(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	r1 := FilterI(ToIterator(1, 2, 3, 4), func(x int, _ int) bool {
+		return x%2 == 0
+	})
+
+	is.Equal(r1.Slice(), []int{2, 4})
+
+	r2 := FilterI(ToIterator("", "foo", "", "bar", ""), func(x string, _ int) bool {
+		return len(x) > 0
+	})
+
+	is.Equal(r2.Slice(), []string{"foo", "bar"})
+}
+
+func TestMapI(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	result1 := MapI(ToIterator(1, 2, 3, 4), func(x int, _ int) string {
+		return "Hello"
+	})
+	result2 := MapI(ToIterator(1, 2, 3, 4), func(x int, _ int) string {
+		return strconv.FormatInt(int64(x), 10)
+	})
+
+	is.Equal(result1.Len(), 4)
+	is.Equal(result2.Len(), 4)
+	is.Equal(result1.Slice(), []string{"Hello", "Hello", "Hello", "Hello"})
+	is.Equal(result2.Slice(), []string{"1", "2", "3", "4"})
+}
+
+func TestFilterMapI(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	r1 := FilterMapI(ToIterator(1, 2, 3, 4), func(x int, _ int) (string, bool) {
+		if x%2 == 0 {
+			return strconv.FormatInt(int64(x), 10), true
+		}
+		return "", false
+	})
+	r2 := FilterMapI(ToIterator("cpu", "gpu", "mouse", "keyboard"), func(x string, _ int) (string, bool) {
+		if strings.HasSuffix(x, "pu") {
+			return "xpu", true
+		}
+		return "", false
+	})
+
+	is.Equal(r1.Len(), 2)
+	is.Equal(r2.Len(), 2)
+	is.Equal(r1.Slice(), []string{"2", "4"})
+	is.Equal(r2.Slice(), []string{"xpu", "xpu"})
+}


### PR DESCRIPTION
I was surprised to see no mention of the upcoming range-over-func experimental feature in the issues/PR list. I haven't measured anything but in theory this feature could dramatically reduce slice allocations when composing "queries" over large collections since no intermediate slices need to be created.

Is there any interest in this? This POC PR demonstrates what iterator support might look like, including tests and examples. I went with an "I" suffix (to mirror the "F" convention) to differentiate the iterator functions from their `slice.go` counterparts.

For example:
```golang
iter := lo.ToIterator(1, 2, 3, 4)
result := lo.FilterI(iter, func(nbr int, index int) bool { return nbr%2 == 0 })
fmt.Printf("%v", result.Slice())
```