### PR TITLE
Add EmptyOnError, EmptyOnError{1->6}

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -113,7 +113,7 @@ func Must6[T1, T2, T3, T4, T5, T6 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 
 	return val1, val2, val3, val4, val5, val6
 }
 
-// just assume fine if err is nil or true.
+// fine assume ok if err is nil or true.
 func fine(err any) bool {
 	if err == nil {
 		return true
@@ -129,54 +129,54 @@ func fine(err any) bool {
 	}
 }
 
-// Just is a helper that wraps a call to a function returning just a value
+// Fine is a helper that wraps a call to a function returning just a value
 // and return zero value if err is nil or true.
-func Just[T any](val T, err any) T {
+func Fine[T any](val T, err any) T {
 	if fine(err) {
 		return val
 	}
 	return Empty[T]()
 }
 
-// Just1 is an alias to Just
-func Just1[T any](val T, err any) T {
-	return Just(val, err)
+// Fine1 is an alias to Fine
+func Fine1[T any](val T, err any) T {
+	return Fine(val, err)
 }
 
-// Just2 has the same behavior as Just, but callback returns 2 variables.
-func Just2[T1, T2 any](val1 T1, val2 T2, err any) (T1, T2) {
+// Fine2 has the same behavior as Fine, but callback returns 2 variables.
+func Fine2[T1, T2 any](val1 T1, val2 T2, err any) (T1, T2) {
 	if fine(err) {
 		return val1, val2
 	}
 	return Empty[T1](), Empty[T2]()
 }
 
-// Just3 has the same behavior as Just, but callback returns 3 variables.
-func Just3[T1, T2, T3 any](val1 T1, val2 T2, val3 T3, err any) (T1, T2, T3) {
+// Fine3 has the same behavior as Fine, but callback returns 3 variables.
+func Fine3[T1, T2, T3 any](val1 T1, val2 T2, val3 T3, err any) (T1, T2, T3) {
 	if fine(err) {
 		return val1, val2, val3
 	}
 	return Empty[T1](), Empty[T2](), Empty[T3]()
 }
 
-// Just4 has the same behavior as Just, but callback returns 4 variables.
-func Just4[T1, T2, T3, T4 any](val1 T1, val2 T2, val3 T3, val4 T4, err any) (T1, T2, T3, T4) {
+// Fine4 has the same behavior as Fine, but callback returns 4 variables.
+func Fine4[T1, T2, T3, T4 any](val1 T1, val2 T2, val3 T3, val4 T4, err any) (T1, T2, T3, T4) {
 	if fine(err) {
 		return val1, val2, val3, val4
 	}
 	return Empty[T1](), Empty[T2](), Empty[T3](), Empty[T4]()
 }
 
-// Just5 has the same behavior as Just, but callback returns 5 variables.
-func Just5[T1, T2, T3, T4, T5 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 T5, err any) (T1, T2, T3, T4, T5) {
+// Fine5 has the same behavior as Fine, but callback returns 5 variables.
+func Fine5[T1, T2, T3, T4, T5 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 T5, err any) (T1, T2, T3, T4, T5) {
 	if fine(err) {
 		return val1, val2, val3, val4, val5
 	}
 	return Empty[T1](), Empty[T2](), Empty[T3](), Empty[T4](), Empty[T5]()
 }
 
-// Just6 has the same behavior as Just, but callback returns 6 variables.
-func Just6[T1, T2, T3, T4, T5, T6 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 T5, val6 T6, err any) (T1, T2, T3, T4, T5, T6) {
+// Fine6 has the same behavior as Fine, but callback returns 6 variables.
+func Fine6[T1, T2, T3, T4, T5, T6 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 T5, val6 T6, err any) (T1, T2, T3, T4, T5, T6) {
 	if fine(err) {
 		return val1, val2, val3, val4, val5, val6
 	}

--- a/errors.go
+++ b/errors.go
@@ -113,6 +113,76 @@ func Must6[T1, T2, T3, T4, T5, T6 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 
 	return val1, val2, val3, val4, val5, val6
 }
 
+// just assume fine if err is nil or true.
+func fine(err any) bool {
+	if err == nil {
+		return true
+	}
+
+	switch e := err.(type) {
+	case bool:
+		return e
+	case error:
+		return false
+	default:
+		return false
+	}
+}
+
+// Just is a helper that wraps a call to a function returning just a value
+// and return zero value if err is nil or true.
+func Just[T any](val T, err any) T {
+	if fine(err) {
+		return val
+	}
+	return Empty[T]()
+}
+
+// Just1 is an alias to Just
+func Just1[T any](val T, err any) T {
+	return Just(val, err)
+}
+
+// Just2 has the same behavior as Just, but callback returns 2 variables.
+func Just2[T1, T2 any](val1 T1, val2 T2, err any) (T1, T2) {
+	if fine(err) {
+		return val1, val2
+	}
+	return Empty[T1](), Empty[T2]()
+}
+
+// Just3 has the same behavior as Just, but callback returns 3 variables.
+func Just3[T1, T2, T3 any](val1 T1, val2 T2, val3 T3, err any) (T1, T2, T3) {
+	if fine(err) {
+		return val1, val2, val3
+	}
+	return Empty[T1](), Empty[T2](), Empty[T3]()
+}
+
+// Just4 has the same behavior as Just, but callback returns 4 variables.
+func Just4[T1, T2, T3, T4 any](val1 T1, val2 T2, val3 T3, val4 T4, err any) (T1, T2, T3, T4) {
+	if fine(err) {
+		return val1, val2, val3, val4
+	}
+	return Empty[T1](), Empty[T2](), Empty[T3](), Empty[T4]()
+}
+
+// Just5 has the same behavior as Just, but callback returns 5 variables.
+func Just5[T1, T2, T3, T4, T5 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 T5, err any) (T1, T2, T3, T4, T5) {
+	if fine(err) {
+		return val1, val2, val3, val4, val5
+	}
+	return Empty[T1](), Empty[T2](), Empty[T3](), Empty[T4](), Empty[T5]()
+}
+
+// Just6 has the same behavior as Just, but callback returns 6 variables.
+func Just6[T1, T2, T3, T4, T5, T6 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 T5, val6 T6, err any) (T1, T2, T3, T4, T5, T6) {
+	if fine(err) {
+		return val1, val2, val3, val4, val5, val6
+	}
+	return Empty[T1](), Empty[T2](), Empty[T3](), Empty[T4](), Empty[T5](), Empty[T6]()
+}
+
 // Try calls the function and return false in case of error.
 func Try(callback func() error) (ok bool) {
 	ok = true

--- a/errors.go
+++ b/errors.go
@@ -129,54 +129,54 @@ func fine(err any) bool {
 	}
 }
 
-// Fine is a helper that wraps a call to a function returning just a value
+// EmptyOnError is a helper that wraps a call to a function returning just a value
 // and return zero value if err is nil or true.
-func Fine[T any](val T, err any) T {
+func EmptyOnError[T any](val T, err any) T {
 	if fine(err) {
 		return val
 	}
 	return Empty[T]()
 }
 
-// Fine1 is an alias to Fine
-func Fine1[T any](val T, err any) T {
-	return Fine(val, err)
+// EmptyOnError1 is an alias to EmptyOnError
+func EmptyOnError1[T any](val T, err any) T {
+	return EmptyOnError(val, err)
 }
 
-// Fine2 has the same behavior as Fine, but callback returns 2 variables.
-func Fine2[T1, T2 any](val1 T1, val2 T2, err any) (T1, T2) {
+// EmptyOnError2 has the same behavior as EmptyOnError, but callback returns 2 variables.
+func EmptyOnError2[T1, T2 any](val1 T1, val2 T2, err any) (T1, T2) {
 	if fine(err) {
 		return val1, val2
 	}
 	return Empty[T1](), Empty[T2]()
 }
 
-// Fine3 has the same behavior as Fine, but callback returns 3 variables.
-func Fine3[T1, T2, T3 any](val1 T1, val2 T2, val3 T3, err any) (T1, T2, T3) {
+// EmptyOnError3 has the same behavior as EmptyOnError, but callback returns 3 variables.
+func EmptyOnError3[T1, T2, T3 any](val1 T1, val2 T2, val3 T3, err any) (T1, T2, T3) {
 	if fine(err) {
 		return val1, val2, val3
 	}
 	return Empty[T1](), Empty[T2](), Empty[T3]()
 }
 
-// Fine4 has the same behavior as Fine, but callback returns 4 variables.
-func Fine4[T1, T2, T3, T4 any](val1 T1, val2 T2, val3 T3, val4 T4, err any) (T1, T2, T3, T4) {
+// EmptyOnError4 has the same behavior as EmptyOnError, but callback returns 4 variables.
+func EmptyOnError4[T1, T2, T3, T4 any](val1 T1, val2 T2, val3 T3, val4 T4, err any) (T1, T2, T3, T4) {
 	if fine(err) {
 		return val1, val2, val3, val4
 	}
 	return Empty[T1](), Empty[T2](), Empty[T3](), Empty[T4]()
 }
 
-// Fine5 has the same behavior as Fine, but callback returns 5 variables.
-func Fine5[T1, T2, T3, T4, T5 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 T5, err any) (T1, T2, T3, T4, T5) {
+// EmptyOnError5 has the same behavior as EmptyOnError, but callback returns 5 variables.
+func EmptyOnError5[T1, T2, T3, T4, T5 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 T5, err any) (T1, T2, T3, T4, T5) {
 	if fine(err) {
 		return val1, val2, val3, val4, val5
 	}
 	return Empty[T1](), Empty[T2](), Empty[T3](), Empty[T4](), Empty[T5]()
 }
 
-// Fine6 has the same behavior as Fine, but callback returns 6 variables.
-func Fine6[T1, T2, T3, T4, T5, T6 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 T5, val6 T6, err any) (T1, T2, T3, T4, T5, T6) {
+// EmptyOnError6 has the same behavior as EmptyOnError, but callback returns 6 variables.
+func EmptyOnError6[T1, T2, T3, T4, T5, T6 any](val1 T1, val2 T2, val3 T3, val4 T4, val5 T5, val6 T6, err any) (T1, T2, T3, T4, T5, T6) {
 	if fine(err) {
 		return val1, val2, val3, val4, val5, val6
 	}

--- a/errors_test.go
+++ b/errors_test.go
@@ -253,63 +253,63 @@ func TestMustX(t *testing.T) {
 	}
 }
 
-func TestFine(t *testing.T) {
+func TestEmptyOnError(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.Equal("foo", Fine("foo", nil))
-	is.Zero(Fine("whatever", errors.New("something went wrong")))
+	is.Equal("foo", EmptyOnError("foo", nil))
+	is.Zero(EmptyOnError("whatever", errors.New("something went wrong")))
 
-	is.Equal(1, Fine(1, true))
-	is.Zero(Fine(999, false))
-	is.Zero(Fine(999, errors.New("something went wrong")))
+	is.Equal(1, EmptyOnError(1, true))
+	is.Zero(EmptyOnError(999, false))
+	is.Zero(EmptyOnError(999, errors.New("something went wrong")))
 
 	cb := func() (string, error) {
 		return "whatever", assert.AnError
 	}
-	is.Zero(Fine(cb()))
+	is.Zero(EmptyOnError(cb()))
 }
 
-func TestFineX(t *testing.T) {
+func TestEmptyOnErrorX(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
 	{
-		val1 := Fine1(1, nil)
+		val1 := EmptyOnError1(1, nil)
 		is.Equal(1, val1)
-		is.Zero(Fine1(1, errors.New("something went wrong")))
+		is.Zero(EmptyOnError1(1, errors.New("something went wrong")))
 	}
 
 	{
-		val1, val2 := Fine2(1, 2, nil)
+		val1, val2 := EmptyOnError2(1, 2, nil)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 
-		val1, val2 = Fine2(1, 2, errors.New("something went wrong"))
+		val1, val2 = EmptyOnError2(1, 2, errors.New("something went wrong"))
 		is.Zero(val1)
 		is.Zero(val2)
 	}
 
 	{
-		val1, val2, val3 := Fine3(1, 2, 3, nil)
+		val1, val2, val3 := EmptyOnError3(1, 2, 3, nil)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 		is.Equal(3, val3)
 
-		val1, val2, val3 = Fine3(1, 2, 3, errors.New("something went wrong"))
+		val1, val2, val3 = EmptyOnError3(1, 2, 3, errors.New("something went wrong"))
 		is.Zero(val1)
 		is.Zero(val2)
 		is.Zero(val3)
 	}
 
 	{
-		val1, val2, val3, val4 := Fine4(1, 2, 3, 4, nil)
+		val1, val2, val3, val4 := EmptyOnError4(1, 2, 3, 4, nil)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 		is.Equal(3, val3)
 		is.Equal(4, val4)
 
-		val1, val2, val3, val4 = Fine4(1, 2, 3, 4, errors.New("something went wrong"))
+		val1, val2, val3, val4 = EmptyOnError4(1, 2, 3, 4, errors.New("something went wrong"))
 		is.Zero(val1)
 		is.Zero(val2)
 		is.Zero(val3)
@@ -317,14 +317,14 @@ func TestFineX(t *testing.T) {
 	}
 
 	{
-		val1, val2, val3, val4, val5 := Fine5(1, 2, 3, 4, 5, nil)
+		val1, val2, val3, val4, val5 := EmptyOnError5(1, 2, 3, 4, 5, nil)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 		is.Equal(3, val3)
 		is.Equal(4, val4)
 		is.Equal(5, val5)
 
-		val1, val2, val3, val4, val5 = Fine5(1, 2, 3, 4, 5, errors.New("something went wrong"))
+		val1, val2, val3, val4, val5 = EmptyOnError5(1, 2, 3, 4, 5, errors.New("something went wrong"))
 		is.Zero(val1)
 		is.Zero(val2)
 		is.Zero(val3)
@@ -333,7 +333,7 @@ func TestFineX(t *testing.T) {
 	}
 
 	{
-		val1, val2, val3, val4, val5, val6 := Fine6(1, 2, 3, 4, 5, 6, nil)
+		val1, val2, val3, val4, val5, val6 := EmptyOnError6(1, 2, 3, 4, 5, 6, nil)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 		is.Equal(3, val3)
@@ -341,7 +341,7 @@ func TestFineX(t *testing.T) {
 		is.Equal(5, val5)
 		is.Equal(6, val6)
 
-		val1, val2, val3, val4, val5, val6 = Fine6(1, 2, 3, 4, 5, 6, errors.New("something went wrong"))
+		val1, val2, val3, val4, val5, val6 = EmptyOnError6(1, 2, 3, 4, 5, 6, errors.New("something went wrong"))
 		is.Zero(val1)
 		is.Zero(val2)
 		is.Zero(val3)
@@ -351,41 +351,41 @@ func TestFineX(t *testing.T) {
 	}
 
 	{
-		val1 := Fine(1, true)
+		val1 := EmptyOnError(1, true)
 		is.Equal(1, val1)
-		is.Zero(Fine(1, false))
+		is.Zero(EmptyOnError(1, false))
 	}
 
 	{
-		val1, val2 := Fine2(1, 2, true)
+		val1, val2 := EmptyOnError2(1, 2, true)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 
-		val1, val2 = Fine2(1, 2, false)
+		val1, val2 = EmptyOnError2(1, 2, false)
 		is.Zero(val1)
 		is.Zero(val2)
 	}
 
 	{
-		val1, val2, val3 := Fine3(1, 2, 3, true)
+		val1, val2, val3 := EmptyOnError3(1, 2, 3, true)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 		is.Equal(3, val3)
 
-		val1, val2, val3 = Fine3(1, 2, 3, false)
+		val1, val2, val3 = EmptyOnError3(1, 2, 3, false)
 		is.Zero(val1)
 		is.Zero(val2)
 		is.Zero(val3)
 	}
 
 	{
-		val1, val2, val3, val4 := Fine4(1, 2, 3, 4, true)
+		val1, val2, val3, val4 := EmptyOnError4(1, 2, 3, 4, true)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 		is.Equal(3, val3)
 		is.Equal(4, val4)
 
-		val1, val2, val3, val4 = Fine4(1, 2, 3, 4, false)
+		val1, val2, val3, val4 = EmptyOnError4(1, 2, 3, 4, false)
 		is.Zero(val1)
 		is.Zero(val2)
 		is.Zero(val3)
@@ -393,14 +393,14 @@ func TestFineX(t *testing.T) {
 	}
 
 	{
-		val1, val2, val3, val4, val5 := Fine5(1, 2, 3, 4, 5, true)
+		val1, val2, val3, val4, val5 := EmptyOnError5(1, 2, 3, 4, 5, true)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 		is.Equal(3, val3)
 		is.Equal(4, val4)
 		is.Equal(5, val5)
 
-		val1, val2, val3, val4, val5 = Fine5(1, 2, 3, 4, 5, false)
+		val1, val2, val3, val4, val5 = EmptyOnError5(1, 2, 3, 4, 5, false)
 		is.Zero(val1)
 		is.Zero(val2)
 		is.Zero(val3)
@@ -409,7 +409,7 @@ func TestFineX(t *testing.T) {
 	}
 
 	{
-		val1, val2, val3, val4, val5, val6 := Fine6(1, 2, 3, 4, 5, 6, true)
+		val1, val2, val3, val4, val5, val6 := EmptyOnError6(1, 2, 3, 4, 5, 6, true)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 		is.Equal(3, val3)
@@ -417,7 +417,7 @@ func TestFineX(t *testing.T) {
 		is.Equal(5, val5)
 		is.Equal(6, val6)
 
-		val1, val2, val3, val4, val5, val6 = Fine6(1, 2, 3, 4, 5, 6, false)
+		val1, val2, val3, val4, val5, val6 = EmptyOnError6(1, 2, 3, 4, 5, 6, false)
 		is.Zero(val1)
 		is.Zero(val2)
 		is.Zero(val3)

--- a/errors_test.go
+++ b/errors_test.go
@@ -53,7 +53,7 @@ func TestMust(t *testing.T) {
 	is.PanicsWithValue("operation should fail: assert.AnError general error for testing", func() {
 		Must0(cb(), "operation should fail")
 	})
-	
+
 	is.PanicsWithValue("must: invalid err type 'int', should either be a bool or an error", func() {
 		Must0(0)
 	})
@@ -253,6 +253,180 @@ func TestMustX(t *testing.T) {
 	}
 }
 
+func TestJust(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	is.Equal("foo", Just("foo", nil))
+	is.Zero(Just("whatever", errors.New("something went wrong")))
+
+	is.Equal(1, Just(1, true))
+	is.Zero(Just(999, false))
+	is.Zero(Just(999, errors.New("something went wrong")))
+
+	cb := func() (string, error) {
+		return "whatever", assert.AnError
+	}
+	is.Zero(Just(cb()))
+}
+
+func TestJustX(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	{
+		val1 := Just1(1, nil)
+		is.Equal(1, val1)
+		is.Zero(Just1(1, errors.New("something went wrong")))
+	}
+
+	{
+		val1, val2 := Just2(1, 2, nil)
+		is.Equal(1, val1)
+		is.Equal(2, val2)
+
+		val1, val2 = Just2(1, 2, errors.New("something went wrong"))
+		is.Zero(val1)
+		is.Zero(val2)
+	}
+
+	{
+		val1, val2, val3 := Just3(1, 2, 3, nil)
+		is.Equal(1, val1)
+		is.Equal(2, val2)
+		is.Equal(3, val3)
+
+		val1, val2, val3 = Just3(1, 2, 3, errors.New("something went wrong"))
+		is.Zero(val1)
+		is.Zero(val2)
+		is.Zero(val3)
+	}
+
+	{
+		val1, val2, val3, val4 := Just4(1, 2, 3, 4, nil)
+		is.Equal(1, val1)
+		is.Equal(2, val2)
+		is.Equal(3, val3)
+		is.Equal(4, val4)
+
+		val1, val2, val3, val4 = Just4(1, 2, 3, 4, errors.New("something went wrong"))
+		is.Zero(val1)
+		is.Zero(val2)
+		is.Zero(val3)
+		is.Zero(val4)
+	}
+
+	{
+		val1, val2, val3, val4, val5 := Just5(1, 2, 3, 4, 5, nil)
+		is.Equal(1, val1)
+		is.Equal(2, val2)
+		is.Equal(3, val3)
+		is.Equal(4, val4)
+		is.Equal(5, val5)
+
+		val1, val2, val3, val4, val5 = Just5(1, 2, 3, 4, 5, errors.New("something went wrong"))
+		is.Zero(val1)
+		is.Zero(val2)
+		is.Zero(val3)
+		is.Zero(val4)
+		is.Zero(val5)
+	}
+
+	{
+		val1, val2, val3, val4, val5, val6 := Just6(1, 2, 3, 4, 5, 6, nil)
+		is.Equal(1, val1)
+		is.Equal(2, val2)
+		is.Equal(3, val3)
+		is.Equal(4, val4)
+		is.Equal(5, val5)
+		is.Equal(6, val6)
+
+		val1, val2, val3, val4, val5, val6 = Just6(1, 2, 3, 4, 5, 6, errors.New("something went wrong"))
+		is.Zero(val1)
+		is.Zero(val2)
+		is.Zero(val3)
+		is.Zero(val4)
+		is.Zero(val5)
+		is.Zero(val6)
+	}
+
+	{
+		val1 := Just(1, true)
+		is.Equal(1, val1)
+		is.Zero(Just(1, false))
+	}
+
+	{
+		val1, val2 := Just2(1, 2, true)
+		is.Equal(1, val1)
+		is.Equal(2, val2)
+
+		val1, val2 = Just2(1, 2, false)
+		is.Zero(val1)
+		is.Zero(val2)
+	}
+
+	{
+		val1, val2, val3 := Just3(1, 2, 3, true)
+		is.Equal(1, val1)
+		is.Equal(2, val2)
+		is.Equal(3, val3)
+
+		val1, val2, val3 = Just3(1, 2, 3, false)
+		is.Zero(val1)
+		is.Zero(val2)
+		is.Zero(val3)
+	}
+
+	{
+		val1, val2, val3, val4 := Just4(1, 2, 3, 4, true)
+		is.Equal(1, val1)
+		is.Equal(2, val2)
+		is.Equal(3, val3)
+		is.Equal(4, val4)
+
+		val1, val2, val3, val4 = Just4(1, 2, 3, 4, false)
+		is.Zero(val1)
+		is.Zero(val2)
+		is.Zero(val3)
+		is.Zero(val4)
+	}
+
+	{
+		val1, val2, val3, val4, val5 := Just5(1, 2, 3, 4, 5, true)
+		is.Equal(1, val1)
+		is.Equal(2, val2)
+		is.Equal(3, val3)
+		is.Equal(4, val4)
+		is.Equal(5, val5)
+
+		val1, val2, val3, val4, val5 = Just5(1, 2, 3, 4, 5, false)
+		is.Zero(val1)
+		is.Zero(val2)
+		is.Zero(val3)
+		is.Zero(val4)
+		is.Zero(val5)
+	}
+
+	{
+		val1, val2, val3, val4, val5, val6 := Just6(1, 2, 3, 4, 5, 6, true)
+		is.Equal(1, val1)
+		is.Equal(2, val2)
+		is.Equal(3, val3)
+		is.Equal(4, val4)
+		is.Equal(5, val5)
+		is.Equal(6, val6)
+
+		val1, val2, val3, val4, val5, val6 = Just6(1, 2, 3, 4, 5, 6, false)
+		is.Zero(val1)
+		is.Zero(val2)
+		is.Zero(val3)
+		is.Zero(val4)
+		is.Zero(val5)
+		is.Zero(val6)
+	}
+}
+
 func TestTry(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -271,11 +445,11 @@ func TestTry(t *testing.T) {
 func TestTryX(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
-	
+
 	is.True(Try1(func() error {
 		return nil
 	}))
-	
+
 	is.True(Try2(func() (string, error) {
 		return "", nil
 	}))
@@ -295,11 +469,11 @@ func TestTryX(t *testing.T) {
 	is.True(Try6(func() (string, string, string, string, string, error) {
 		return "", "", "", "", "", nil
 	}))
-	
+
 	is.False(Try1(func() error {
 		panic("error")
 	}))
-	
+
 	is.False(Try2(func() (string, error) {
 		panic("error")
 	}))
@@ -319,11 +493,11 @@ func TestTryX(t *testing.T) {
 	is.False(Try6(func() (string, string, string, string, string, error) {
 		panic("error")
 	}))
-	
+
 	is.False(Try1(func() error {
 		return errors.New("foo")
 	}))
-	
+
 	is.False(Try2(func() (string, error) {
 		return "", errors.New("foo")
 	}))
@@ -513,13 +687,13 @@ func TestTryWithErrorValue(t *testing.T) {
 	})
 	is.False(ok)
 	is.Equal("error", err)
-	
+
 	err, ok = TryWithErrorValue(func() error {
 		return errors.New("foo")
 	})
 	is.False(ok)
 	is.EqualError(err.(error), "foo")
-	
+
 	err, ok = TryWithErrorValue(func() error {
 		return nil
 	})

--- a/errors_test.go
+++ b/errors_test.go
@@ -253,63 +253,63 @@ func TestMustX(t *testing.T) {
 	}
 }
 
-func TestJust(t *testing.T) {
+func TestFine(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.Equal("foo", Just("foo", nil))
-	is.Zero(Just("whatever", errors.New("something went wrong")))
+	is.Equal("foo", Fine("foo", nil))
+	is.Zero(Fine("whatever", errors.New("something went wrong")))
 
-	is.Equal(1, Just(1, true))
-	is.Zero(Just(999, false))
-	is.Zero(Just(999, errors.New("something went wrong")))
+	is.Equal(1, Fine(1, true))
+	is.Zero(Fine(999, false))
+	is.Zero(Fine(999, errors.New("something went wrong")))
 
 	cb := func() (string, error) {
 		return "whatever", assert.AnError
 	}
-	is.Zero(Just(cb()))
+	is.Zero(Fine(cb()))
 }
 
-func TestJustX(t *testing.T) {
+func TestFineX(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
 	{
-		val1 := Just1(1, nil)
+		val1 := Fine1(1, nil)
 		is.Equal(1, val1)
-		is.Zero(Just1(1, errors.New("something went wrong")))
+		is.Zero(Fine1(1, errors.New("something went wrong")))
 	}
 
 	{
-		val1, val2 := Just2(1, 2, nil)
+		val1, val2 := Fine2(1, 2, nil)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 
-		val1, val2 = Just2(1, 2, errors.New("something went wrong"))
+		val1, val2 = Fine2(1, 2, errors.New("something went wrong"))
 		is.Zero(val1)
 		is.Zero(val2)
 	}
 
 	{
-		val1, val2, val3 := Just3(1, 2, 3, nil)
+		val1, val2, val3 := Fine3(1, 2, 3, nil)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 		is.Equal(3, val3)
 
-		val1, val2, val3 = Just3(1, 2, 3, errors.New("something went wrong"))
+		val1, val2, val3 = Fine3(1, 2, 3, errors.New("something went wrong"))
 		is.Zero(val1)
 		is.Zero(val2)
 		is.Zero(val3)
 	}
 
 	{
-		val1, val2, val3, val4 := Just4(1, 2, 3, 4, nil)
+		val1, val2, val3, val4 := Fine4(1, 2, 3, 4, nil)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 		is.Equal(3, val3)
 		is.Equal(4, val4)
 
-		val1, val2, val3, val4 = Just4(1, 2, 3, 4, errors.New("something went wrong"))
+		val1, val2, val3, val4 = Fine4(1, 2, 3, 4, errors.New("something went wrong"))
 		is.Zero(val1)
 		is.Zero(val2)
 		is.Zero(val3)
@@ -317,14 +317,14 @@ func TestJustX(t *testing.T) {
 	}
 
 	{
-		val1, val2, val3, val4, val5 := Just5(1, 2, 3, 4, 5, nil)
+		val1, val2, val3, val4, val5 := Fine5(1, 2, 3, 4, 5, nil)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 		is.Equal(3, val3)
 		is.Equal(4, val4)
 		is.Equal(5, val5)
 
-		val1, val2, val3, val4, val5 = Just5(1, 2, 3, 4, 5, errors.New("something went wrong"))
+		val1, val2, val3, val4, val5 = Fine5(1, 2, 3, 4, 5, errors.New("something went wrong"))
 		is.Zero(val1)
 		is.Zero(val2)
 		is.Zero(val3)
@@ -333,7 +333,7 @@ func TestJustX(t *testing.T) {
 	}
 
 	{
-		val1, val2, val3, val4, val5, val6 := Just6(1, 2, 3, 4, 5, 6, nil)
+		val1, val2, val3, val4, val5, val6 := Fine6(1, 2, 3, 4, 5, 6, nil)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 		is.Equal(3, val3)
@@ -341,7 +341,7 @@ func TestJustX(t *testing.T) {
 		is.Equal(5, val5)
 		is.Equal(6, val6)
 
-		val1, val2, val3, val4, val5, val6 = Just6(1, 2, 3, 4, 5, 6, errors.New("something went wrong"))
+		val1, val2, val3, val4, val5, val6 = Fine6(1, 2, 3, 4, 5, 6, errors.New("something went wrong"))
 		is.Zero(val1)
 		is.Zero(val2)
 		is.Zero(val3)
@@ -351,41 +351,41 @@ func TestJustX(t *testing.T) {
 	}
 
 	{
-		val1 := Just(1, true)
+		val1 := Fine(1, true)
 		is.Equal(1, val1)
-		is.Zero(Just(1, false))
+		is.Zero(Fine(1, false))
 	}
 
 	{
-		val1, val2 := Just2(1, 2, true)
+		val1, val2 := Fine2(1, 2, true)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 
-		val1, val2 = Just2(1, 2, false)
+		val1, val2 = Fine2(1, 2, false)
 		is.Zero(val1)
 		is.Zero(val2)
 	}
 
 	{
-		val1, val2, val3 := Just3(1, 2, 3, true)
+		val1, val2, val3 := Fine3(1, 2, 3, true)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 		is.Equal(3, val3)
 
-		val1, val2, val3 = Just3(1, 2, 3, false)
+		val1, val2, val3 = Fine3(1, 2, 3, false)
 		is.Zero(val1)
 		is.Zero(val2)
 		is.Zero(val3)
 	}
 
 	{
-		val1, val2, val3, val4 := Just4(1, 2, 3, 4, true)
+		val1, val2, val3, val4 := Fine4(1, 2, 3, 4, true)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 		is.Equal(3, val3)
 		is.Equal(4, val4)
 
-		val1, val2, val3, val4 = Just4(1, 2, 3, 4, false)
+		val1, val2, val3, val4 = Fine4(1, 2, 3, 4, false)
 		is.Zero(val1)
 		is.Zero(val2)
 		is.Zero(val3)
@@ -393,14 +393,14 @@ func TestJustX(t *testing.T) {
 	}
 
 	{
-		val1, val2, val3, val4, val5 := Just5(1, 2, 3, 4, 5, true)
+		val1, val2, val3, val4, val5 := Fine5(1, 2, 3, 4, 5, true)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 		is.Equal(3, val3)
 		is.Equal(4, val4)
 		is.Equal(5, val5)
 
-		val1, val2, val3, val4, val5 = Just5(1, 2, 3, 4, 5, false)
+		val1, val2, val3, val4, val5 = Fine5(1, 2, 3, 4, 5, false)
 		is.Zero(val1)
 		is.Zero(val2)
 		is.Zero(val3)
@@ -409,7 +409,7 @@ func TestJustX(t *testing.T) {
 	}
 
 	{
-		val1, val2, val3, val4, val5, val6 := Just6(1, 2, 3, 4, 5, 6, true)
+		val1, val2, val3, val4, val5, val6 := Fine6(1, 2, 3, 4, 5, 6, true)
 		is.Equal(1, val1)
 		is.Equal(2, val2)
 		is.Equal(3, val3)
@@ -417,7 +417,7 @@ func TestJustX(t *testing.T) {
 		is.Equal(5, val5)
 		is.Equal(6, val6)
 
-		val1, val2, val3, val4, val5, val6 = Just6(1, 2, 3, 4, 5, 6, false)
+		val1, val2, val3, val4, val5, val6 = Fine6(1, 2, 3, 4, 5, 6, false)
 		is.Zero(val1)
 		is.Zero(val2)
 		is.Zero(val3)


### PR DESCRIPTION
## Summary
This PR introduces a new helper function named `EmptyOnError` along with `EmptyOnError1` to `EmptyOnError6`. These functions are designed to safely retrieve values while ignoring errors, ensuring that in the case of an error, empty values are returned instead of triggering a panic.

## Motivation
In many scenarios, developers may only be interested in retrieving a value and are willing to ignore potential errors without risking a panic. The existing `Must` helper function, while useful, panics when an error is encountered, which might not always be desirable. The `EmptyOnError` helper and its variants (`EmptyOnError1` to `EmptyOnError6`) provide a safer alternative by returning empty values in case of an error.

Unlike `Must`, which can handle zero return values, `EmptyOnError` focuses solely on the values returned by a function. Therefore, there is no `EmptyOnError0` variant, as it would be redundant.