### PR TITLE
docs: clarify `Empty` returns zero value

### DIFF
--- a/README.md
+++ b/README.md
@@ -2099,7 +2099,7 @@ subset := lo.Without([]int{0, 2, 10}, 0, 1, 2, 3, 4, 5)
 
 ### WithoutEmpty
 
-Returns slice excluding empty values.
+Returns slice excluding zero values.
 
 ```go
 subset := lo.WithoutEmpty([]int{0, 2, 10})
@@ -2788,7 +2788,7 @@ elements, ok := lo.FromAnySlice([]any{"foobar", "42"})
 
 ### Empty
 
-Returns an empty value.
+Returns the [zero value](https://go.dev/ref/spec#The_zero_value).
 
 ```go
 lo.Empty[int]()

--- a/intersect.go
+++ b/intersect.go
@@ -176,7 +176,7 @@ func Without[T comparable, Slice ~[]T](collection Slice, exclude ...T) Slice {
 	return result
 }
 
-// WithoutEmpty returns slice excluding empty values.
+// WithoutEmpty returns slice excluding zero values.
 //
 // Deprecated: Use lo.Compact instead.
 func WithoutEmpty[T comparable, Slice ~[]T](collection Slice) Slice {

--- a/type_manipulation.go
+++ b/type_manipulation.go
@@ -106,7 +106,7 @@ func FromAnySlice[T any](in []any) (out []T, ok bool) {
 	return result, true
 }
 
-// Empty returns an empty value.
+// Empty returns the zero value (https://go.dev/ref/spec#The_zero_value).
 func Empty[T any]() T {
 	var zero T
 	return zero

--- a/type_manipulation_test.go
+++ b/type_manipulation_test.go
@@ -180,6 +180,8 @@ func TestEmpty(t *testing.T) {
 	is.Empty(Empty[int64]())
 	is.Empty(Empty[test]())
 	is.Empty(Empty[chan string]())
+	is.Nil(Empty[[]int]())
+	is.Nil(Empty[map[string]int]())
 }
 
 func TestIsEmpty(t *testing.T) {


### PR DESCRIPTION
https://go.dev/ref/spec#The_zero_value does not define “empty value”. It informally mentions “empty value”, meaning (non-nil && 0-length) slice or map.

> Note that the zero value for a slice or map type is not the same as an initialized but empty value of the same type.