### PR TITLE
perf: preallocate in Assign

### DIFF
--- a/map.go
+++ b/map.go
@@ -171,8 +171,12 @@ func Invert[K comparable, V comparable](in map[K]V) map[V]K {
 // Assign merges multiple maps from left to right.
 // Play: https://go.dev/play/p/VhwfJOyxf5o
 func Assign[K comparable, V any, Map ~map[K]V](maps ...Map) Map {
-	out := Map{}
+	count := 0
+	for i := range maps {
+		count += len(maps[i])
+	}
 
+	out := make(Map, count)
 	for i := range maps {
 		for k := range maps[i] {
 			out[k] = maps[i][k]


### PR DESCRIPTION
Heuristically preallocate in `Assign`.

Assumption is that `Assign` is typically called with maps with different keys. For this invocations the benefit is the greatest.

Worst case scenario is when all the keys in all the merged maps are the same. The allocations for those calls are unnecessary but the execution time is roughly the same.

The preallocation factor can be decreased to e.g. half the count of all the entries in all the provided maps to try to cover both mentioned scenarios.

```
benchstat -confidence 0.6 old.txt new.txt | cb
goos: darwin
goarch: arm64
pkg: github.com/samber/lo
                          │   old.txt    │              new.txt               │
                          │    sec/op    │   sec/op     vs base               │
Assign/32768/different-10    3.659m ± 1%   2.365m ± 1%  -35.36% (p=0.002 n=6)
Assign/32768/same-10         5.419m ± 1%   5.464m ± 0%   +0.82% (p=0.015 n=6)
Assign/1024/different-10    106.92µ ± 0%   64.97µ ± 0%  -39.23% (p=0.002 n=6)
Assign/1024/same-10          171.4µ ± 0%   182.8µ ± 0%   +6.60% (p=0.002 n=6)
Assign/128/different-10     12.773µ ± 0%   8.042µ ± 1%  -37.04% (p=0.002 n=6)
Assign/128/same-10           21.91µ ± 0%   22.10µ ± 0%   +0.87% (p=0.009 n=6)
Assign/32/different-10       3.009µ ± 0%   1.934µ ± 0%  -35.70% (p=0.002 n=6)
Assign/32/same-10            5.562µ ± 0%   5.933µ ± 0%   +6.68% (p=0.002 n=6)
Assign/2/different-10        86.19n ± 0%   89.40n ± 1%   +3.72% (p=0.002 n=6)
Assign/2/same-10             345.6n ± 0%   470.5n ± 0%  +36.17% (p=0.002 n=6)
geomean                      23.47µ        20.51µ       -12.61%

                          │     old.txt     │                new.txt                │
                          │      B/op       │     B/op      vs base                 │
Assign/32768/different-10    3.692Mi ± 0%     1.727Mi ± 0%  -53.24% (p=0.002 n=6)
Assign/32768/same-10         0.000Mi ± 0%     6.906Mi ± 0%        ? (p=0.002 n=6)
Assign/1024/different-10    119.23Ki ± 0%     56.02Ki ± 0%  -53.01% (p=0.002 n=6)
Assign/1024/same-10            0.0Ki ± 0%     224.0Ki ± 0%        ? (p=0.002 n=6)
Assign/128/different-10     15.683Ki ± 0%     8.023Ki ± 0%  -48.84% (p=0.002 n=6)
Assign/128/same-10            0.00Ki ± 0%     28.02Ki ± 0%        ? (p=0.002 n=6)
Assign/32/different-10       3.254Ki ± 0%     1.772Ki ± 0%  -45.54% (p=0.002 n=6)
Assign/32/same-10            0.000Ki ± 0%     8.023Ki ± 0%        ? (p=0.002 n=6)
Assign/2/different-10          0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
Assign/2/same-10                 0.0 ± 0%       416.0 ± 0%        ? (p=0.002 n=6)
geomean                                   ²                 ?                     ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                          │     old.txt     │               new.txt               │
                          │    allocs/op    │ allocs/op   vs base                 │
Assign/32768/different-10   1134.000 ± 0%     2.000 ± 0%  -99.82% (p=0.002 n=6)
Assign/32768/same-10           0.000 ± 0%     2.000 ± 0%        ? (p=0.002 n=6)
Assign/1024/different-10      39.000 ± 0%     2.000 ± 0%  -94.87% (p=0.002 n=6)
Assign/1024/same-10            0.000 ± 0%     2.000 ± 0%        ? (p=0.002 n=6)
Assign/128/different-10        9.000 ± 0%     2.000 ± 0%  -77.78% (p=0.002 n=6)
Assign/128/same-10             0.000 ± 0%     2.000 ± 0%        ? (p=0.002 n=6)
Assign/32/different-10         4.000 ± 0%     1.000 ± 0%  -75.00% (p=0.002 n=6)
Assign/32/same-10              0.000 ± 0%     2.000 ± 0%        ? (p=0.002 n=6)
Assign/2/different-10          0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
Assign/2/same-10               0.000 ± 0%     1.000 ± 0%        ? (p=0.002 n=6)
geomean                                   ²               ?                     ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

---


```
 go test -v -run NONE -benchmem -bench Assign -count 6 . | tee new.txt
goos: darwin
goarch: arm64
pkg: github.com/samber/lo
BenchmarkAssign
BenchmarkAssign/32768
BenchmarkAssign/32768/different
BenchmarkAssign/32768/different-10                   488           2349970 ns/op         1810458 B/op          2 allocs/op
BenchmarkAssign/32768/different-10                   512           2362332 ns/op         1810458 B/op          2 allocs/op
BenchmarkAssign/32768/different-10                   488           2377271 ns/op         1810459 B/op          2 allocs/op
BenchmarkAssign/32768/different-10                   500           2368106 ns/op         1810460 B/op          2 allocs/op
BenchmarkAssign/32768/different-10                   517           2391250 ns/op         1810460 B/op          2 allocs/op
BenchmarkAssign/32768/different-10                   510           2357242 ns/op         1810460 B/op          2 allocs/op
BenchmarkAssign/32768/same
BenchmarkAssign/32768/same-10                        217           5471991 ns/op         7241760 B/op          2 allocs/op
BenchmarkAssign/32768/same-10                        219           5481591 ns/op         7241762 B/op          2 allocs/op
BenchmarkAssign/32768/same-10                        218           5450254 ns/op         7241759 B/op          2 allocs/op
BenchmarkAssign/32768/same-10                        218           5456355 ns/op         7241762 B/op          2 allocs/op
BenchmarkAssign/32768/same-10                        218           5421646 ns/op         7241762 B/op          2 allocs/op
BenchmarkAssign/32768/same-10                        220           5470916 ns/op         7241760 B/op          2 allocs/op
BenchmarkAssign/1024
BenchmarkAssign/1024/different
BenchmarkAssign/1024/different-10                  18632             64993 ns/op           57368 B/op          2 allocs/op
BenchmarkAssign/1024/different-10                  18032             64586 ns/op           57368 B/op          2 allocs/op
BenchmarkAssign/1024/different-10                  18276             65536 ns/op           57368 B/op          2 allocs/op
BenchmarkAssign/1024/different-10                  18330             64956 ns/op           57368 B/op          2 allocs/op
BenchmarkAssign/1024/different-10                  18478             64996 ns/op           57368 B/op          2 allocs/op
BenchmarkAssign/1024/different-10                  18424             64878 ns/op           57368 B/op          2 allocs/op
BenchmarkAssign/1024/same
BenchmarkAssign/1024/same-10                        6428            182633 ns/op          229402 B/op          2 allocs/op
BenchmarkAssign/1024/same-10                        6660            182984 ns/op          229401 B/op          2 allocs/op
BenchmarkAssign/1024/same-10                        6470            182713 ns/op          229401 B/op          2 allocs/op
BenchmarkAssign/1024/same-10                        6757            182685 ns/op          229402 B/op          2 allocs/op
BenchmarkAssign/1024/same-10                        6297            183787 ns/op          229402 B/op          2 allocs/op
BenchmarkAssign/1024/same-10                        6607            182789 ns/op          229402 B/op          2 allocs/op
BenchmarkAssign/128
BenchmarkAssign/128/different
BenchmarkAssign/128/different-10                  151622              8037 ns/op            8216 B/op          2 allocs/op
BenchmarkAssign/128/different-10                  146475              8047 ns/op            8216 B/op          2 allocs/op
BenchmarkAssign/128/different-10                  148665              7998 ns/op            8216 B/op          2 allocs/op
BenchmarkAssign/128/different-10                  150343              7994 ns/op            8216 B/op          2 allocs/op
BenchmarkAssign/128/different-10                  148636              8059 ns/op            8216 B/op          2 allocs/op
BenchmarkAssign/128/different-10                  148244              8056 ns/op            8216 B/op          2 allocs/op
BenchmarkAssign/128/same
BenchmarkAssign/128/same-10                        54115             22062 ns/op           28696 B/op          2 allocs/op
BenchmarkAssign/128/same-10                        54252             22093 ns/op           28696 B/op          2 allocs/op
BenchmarkAssign/128/same-10                        54268             22125 ns/op           28696 B/op          2 allocs/op
BenchmarkAssign/128/same-10                        54196             22138 ns/op           28696 B/op          2 allocs/op
BenchmarkAssign/128/same-10                        53952             22099 ns/op           28696 B/op          2 allocs/op
BenchmarkAssign/128/same-10                        55070             21988 ns/op           28696 B/op          2 allocs/op
BenchmarkAssign/32
BenchmarkAssign/32/different
BenchmarkAssign/32/different-10                   598707              1936 ns/op            1815 B/op          1 allocs/op
BenchmarkAssign/32/different-10                   619924              1943 ns/op            1815 B/op          1 allocs/op
BenchmarkAssign/32/different-10                   622550              1934 ns/op            1815 B/op          1 allocs/op
BenchmarkAssign/32/different-10                   613885              1924 ns/op            1815 B/op          1 allocs/op
BenchmarkAssign/32/different-10                   621602              1930 ns/op            1815 B/op          1 allocs/op
BenchmarkAssign/32/different-10                   624930              1935 ns/op            1815 B/op          1 allocs/op
BenchmarkAssign/32/same
BenchmarkAssign/32/same-10                        199240              5948 ns/op            8216 B/op          2 allocs/op
BenchmarkAssign/32/same-10                        205632              5908 ns/op            8216 B/op          2 allocs/op
BenchmarkAssign/32/same-10                        202818              5919 ns/op            8216 B/op          2 allocs/op
BenchmarkAssign/32/same-10                        203038              5947 ns/op            8216 B/op          2 allocs/op
BenchmarkAssign/32/same-10                        180860              5953 ns/op            8216 B/op          2 allocs/op
BenchmarkAssign/32/same-10                        203205              5900 ns/op            8216 B/op          2 allocs/op
BenchmarkAssign/2
BenchmarkAssign/2/different
BenchmarkAssign/2/different-10                  13472738                89.58 ns/op            0 B/op          0 allocs/op
BenchmarkAssign/2/different-10                  13398888                89.43 ns/op            0 B/op          0 allocs/op
BenchmarkAssign/2/different-10                  13365050                89.87 ns/op            0 B/op          0 allocs/op
BenchmarkAssign/2/different-10                  13320049                89.37 ns/op            0 B/op          0 allocs/op
BenchmarkAssign/2/different-10                  13533624                88.60 ns/op            0 B/op          0 allocs/op
BenchmarkAssign/2/different-10                  13386886                88.88 ns/op            0 B/op          0 allocs/op
BenchmarkAssign/2/same
BenchmarkAssign/2/same-10                        2556658               471.3 ns/op           416 B/op          1 allocs/op
BenchmarkAssign/2/same-10                        2531754               469.5 ns/op           416 B/op          1 allocs/op
BenchmarkAssign/2/same-10                        2554063               472.1 ns/op           416 B/op          1 allocs/op
BenchmarkAssign/2/same-10                        2549134               470.7 ns/op           416 B/op          1 allocs/op
BenchmarkAssign/2/same-10                        2520854               470.0 ns/op           416 B/op          1 allocs/op
BenchmarkAssign/2/same-10                        2552991               470.4 ns/op           416 B/op          1 allocs/op
PASS
ok      github.com/samber/lo    86.681s
```

```
go test -v -run NONE -benchmem -bench Assign -count 6 . | tee old.txt
goos: darwin
goarch: arm64
pkg: github.com/samber/lo
BenchmarkAssign
BenchmarkAssign/32768
BenchmarkAssign/32768/different
BenchmarkAssign/32768/different-10                   320           3656599 ns/op         3871391 B/op       1134 allocs/op
BenchmarkAssign/32768/different-10                   333           3629449 ns/op         3871485 B/op       1135 allocs/op
BenchmarkAssign/32768/different-10                   325           3630753 ns/op         3871351 B/op       1134 allocs/op
BenchmarkAssign/32768/different-10                   334           3670339 ns/op         3871191 B/op       1133 allocs/op
BenchmarkAssign/32768/different-10                   326           3661234 ns/op         3871614 B/op       1135 allocs/op
BenchmarkAssign/32768/different-10                   330           3663533 ns/op         3871439 B/op       1134 allocs/op
BenchmarkAssign/32768/same
BenchmarkAssign/32768/same-10                        219           5426764 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/32768/same-10                        219           5411827 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/32768/same-10                        220           5447425 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/32768/same-10                        219           5446835 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/32768/same-10                        219           5405492 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/32768/same-10                        218           5408272 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/1024
BenchmarkAssign/1024/different
BenchmarkAssign/1024/different-10                  10000            106963 ns/op          122084 B/op         39 allocs/op
BenchmarkAssign/1024/different-10                  10000            106913 ns/op          122104 B/op         39 allocs/op
BenchmarkAssign/1024/different-10                  10000            106917 ns/op          122088 B/op         39 allocs/op
BenchmarkAssign/1024/different-10                  10000            107567 ns/op          122091 B/op         39 allocs/op
BenchmarkAssign/1024/different-10                  10000            106823 ns/op          122095 B/op         39 allocs/op
BenchmarkAssign/1024/different-10                  10000            106472 ns/op          122101 B/op         39 allocs/op
BenchmarkAssign/1024/same
BenchmarkAssign/1024/same-10                        6861            172242 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/1024/same-10                        6926            171407 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/1024/same-10                        6940            171472 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/1024/same-10                        6986            171313 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/1024/same-10                        6790            171546 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/1024/same-10                        6991            170995 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/128
BenchmarkAssign/128/different
BenchmarkAssign/128/different-10                   93513             12739 ns/op           16059 B/op          9 allocs/op
BenchmarkAssign/128/different-10                   95340             12785 ns/op           16060 B/op          9 allocs/op
BenchmarkAssign/128/different-10                   93154             12761 ns/op           16059 B/op          9 allocs/op
BenchmarkAssign/128/different-10                   94578             12661 ns/op           16059 B/op          9 allocs/op
BenchmarkAssign/128/different-10                   95094             12808 ns/op           16061 B/op          9 allocs/op
BenchmarkAssign/128/different-10                   93662             12808 ns/op           16060 B/op          9 allocs/op
BenchmarkAssign/128/same
BenchmarkAssign/128/same-10                        54939             21899 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/128/same-10                        54654             22027 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/128/same-10                        54922             21908 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/128/same-10                        54811             21994 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/128/same-10                        54367             21901 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/128/same-10                        55021             21905 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/32
BenchmarkAssign/32/different
BenchmarkAssign/32/different-10                   393483              3013 ns/op            3332 B/op          4 allocs/op
BenchmarkAssign/32/different-10                   399706              2995 ns/op            3333 B/op          4 allocs/op
BenchmarkAssign/32/different-10                   394293              3007 ns/op            3333 B/op          4 allocs/op
BenchmarkAssign/32/different-10                   396872              3020 ns/op            3332 B/op          4 allocs/op
BenchmarkAssign/32/different-10                   400786              3010 ns/op            3332 B/op          4 allocs/op
BenchmarkAssign/32/different-10                   373470              3002 ns/op            3333 B/op          4 allocs/op
BenchmarkAssign/32/same
BenchmarkAssign/32/same-10                        200270              5556 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/32/same-10                        216384              5563 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/32/same-10                        216650              5563 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/32/same-10                        214627              5569 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/32/same-10                        216390              5560 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/32/same-10                        212517              5553 ns/op               0 B/op          0 allocs/op
BenchmarkAssign/2
BenchmarkAssign/2/different
BenchmarkAssign/2/different-10                  13896688                86.16 ns/op            0 B/op          0 allocs/op
BenchmarkAssign/2/different-10                  13841455                86.49 ns/op            0 B/op          0 allocs/op
BenchmarkAssign/2/different-10                  13793863                86.05 ns/op            0 B/op          0 allocs/op
BenchmarkAssign/2/different-10                  13995576                86.14 ns/op            0 B/op          0 allocs/op
BenchmarkAssign/2/different-10                  13899465                86.81 ns/op            0 B/op          0 allocs/op
BenchmarkAssign/2/different-10                  13764072                86.22 ns/op            0 B/op          0 allocs/op
BenchmarkAssign/2/same
BenchmarkAssign/2/same-10                        3463402               345.1 ns/op             0 B/op          0 allocs/op
BenchmarkAssign/2/same-10                        3299050               346.6 ns/op             0 B/op          0 allocs/op
BenchmarkAssign/2/same-10                        3482013               345.6 ns/op             0 B/op          0 allocs/op
BenchmarkAssign/2/same-10                        3446592               345.5 ns/op             0 B/op          0 allocs/op
BenchmarkAssign/2/same-10                        3476407               345.8 ns/op             0 B/op          0 allocs/op
BenchmarkAssign/2/same-10                        3474606               344.8 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/samber/lo    82.327s
```