### PR TITLE
Add FromSlicePtr

### DIFF
--- a/type_manipulation.go
+++ b/type_manipulation.go
@@ -43,6 +43,16 @@ func FromPtrOr[T any](x *T, fallback T) T {
 	return *x
 }
 
+// FromSlicePtr returns a slice of value filtering any nil pointers.
+func FromSlicePtr[T any](collection []*T) []T {
+	return FilterMap(collection, func(item *T, _ int) (T, bool) {
+		if item == nil {
+			return Empty[T](), false
+		}
+		return *item, true
+	})
+}
+
 // ToSlicePtr returns a slice of pointer copy of value.
 func ToSlicePtr[T any](collection []T) []*T {
 	return Map(collection, func(x T, _ int) *T {

--- a/type_manipulation_test.go
+++ b/type_manipulation_test.go
@@ -89,6 +89,17 @@ func TestFromPtrOr(t *testing.T) {
 	is.Equal(fallbackInt, FromPtrOr(nil, fallbackInt))
 }
 
+func TestFromSlicePtr(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	str1 := "foo"
+	str2 := "bar"
+	result1 := FromSlicePtr([]*string{&str1, nil, &str2})
+
+	is.Equal(result1, []string{str1, str2})
+}
+
 func TestToSlicePtr(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)


### PR DESCRIPTION
This proposal implements the reverse of `ToSlicePtr` by using `FilterMap` internally to skip any `nil` pointer values in an input array of pointers and returning the corresponding array of values safely.