### PR TITLE
Remove redundant params of Filter, Map, FilterMap and FlatMap

### DIFF
--- a/map_benchmark_test.go
+++ b/map_benchmark_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
-	lop "github.com/samber/lo/parallel"
 	"github.com/thoas/go-funk"
+
+	lop "github.com/samber/lo/parallel"
 )
 
 func sliceGenerator(size uint) []int64 {
@@ -39,7 +40,7 @@ func BenchmarkMap(b *testing.B) {
 
 	b.Run("lo.Map", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_ = Map(arr, func(x int64, i int) string {
+			_ = Map(arr, func(x int64) string {
 				return strconv.FormatInt(x, 10)
 			})
 		}

--- a/slice.go
+++ b/slice.go
@@ -8,12 +8,12 @@ import (
 )
 
 // Filter iterates over elements of collection, returning an array of all elements predicate returns truthy for.
-// Play: https://go.dev/play/p/Apjg3WeSi7K
-func Filter[T any, Slice ~[]T](collection Slice, predicate func(item T, index int) bool) Slice {
+// Play: https://go.dev/play/p/iz6z5ugFGOU
+func Filter[T any, Slice ~[]T](collection Slice, predicate func(item T) bool) Slice {
 	result := make(Slice, 0, len(collection))
 
 	for i := range collection {
-		if predicate(collection[i], i) {
+		if predicate(collection[i]) {
 			result = append(result, collection[i])
 		}
 	}
@@ -22,12 +22,12 @@ func Filter[T any, Slice ~[]T](collection Slice, predicate func(item T, index in
 }
 
 // Map manipulates a slice and transforms it to a slice of another type.
-// Play: https://go.dev/play/p/OkPcYAhBo0D
-func Map[T any, R any](collection []T, iteratee func(item T, index int) R) []R {
+// Play: https://go.dev/play/p/WAbWdruxOX7
+func Map[T any, R any](collection []T, iteratee func(item T) R) []R {
 	result := make([]R, len(collection))
 
 	for i := range collection {
-		result[i] = iteratee(collection[i], i)
+		result[i] = iteratee(collection[i])
 	}
 
 	return result
@@ -38,12 +38,12 @@ func Map[T any, R any](collection []T, iteratee func(item T, index int) R) []R {
 //   - the result of the mapping operation and
 //   - whether the result element should be included or not.
 //
-// Play: https://go.dev/play/p/-AuYXfy7opz
-func FilterMap[T any, R any](collection []T, callback func(item T, index int) (R, bool)) []R {
+// Play: https://go.dev/play/p/KUc8OqUYIyI
+func FilterMap[T any, R any](collection []T, callback func(item T) (R, bool)) []R {
 	result := []R{}
 
 	for i := range collection {
-		if r, ok := callback(collection[i], i); ok {
+		if r, ok := callback(collection[i]); ok {
 			result = append(result, r)
 		}
 	}
@@ -54,12 +54,12 @@ func FilterMap[T any, R any](collection []T, callback func(item T, index int) (R
 // FlatMap manipulates a slice and transforms and flattens it to a slice of another type.
 // The transform function can either return a slice or a `nil`, and in the `nil` case
 // no value is added to the final slice.
-// Play: https://go.dev/play/p/YSoYmQTA8-U
-func FlatMap[T any, R any](collection []T, iteratee func(item T, index int) []R) []R {
+// https://go.dev/play/p/NZ1V0KfQuJA
+func FlatMap[T any, R any](collection []T, iteratee func(item T) []R) []R {
 	result := make([]R, 0, len(collection))
 
 	for i := range collection {
-		result = append(result, iteratee(collection[i], i)...)
+		result = append(result, iteratee(collection[i])...)
 	}
 
 	return result

--- a/slice_example_test.go
+++ b/slice_example_test.go
@@ -9,7 +9,7 @@ import (
 func ExampleFilter() {
 	list := []int64{1, 2, 3, 4}
 
-	result := Filter(list, func(nbr int64, index int) bool {
+	result := Filter(list, func(nbr int64) bool {
 		return nbr%2 == 0
 	})
 
@@ -20,7 +20,7 @@ func ExampleFilter() {
 func ExampleMap() {
 	list := []int64{1, 2, 3, 4}
 
-	result := Map(list, func(nbr int64, index int) string {
+	result := Map(list, func(nbr int64) string {
 		return strconv.FormatInt(nbr*2, 10)
 	})
 
@@ -31,7 +31,7 @@ func ExampleMap() {
 func ExampleFilterMap() {
 	list := []int64{1, 2, 3, 4}
 
-	result := FilterMap(list, func(nbr int64, index int) (string, bool) {
+	result := FilterMap(list, func(nbr int64) (string, bool) {
 		return strconv.FormatInt(nbr*2, 10), nbr%2 == 0
 	})
 
@@ -42,7 +42,7 @@ func ExampleFilterMap() {
 func ExampleFlatMap() {
 	list := []int64{1, 2, 3, 4}
 
-	result := FlatMap(list, func(nbr int64, index int) []string {
+	result := FlatMap(list, func(nbr int64) []string {
 		return []string{
 			strconv.FormatInt(nbr, 10), // base 10
 			strconv.FormatInt(nbr, 2),  // base 2

--- a/slice_test.go
+++ b/slice_test.go
@@ -15,19 +15,19 @@ func TestFilter(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := Filter([]int{1, 2, 3, 4}, func(x int, _ int) bool {
+	r1 := Filter([]int{1, 2, 3, 4}, func(x int) bool {
 		return x%2 == 0
 	})
 	is.Equal(r1, []int{2, 4})
 
-	r2 := Filter([]string{"", "foo", "", "bar", ""}, func(x string, _ int) bool {
+	r2 := Filter([]string{"", "foo", "", "bar", ""}, func(x string) bool {
 		return len(x) > 0
 	})
 	is.Equal(r2, []string{"foo", "bar"})
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
-	nonempty := Filter(allStrings, func(x string, _ int) bool {
+	nonempty := Filter(allStrings, func(x string) bool {
 		return len(x) > 0
 	})
 	is.IsType(nonempty, allStrings, "type preserved")
@@ -37,10 +37,10 @@ func TestMap(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Map([]int{1, 2, 3, 4}, func(x int, _ int) string {
+	result1 := Map([]int{1, 2, 3, 4}, func(x int) string {
 		return "Hello"
 	})
-	result2 := Map([]int64{1, 2, 3, 4}, func(x int64, _ int) string {
+	result2 := Map([]int64{1, 2, 3, 4}, func(x int64) string {
 		return strconv.FormatInt(x, 10)
 	})
 
@@ -54,13 +54,13 @@ func TestFilterMap(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := FilterMap([]int64{1, 2, 3, 4}, func(x int64, _ int) (string, bool) {
+	r1 := FilterMap([]int64{1, 2, 3, 4}, func(x int64) (string, bool) {
 		if x%2 == 0 {
 			return strconv.FormatInt(x, 10), true
 		}
 		return "", false
 	})
-	r2 := FilterMap([]string{"cpu", "gpu", "mouse", "keyboard"}, func(x string, _ int) (string, bool) {
+	r2 := FilterMap([]string{"cpu", "gpu", "mouse", "keyboard"}, func(x string) (string, bool) {
 		if strings.HasSuffix(x, "pu") {
 			return "xpu", true
 		}
@@ -77,10 +77,10 @@ func TestFlatMap(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := FlatMap([]int{0, 1, 2, 3, 4}, func(x int, _ int) []string {
+	result1 := FlatMap([]int{0, 1, 2, 3, 4}, func(x int) []string {
 		return []string{"Hello"}
 	})
-	result2 := FlatMap([]int64{0, 1, 2, 3, 4}, func(x int64, _ int) []string {
+	result2 := FlatMap([]int64{0, 1, 2, 3, 4}, func(x int64) []string {
 		result := make([]string, 0, x)
 		for i := int64(0); i < x; i++ {
 			result = append(result, strconv.FormatInt(x, 10))

--- a/type_manipulation.go
+++ b/type_manipulation.go
@@ -61,7 +61,7 @@ func ToSlicePtr[T any](collection []T) []*T {
 // FromSlicePtr returns a slice with the pointer values.
 // Returns a zero value in case of a nil pointer element.
 func FromSlicePtr[T any](collection []*T) []T {
-	return Map(collection, func(x *T, _ int) T {
+	return Map(collection, func(x *T) T {
 		if x == nil {
 			return Empty[T]()
 		}
@@ -71,7 +71,7 @@ func FromSlicePtr[T any](collection []*T) []T {
 
 // FromSlicePtrOr returns a slice with the pointer values or the fallback value.
 func FromSlicePtrOr[T any](collection []*T, fallback T) []T {
-	return Map(collection, func(x *T, _ int) T {
+	return Map(collection, func(x *T) T {
 		if x == nil {
 			return fallback
 		}


### PR DESCRIPTION
There's no need to declare an `int index` without any usage. 
Since these internal functions won't receive the slice itself, the index won't be able to be used to obtain the items.