### PR TITLE
ToSlicePtr: reduce allocations and improving speed

### DIFF
--- a/slice_benchmark_test.go
+++ b/slice_benchmark_test.go
@@ -171,3 +171,10 @@ func BenchmarkReplace(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkToSlicePtr(b *testing.B) {
+	preallocated := make([]int, 100000)
+	for i := 0; i < b.N; i++ {
+		_ = ToSlicePtr(preallocated)
+	}
+}

--- a/type_manipulation.go
+++ b/type_manipulation.go
@@ -45,9 +45,12 @@ func FromPtrOr[T any](x *T, fallback T) T {
 
 // ToSlicePtr returns a slice of pointer copy of value.
 func ToSlicePtr[T any](collection []T) []*T {
-	return Map(collection, func(x T, _ int) *T {
-		return &x
-	})
+	result := make([]*T, len(collection))
+
+	for i := range collection {
+		result[i] = &collection[i]
+	}
+	return result
 }
 
 // ToAnySlice returns a slice with all elements mapped to `any` type


### PR DESCRIPTION
Hi, I found a way to reduce the number of allocations and improve the overall performance of `ToSlicePtr`.

here is simple benchmark:
```
name           old time/op    new time/op    delta
ToSlicePtr-10    1.18ms ± 6%    0.25ms ± 5%   -78.60%  (p=0.000 n=14+12)

name           old alloc/op   new alloc/op   delta
ToSlicePtr-10    1.60MB ± 0%    0.80MB ± 0%   -49.92%  (p=0.000 n=15+15)

name           old allocs/op  new allocs/op  delta
ToSlicePtr-10      100k ± 0%        0k ± 0%  -100.00%  (p=0.000 n=15+15)
```