### PR TITLE
Add nil pointer protection to ternary function

### DIFF
--- a/condition.go
+++ b/condition.go
@@ -4,10 +4,10 @@ package lo
 // Play: https://go.dev/play/p/t-D7WBL44h2
 func Ternary[T any](condition bool, ifOutput T, elseOutput T) T {
 	if condition {
-		return ifOutput
+		return func() T { return ifOutput }()
 	}
 
-	return elseOutput
+	return func() T { return elseOutput }()
 }
 
 // TernaryF is a 1 line if/else statement whose options are functions


### PR DESCRIPTION
Allows you to use `lo.Ternary` to fallback to default values when checking if a value is nil before access an attribute:

```
lo.Ternary(example != nil, example.attribute, "fallback")
```

Previously, both arguments would be evaluated which causes a nil pointer exception. Using anonymous inlined function protects against this.