### PR TITLE
feat(map): add GetOrSet for get value of exist key or set it

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,6 +958,21 @@ value := lo.ValueOr[string, int](map[string]int{"foo": 1, "bar": 2}, "baz", 42)
 // 42
 ```
 
+[[play](https://go.dev/play/p/pvoEPxdiL8m)]
+
+### _GetOrSet_
+
+Returns the value of the given key or the fallback value if the key is not present.
+
+```go
+value := lo.GetOrSet[string, int](map[string]int{"foo": 1, "bar": 2}, "foo", 42)
+// 1
+
+value := lo.GetOrSet[string, int](map[string]int{"foo": 1, "bar": 2}, "baz", 42)
+// 42
+// and the original map becomes map[string]int{"foo": 1, "bar": 2, "baz": 42}
+```
+
 [[play](https://go.dev/play/p/bAq9mHErB4V)]
 
 ### PickBy

--- a/map.go
+++ b/map.go
@@ -33,6 +33,16 @@ func ValueOr[K comparable, V any](in map[K]V, key K, fallback V) V {
 	return fallback
 }
 
+// GetOrSet returns value of the given key or set the fallback value if not present
+// Play: https://go.dev/play/p/pvoEPxdiL8m
+func GetOrSet[K comparable, V any](in map[K]V, key K, fallback V) V {
+	if v, ok := in[key]; ok {
+		return v
+	}
+	in[key] = fallback
+	return fallback
+}
+
 // PickBy returns same map type filtered by given predicate.
 // Play: https://go.dev/play/p/kdg8GR_QMmf
 func PickBy[K comparable, V any](in map[K]V, predicate func(key K, value V) bool) map[K]V {

--- a/map_example_test.go
+++ b/map_example_test.go
@@ -37,6 +37,16 @@ func ExampleValueOr() {
 	// Output: 1 42
 }
 
+func ExampleGetOrSet() {
+	kv := map[string]int{"foo": 1}
+
+	result1 := GetOrSet(kv, "foo", 1)
+	result2 := GetOrSet(kv, "bar", 2)
+
+	fmt.Printf("%v %v %v", result1, result2, kv)
+	// Output: 1 2 map[bar:2 foo:1]
+}
+
 func ExamplePickBy() {
 	kv := map[string]int{"foo": 1, "bar": 2, "baz": 3}
 

--- a/map_test.go
+++ b/map_test.go
@@ -40,6 +40,21 @@ func TestValueOr(t *testing.T) {
 	is.Equal(r2, 1)
 }
 
+func TestGetOrSet(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	kv := map[string]int{"foo": 1}
+
+	r1 := GetOrSet(kv, "foo", 2)
+	is.Equal(r1, 1)
+
+	r2 := GetOrSet(kv, "bar", 2)
+	is.Equal(r2, 2)
+
+	is.Equal(kv, map[string]int{"foo": 1, "bar": 2})
+}
+
 func TestPickBy(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -290,18 +305,18 @@ func TestMapEntries(t *testing.T) {
 		}, map[string]any{"b": 5})
 	}
 
-	//// OverlappingKeys
-	//// because using range over map, the order is not guaranteed
-	//// this test is not deterministic
-	//{
+	// // OverlappingKeys
+	// // because using range over map, the order is not guaranteed
+	// // this test is not deterministic
+	// {
 	//	mapEntriesTest(t, map[string]any{"foo": 1, "foo2": 2, "Foo": 2, "Foo2": "2", "bar": "2", "ccc": true}, func(k string, v any) (string, any) {
 	//		return string(k[0]), v
 	//	}, map[string]any{"F": "2", "b": "2", "c": true, "f": 2})
 	//	mapEntriesTest(t, map[string]string{"foo": "1", "foo2": "2", "Foo": "2", "Foo2": "2", "bar": "2", "ccc": "true"}, func(k string, v string) (string, string) {
 	//		return v, k
 	//	}, map[string]string{"1": "foo", "2": "bar", "true": "ccc"})
-	//}
-	//NormalMappers
+	// }
+	// NormalMappers
 	{
 		mapEntriesTest(t, map[string]string{"foo": "1", "foo2": "2", "Foo": "2", "Foo2": "2", "bar": "2", "ccc": "true"}, func(k string, v string) (string, string) {
 			return k, k + v


### PR DESCRIPTION
GetOrSet is like setdefault(key, default=None) in Python for dict , and map.getOrDefault(Object key, V defaultValue), returns the value of the given key or set the fallback value if not present.