### PR TITLE
feat: add In function

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Supported helpers for slices:
 - [IsSorted](#issorted)
 - [IsSortedByKey](#issortedbykey)
 - [Splice](#Splice)
+- [In](#In)
 
 Supported helpers for maps:
 
@@ -1040,6 +1041,21 @@ result = lo.Splice([]string{"a", "b"}, 42, "1", "2")
 ```
 
 [[play](https://go.dev/play/p/G5_GhkeSUBA)]
+
+### In
+
+Checks if an element exists in the collection. It returns true if the element is found; otherwise, false.
+
+```go
+result := lo.In([]int{1, 2, 3, 4, 5}, 4)
+// true
+
+result = lo.In([]string{"a", "b"}, "c")
+// false
+
+```
+
+[[play](https://go.dev/play/p/h2sv3kXnucy)]
 
 ### Keys
 

--- a/slice.go
+++ b/slice.go
@@ -693,3 +693,16 @@ func Splice[T any, Slice ~[]T](collection Slice, i int, elements ...T) Slice {
 
 	return append(append(append(output, collection[:i]...), elements...), collection[i:]...)
 }
+
+// In checks if an element (needle) exists in the collection.
+// It returns true if the needle is found; otherwise, false.
+// Play: https://go.dev/play/p/h2sv3kXnucy
+func In[T comparable, Slice ~[]T](collection Slice, needle T) bool {
+	for _, element := range collection {
+		if element == needle {
+			return true
+		}
+	}
+
+	return false
+}

--- a/slice_test.go
+++ b/slice_test.go
@@ -1029,3 +1029,26 @@ func TestSplice(t *testing.T) {
 	nonempty := Splice(allStrings, 1, "1", "2")
 	is.IsType(nonempty, allStrings, "type preserved")
 }
+
+func TestIn(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	result1 := In([]int{0, 1, 2, 3, 4, 5}, 3)
+	is.True(result1)
+
+	result2 := In([]int{0, 1, 2, 3, 4, 5}, 6)
+	is.False(result2)
+
+	result3 := In([]float32{0.1, 1.1, 2.4, 3.6, 4.9}, 4.9)
+	is.True(result3)
+
+	result4 := In([]float32{0.1, 1.1, 2.4, 3.6, 4.9}, 7.9)
+	is.False(result4)
+
+	result5 := In([]string{"a", "b", "c"}, "b")
+	is.True(result5)
+
+	result6 := In([]string{"a", "b", "c"}, "d")
+	is.False(result6)
+}


### PR DESCRIPTION
**Introduce `In` function for element existence check in a collection**

Checks if an element exists in the collection. It returns true if the element is found; otherwise, false.

```go
result := lo.In([]int{1, 2, 3, 4, 5}, 4)
// true

result = lo.In([]string{"a", "b"}, "c")
// false

```

> Note: This can be done using existing `lo.Count([]int{1, 5, 1}, 1)>0` or using `lo.CountBy`

**The `In` function offers several advantages:**
- Readability and Intent:  The `In` function explicitly states its purpose of checking for element existence, making the code easier to understand.
- Performance: The`In` function returns immediately upon finding the first match, while the Count function iterates through the entire collection even if it finds a match early. This can lead to unnecessary iterations, especially in large collections
- Return Value: The `In` function returns a boolean, which is a straightforward answer to the question of whether the element exists. In contrast, Count returns a count, which is more information than needed for a simple existence check.