### PR TITLE
add ForEachCondition implement

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -94,6 +94,16 @@ func ForEach[T any](collection []T, iteratee func(item T, index int)) {
 	}
 }
 
+// ForEachCondition iterates over elements of collection and invokes iteratee for each element
+// collection  return value  decide to continue or break.
+func ForEachCondition[T any](collection []T, iteratee func(item T, index int) (goon bool)) {
+	for i := range collection {
+		if !iteratee(collection[i], i) {
+			break
+		}
+	}
+}
+
 // Times invokes the iteratee n times, returning an array of the results of each invocation.
 // The iteratee is invoked with index as argument.
 // Play: https://go.dev/play/p/vgQj3Glr6lT

--- a/slice_example_test.go
+++ b/slice_example_test.go
@@ -88,7 +88,21 @@ func ExampleForEach() {
 	// 3
 	// 4
 }
+func ExampleForEachCondition() {
+	list := []int64{1, 2, -math.MaxInt, 4}
 
+	ForEachCondition(list, func(x int64, _ int) bool {
+		if x < 0 {
+			return false
+		}
+		fmt.Println(x)
+		return true
+	})
+
+	// Output:
+	// 1
+	// 2
+}
 func ExampleTimes() {
 	result := Times(3, func(i int) string {
 		return strconv.FormatInt(int64(i), 10)

--- a/slice_test.go
+++ b/slice_test.go
@@ -157,6 +157,29 @@ func TestForEach(t *testing.T) {
 	is.IsIncreasing(callParams2)
 }
 
+func TestForEachCondition(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	// check of callback is called for every element and in proper order
+
+	var callParams1 []string
+	var callParams2 []int
+
+	ForEachCondition([]string{"a", "b", "c"}, func(item string, i int) bool {
+		if item == "c" {
+			return false
+		}
+		callParams1 = append(callParams1, item)
+		callParams2 = append(callParams2, i)
+		return true
+	})
+
+	is.ElementsMatch([]string{"a", "b"}, callParams1)
+	is.ElementsMatch([]int{0, 1}, callParams2)
+	is.IsIncreasing(callParams2)
+}
+
 func TestUniq(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)


### PR DESCRIPTION
In certain cases, we want to control whether the foreach continues to execute, such as checking if a set of data meets certain criteria. ForEachCondition implements this functionality to address this need