### PR TITLE
Without By

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Supported intersection helpers:
 - [Union](#union)
 - [Without](#without)
 - [WithoutEmpty](#withoutempty)
+- [WithoutBy](#withoutby)
 
 Supported search helpers:
 
@@ -2104,6 +2105,22 @@ Returns slice excluding empty values.
 ```go
 subset := lo.WithoutEmpty([]int{0, 2, 10})
 // []int{2, 10}
+```
+
+### WithoutBy
+
+Returns slice excluding all values that satisfy the predicate.
+
+```go
+subset := lo.WithoutBy([]int{0, 2, 10}, func(x int) bool {
+	return x < 5
+})
+// []int{10}
+
+subset := lo.WithoutBy([]string{"a", "b", "c"}, func(x string) bool {
+	return x == "a"
+})
+// []string{"b", "c"}
 ```
 
 ### IndexOf

--- a/intersect.go
+++ b/intersect.go
@@ -176,6 +176,18 @@ func Without[T comparable, Slice ~[]T](collection Slice, exclude ...T) Slice {
 	return result
 }
 
+// WithoutBy returns slice excluding all values that satisfy the predicate.
+// The predicate function should return true if the item should be excluded.
+func WithoutBy[T any, Slice ~[]T](collection Slice, predicate func(item T) bool) Slice {
+	result := make(Slice, 0, len(collection))
+	for i := range collection {
+		if !predicate(collection[i]) {
+			result = append(result, collection[i])
+		}
+	}
+	return result
+}
+
 // WithoutEmpty returns slice excluding empty values.
 //
 // Deprecated: Use lo.Compact instead.

--- a/intersect_test.go
+++ b/intersect_test.go
@@ -270,6 +270,45 @@ func TestWithout(t *testing.T) {
 	is.IsType(nonempty, allStrings, "type preserved")
 }
 
+func TestWithoutBy(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+	// Suite of tests to ensure that the WithoutBy function works as expected
+	// Tests will cover different types of slices and different types of elements
+	// to be removed from the slice
+
+	result1 := WithoutBy([]int{0, 1, 2, 3, 4, 5}, func(i int) bool { return i < 3 })
+	result2 := WithoutBy([]int{0, 1, 2, 3, 4, 5}, func(i int) bool { return i > 3 })
+	result3 := WithoutBy([]int{0, 1, 2, 3, 4, 5}, func(i int) bool { return i == 3 })
+
+	result4 := WithoutBy([]string{"foo", "bar", "baz"}, func(s string) bool { return s == "foo" })
+	result5 := WithoutBy([]string{"foo", "bar", "baz"}, func(s string) bool { return s == "bar" })
+	result6 := WithoutBy([]string{"foo", "bar", "baz"}, func(s string) bool { return s == "baz" })
+
+	result7 := WithoutBy([]bool{true, false, true}, func(b bool) bool { return b })
+	result8 := WithoutBy([]bool{true, false, true}, func(b bool) bool { return !b })
+
+	result9 := WithoutBy([]float64{1.1, 2.2, 3.3}, func(f float64) bool { return f == 1.1 })
+	result10 := WithoutBy([]float64{1.1, 2.2, 3.3}, func(f float64) bool { return f == 2.2 })
+	result11 := WithoutBy([]float64{1.1, 2.2, 3.3}, func(f float64) bool { return f == 3.3 })
+
+	is.Equal(result1, []int{3, 4, 5})
+	is.Equal(result2, []int{0, 1, 2, 3})
+	is.Equal(result3, []int{0, 1, 2, 4, 5})
+
+	is.Equal(result4, []string{"bar", "baz"})
+	is.Equal(result5, []string{"foo", "baz"})
+	is.Equal(result6, []string{"foo", "bar"})
+
+	is.Equal(result7, []bool{false})
+	is.Equal(result8, []bool{true, true})
+
+	is.Equal(result9, []float64{2.2, 3.3})
+	is.Equal(result10, []float64{1.1, 3.3})
+	is.Equal(result11, []float64{1.1, 2.2})
+
+}
+
 func TestWithoutEmpty(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)


### PR DESCRIPTION
# Without By

Resolves #505 

## Description

The `WithoutBy` function filters a slice of elements based on a given predicate function. It returns a new slice containing only the elements for which the predicate function returns false. 

## Examples

### Filtering unverified users

```go
func isValidEmail(email string) bool {
        // Basic email validation using regular expression
        emailRegex := regexp.MustCompile(`^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$`)
        return emailRegex.MatchString(email)
}

func cleanUserList(users []User) []User {
        return WithoutBy(users, func(u User) bool { return !isValidEmail(u.Email) })
}
```

### Filtering even numbers

```go
func isEven(num int) bool {
        return num%2 == 0
}

func removeEven(numbers []int) []int {
        return WithoutBy(numbers, isEven)
}
```

