### PR TITLE
Feat: Adding the equivalent of checking if two slices are the same

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Supported intersection helpers:
 - [ContainsBy](#containsby)
 - [Every](#every)
 - [EveryBy](#everyby)
-- [Equivalent](#equivalent)
+- [EqualUnordered](#equalunordered)
 - [Some](#some)
 - [SomeBy](#someby)
 - [None](#none)
@@ -1951,7 +1951,7 @@ b := EveryBy([]int{1, 2, 3, 4}, func(x int) bool {
 ### EqualUnordered
 
 Returns true if the subset has the same elements and the same number of each element as the collection.
-Unlike slices.Equal(), which returns effected by order, Equivalent does not care about the order of the elements.
+Unlike slices.Equal(), which returns effected by order, EqualUnordered does not care about the order of the elements.
 
 ```go
 b := EqualUnordered([]int{0, 1, 1, 3, 0, 0}, []int{0, 1, 3, 0, 1, 0})

--- a/README.md
+++ b/README.md
@@ -1948,13 +1948,13 @@ b := EveryBy([]int{1, 2, 3, 4}, func(x int) bool {
 // true
 ```
 
-### Equivalent
+### EqualUnordered
 
 Returns true if the subset has the same elements and the same number of each element as the collection.
 Unlike slices.Equal(), which returns effected by order, Equivalent does not care about the order of the elements.
 
 ```go
-b := Equivalent([]int{0, 1, 1, 3, 0, 0}, []int{0, 1, 3, 0, 1, 0})
+b := EqualUnordered([]int{0, 1, 1, 3, 0, 0}, []int{0, 1, 3, 0, 1, 0})
 // true
 ```
 

--- a/README.md
+++ b/README.md
@@ -1951,6 +1951,7 @@ b := EveryBy([]int{1, 2, 3, 4}, func(x int) bool {
 ### Equivalent
 
 Returns true if the subset has the same elements and the same number of each element as the collection.
+Unlike slices.Equal(), which returns effected by order, Equivalent does not care about the order of the elements.
 
 ```go
 b := Equivalent([]int{0, 1, 1, 3, 0, 0}, []int{0, 1, 3, 0, 1, 0})

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Supported intersection helpers:
 - [ContainsBy](#containsby)
 - [Every](#every)
 - [EveryBy](#everyby)
+- [Equivalent](#equivalent)
 - [Some](#some)
 - [SomeBy](#someby)
 - [None](#none)
@@ -1940,6 +1941,15 @@ Returns true if the predicate returns true for all of the elements in the collec
 b := EveryBy([]int{1, 2, 3, 4}, func(x int) bool {
     return x < 5
 })
+// true
+```
+
+### Equivalent
+
+Returns true if the subset has the same elements and the same number of each element as the collection.
+
+```go
+b := Equivalent([]int{0, 1, 1, 3, 0, 0}, []int{0, 1, 3, 0, 1, 0})
 // true
 ```
 

--- a/intersect.go
+++ b/intersect.go
@@ -45,7 +45,8 @@ func EveryBy[T any](collection []T, predicate func(item T) bool) bool {
 }
 
 // Equivalent Returns true if the subset has the same elements and the same number of each element as the collection.
-func Equivalent[T comparable](collection, subset []T) bool {
+// Unlike slices.Equal(), which returns effected by order, Equivalent does not care about the order of the elements.
+func Equivalent[T comparable, Slice ~[]T](collection, subset Slice) bool {
 	l := len(collection)
 	if l != len(subset) {
 		return false

--- a/intersect.go
+++ b/intersect.go
@@ -53,10 +53,8 @@ func Equivalent[T comparable, Slice ~[]T](collection, subset Slice) bool {
 	}
 
 	var m = make(map[T]int, l)
-	for i := range collection {
+	for i := 0; i < l; i++ {
 		m[collection[i]] += 1
-	}
-	for i := range subset {
 		m[subset[i]] -= 1
 	}
 	for _, v := range m {

--- a/intersect.go
+++ b/intersect.go
@@ -44,9 +44,9 @@ func EveryBy[T any](collection []T, predicate func(item T) bool) bool {
 	return true
 }
 
-// Equivalent Returns true if the subset has the same elements and the same number of each element as the collection.
-// Unlike slices.Equal(), which returns effected by order, Equivalent does not care about the order of the elements.
-func Equivalent[T comparable, Slice ~[]T](collection, subset Slice) bool {
+// EqualUnordered returns true if the subset has the same elements and the same number of each element as the collection.
+// Unlike slices.Equal(), which returns effected by order, EqualUnordered does not care about the order of the elements.
+func EqualUnordered[T comparable, Slice ~[]T](collection, subset Slice) bool {
 	l := len(collection)
 	if l != len(subset) {
 		return false

--- a/intersect.go
+++ b/intersect.go
@@ -44,6 +44,28 @@ func EveryBy[T any](collection []T, predicate func(item T) bool) bool {
 	return true
 }
 
+// Equivalent Returns true if the subset has the same elements and the same number of each element as the collection.
+func Equivalent[T comparable](collection, subset []T) bool {
+	l := len(collection)
+	if l != len(subset) {
+		return false
+	}
+
+	var m = make(map[T]int, l)
+	for i := range collection {
+		m[collection[i]] += 1
+	}
+	for i := range subset {
+		m[subset[i]] -= 1
+	}
+	for _, v := range m {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // Some returns true if at least 1 element of a subset is contained into a collection.
 // If the subset is empty Some returns false.
 func Some[T comparable](collection []T, subset []T) bool {

--- a/intersect_test.go
+++ b/intersect_test.go
@@ -84,26 +84,26 @@ func TestEveryBy(t *testing.T) {
 	is.True(result4)
 }
 
-func TestEquivalent(t *testing.T) {
+func TestEqualUnordered(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Equivalent([]int{0, 1, 2, 3, 4, 5}, []int{0, 1, 2, 3, 4, 5})
+	result1 := EqualUnordered([]int{0, 1, 2, 3, 4, 5}, []int{0, 1, 2, 3, 4, 5})
 	is.True(result1)
 
-	result2 := Equivalent([]int{2, 3, 4, 5, 0, 1}, []int{0, 1, 2, 3, 4, 5})
+	result2 := EqualUnordered([]int{2, 3, 4, 5, 0, 1}, []int{0, 1, 2, 3, 4, 5})
 	is.True(result2)
 
-	result3 := Equivalent([]int{0, 1, 1, 3, 0, 0}, []int{0, 1, 3, 0, 1, 0})
+	result3 := EqualUnordered([]int{0, 1, 1, 3, 0, 0}, []int{0, 1, 3, 0, 1, 0})
 	is.True(result3)
 
-	result4 := Equivalent([]int{0, 1, 2, 3, 4}, []int{0, 1, 2, 3, 4, 5})
+	result4 := EqualUnordered([]int{0, 1, 2, 3, 4}, []int{0, 1, 2, 3, 4, 5})
 	is.False(result4)
 
-	result5 := Equivalent([]int{0, 1, 2, 3, 4, 6}, []int{0, 1, 2, 3, 4, 5})
+	result5 := EqualUnordered([]int{0, 1, 2, 3, 4, 6}, []int{0, 1, 2, 3, 4, 5})
 	is.False(result5)
 
-	result6 := Equivalent([]int{0, 1, 1, 1, 1, 1}, []int{0, 0, 1, 1, 1, 1})
+	result6 := EqualUnordered([]int{0, 1, 1, 1, 1, 1}, []int{0, 0, 1, 1, 1, 1})
 	is.False(result6)
 }
 

--- a/intersect_test.go
+++ b/intersect_test.go
@@ -84,6 +84,29 @@ func TestEveryBy(t *testing.T) {
 	is.True(result4)
 }
 
+func TestEquivalent(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	result1 := Equivalent([]int{0, 1, 2, 3, 4, 5}, []int{0, 1, 2, 3, 4, 5})
+	is.True(result1)
+
+	result2 := Equivalent([]int{2, 3, 4, 5, 0, 1}, []int{0, 1, 2, 3, 4, 5})
+	is.True(result2)
+
+	result3 := Equivalent([]int{0, 1, 1, 3, 0, 0}, []int{0, 1, 3, 0, 1, 0})
+	is.True(result3)
+
+	result4 := Equivalent([]int{0, 1, 2, 3, 4}, []int{0, 1, 2, 3, 4, 5})
+	is.False(result4)
+
+	result5 := Equivalent([]int{0, 1, 2, 3, 4, 6}, []int{0, 1, 2, 3, 4, 5})
+	is.False(result5)
+
+	result6 := Equivalent([]int{0, 1, 1, 1, 1, 1}, []int{0, 0, 1, 1, 1, 1})
+	is.False(result6)
+}
+
 func TestSome(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)


### PR DESCRIPTION
Often, I need to compare if two slices are same in elements and count of each element. However, I have not found an existing method that accomplishes this functionality. Therefore, I have added this method.