### PR TITLE
CI: tests on multi go versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,22 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - '1.18'
+          - '1.19'
+          - '1.20'
+          - '1.21'
+          - '1.22'
+          - '1.x'
     steps:
     - uses: actions/checkout@v2
 
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: ${{ matrix.go }}
         stable: false
 
     - name: Build
@@ -35,3 +44,4 @@ jobs:
         file: ./cover.out
         flags: unittests
         verbose: true
+      if: matrix.go == '1.18'


### PR DESCRIPTION
## Overview

* Added CI tests of Go 1.19, 1.20, 1.21, 1.22 and stable
* Codecov job runs on go 1.18 only