### PR TITLE
feat(find): implement maxn & minn for variadic count items

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,10 +223,12 @@ Supported search helpers:
 - [FindDuplicates](#findduplicates)
 - [FindDuplicatesBy](#findduplicatesby)
 - [Min](#min)
+- [MinN](#minn)
 - [MinBy](#minby)
 - [Earliest](#earliest)
 - [EarliestBy](#earliestby)
 - [Max](#max)
+- [MaxN](#maxn)
 - [MaxBy](#maxby)
 - [Latest](#latest)
 - [LatestBy](#latestby)
@@ -2285,6 +2287,23 @@ min := lo.Min([]time.Duration{time.Second, time.Hour})
 // 1s
 ```
 
+### MinN
+
+Search the minimum value of arbitrary number params.
+
+Returns zero value when the no param are given.
+
+```go
+min := lo.MinN(1, 2, 3)
+// 1
+
+min := lo.Min([]int{}...)
+// 0
+
+min := lo.Min(time.Second, time.Hour...)
+// 1s
+```
+
 ### MinBy
 
 Search the minimum value of a collection using the given comparison function.
@@ -2349,6 +2368,25 @@ max := lo.Max([]int{})
 max := lo.Max([]time.Duration{time.Second, time.Hour})
 // 1h
 ```
+
+### MaxN
+
+Search the maximum value of arbitrary number params.
+
+Returns zero value when the no param are given.
+
+```go
+max := lo.MaxN(1, 2, 3)
+// 3
+
+max := lo.MaxN([]int{}...)
+// 0
+
+max := lo.MaxN(time.Second, time.Hour)
+// 1h
+```
+
+
 
 ### MaxBy
 

--- a/find.go
+++ b/find.go
@@ -241,8 +241,8 @@ func Min[T constraints.Ordered](collection []T) T {
 	return min
 }
 
-// MinN searches the minimum value from varidical items.
-// Returns zero value when the no items are given.
+// MinN search the minimum value of arbitrary number params.
+// returns zero value when the no param are given.
 func MinN[T constraints.Ordered](items ...T) T {
 	return Min(items)
 }
@@ -338,8 +338,8 @@ func Max[T constraints.Ordered](collection []T) T {
 	return max
 }
 
-// MaxN searches the maximum value from varidical items.
-// Returns zero value when the no items are given.
+// MinN searches the maximum value of arbitrary number params.
+// returns zero value when the no param are given.
 func MaxN[T constraints.Ordered](items ...T) T {
 	return Max(items)
 }

--- a/find.go
+++ b/find.go
@@ -241,6 +241,12 @@ func Min[T constraints.Ordered](collection []T) T {
 	return min
 }
 
+// MinN searches the minimum value from varidical items.
+// Returns zero value when the no items are given.
+func MinN[T constraints.Ordered](items ...T) T {
+	return Min(items)
+}
+
 // MinBy search the minimum value of a collection using the given comparison function.
 // If several values of the collection are equal to the smallest value, returns the first such value.
 // Returns zero value when the collection is empty.
@@ -330,6 +336,12 @@ func Max[T constraints.Ordered](collection []T) T {
 	}
 
 	return max
+}
+
+// MaxN searches the maximum value from varidical items.
+// Returns zero value when the no items are given.
+func MaxN[T constraints.Ordered](items ...T) T {
+	return Max(items)
 }
 
 // MaxBy search the maximum value of a collection using the given comparison function.

--- a/find_test.go
+++ b/find_test.go
@@ -302,6 +302,16 @@ func TestMin(t *testing.T) {
 	is.Equal(result2, 1)
 	is.Equal(result3, time.Second)
 	is.Equal(result4, 0)
+
+	result1 = MinN(1, 2, 3)
+	result2 = MinN(3, 2, 1)
+	result3 = MinN(time.Second, time.Minute, time.Hour)
+	result4 = MinN([]int{}...)
+
+	is.Equal(result1, 1)
+	is.Equal(result2, 1)
+	is.Equal(result3, time.Second)
+	is.Equal(result4, 0)
 }
 
 func TestMinBy(t *testing.T) {
@@ -370,6 +380,16 @@ func TestMax(t *testing.T) {
 	result2 := Max([]int{3, 2, 1})
 	result3 := Max([]time.Duration{time.Second, time.Minute, time.Hour})
 	result4 := Max([]int{})
+
+	is.Equal(result1, 3)
+	is.Equal(result2, 3)
+	is.Equal(result3, time.Hour)
+	is.Equal(result4, 0)
+
+	result1 = MaxN(1, 2, 3)
+	result2 = MaxN(3, 2, 1)
+	result3 = MaxN(time.Second, time.Minute, time.Hour)
+	result4 = MaxN([]int{}...)
 
 	is.Equal(result1, 3)
 	is.Equal(result2, 3)


### PR DESCRIPTION
After reviewing code in issue #224,I implemented a version in more convenient way, I do not agree to change the interface, because the interface of the base library once opened to change will cause a lot of dissatisfaction.

```go
func MaxN[T constraints.Ordered](items ...T) T {
	return Max(items)
}

func MinN[T constraints.Ordered](items ...T) T {
	return Min(items)
}
```