### PR TITLE
Fix documentation for Duration3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1650,7 +1650,7 @@ err, duration := lo.Duration1(func() error {
 // an error
 // 3s
 
-err, duration := lo.Duration3(func() (string, int, error) {
+str, nbr, err, duration := lo.Duration3(func() (string, int, error) {
     // very long job
     return "hello", 42, nil
 })


### PR DESCRIPTION
Duration3 needs 4 assignments to call.

To match`TryOf` documentation,  `str, nbr, err, duration` names are used for the assignments.


ref: https://github.com/samber/lo/pull/471 ( released at https://github.com/samber/lo/releases/tag/v1.41.0 )