### PR TITLE
feat: adding FromSlicePtrNotNil

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Type manipulation helpers:
 - [ToSlicePtr](#tosliceptr)
 - [FromSlicePtr](#fromsliceptr)
 - [FromSlicePtrOr](#fromsliceptror)
+- [FromSlicePtrNotNil](#fromsliceptrnotnil)
 - [ToAnySlice](#toanyslice)
 - [FromAnySlice](#fromanyslice)
 - [Empty](#empty)
@@ -2709,8 +2710,20 @@ Returns a slice with the pointer values or the fallback value.
 str1 := "hello"
 str2 := "world"
 
-ptr := lo.FromSlicePtrOr[string]([]*string{&str1, &str2, "fallback value"})
+ptr := lo.FromSlicePtrOr[string]([]*string{&str1, &str2, nil}, "fallback value")
 // []string{"hello", "world", "fallback value"}
+```
+
+### FromSlicePtrNotNil
+
+Returns a slice with the pointer values without nil elements.
+
+```go
+str1 := "hello"
+str2 := "world"
+
+ptr := lo.FromSlicePtrNotNil[string]([]*string{&str1, &str2, nil})
+// []string{"hello", "world"}
 ```
 
 ### ToAnySlice

--- a/type_manipulation.go
+++ b/type_manipulation.go
@@ -69,13 +69,23 @@ func FromSlicePtr[T any](collection []*T) []T {
 	})
 }
 
-// FromSlicePtr returns a slice with the pointer values or the fallback value.
+// FromSlicePtrOr returns a slice with the pointer values or the fallback value.
 func FromSlicePtrOr[T any](collection []*T, fallback T) []T {
 	return Map(collection, func(x *T, _ int) T {
 		if x == nil {
 			return fallback
 		}
 		return *x
+	})
+}
+
+// FromSlicePtrNotNil returns a slice with the pointer values without nil elements.
+func FromSlicePtrNotNil[T any](collection []*T) []T {
+	return FilterMap(collection, func(x *T, _ int) (T, bool) {
+		if x == nil {
+			return Empty[T](), false
+		}
+		return *x, true
 	})
 }
 

--- a/type_manipulation_test.go
+++ b/type_manipulation_test.go
@@ -141,6 +141,16 @@ func TestFromSlicePtrOr(t *testing.T) {
 	is.Equal(result1, []string{str1, str2, "fallback"})
 }
 
+func TestFromSlicePtrNotNil(t *testing.T) {
+	is := assert.New(t)
+
+	str1 := "foo"
+	str2 := "bar"
+	result1 := FromSlicePtrNotNil([]*string{&str1, &str2, nil})
+
+	is.Equal(result1, []string{str1, str2})
+}
+
 func TestToAnySlice(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)


### PR DESCRIPTION
Maybe we could name this helper differently.

Also, we could return a boolean when at least 1 nil value is detected and dropped. (see lo.FromAnySlice)