### PR TITLE
feat(func): add `FuncWithIndex` and `FuncWithIndexNoReturn`

### DIFF
--- a/func.go
+++ b/func.go
@@ -39,3 +39,15 @@ func Partial5[T1, T2, T3, T4, T5, T6, R any](f func(T1, T2, T3, T4, T5, T6) R, a
 		return f(arg1, t2, t3, t4, t5, t6)
 	}
 }
+
+func FuncWithIndexNoReturn[T any](f func(T)) func(T, int) {
+	return func(v T, _ int) {
+		f(v)
+	}
+}
+
+func FuncWithIndex[T any, U any](f func(T) U) func(T, int) U {
+	return func(v T, _ int) U {
+		return f(v)
+	}
+}

--- a/func_test.go
+++ b/func_test.go
@@ -78,3 +78,25 @@ func TestPartial5(t *testing.T) {
 	is.Equal("26", f(10, 9, -3, 0, 5))
 	is.Equal("21", f(-5, 8, 7, -1, 7))
 }
+
+func TestFuncWithIndexNoReturn(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	var result string
+	f := FuncWithIndexNoReturn(func(x string) {
+		result = x
+	})
+	f("lo", 0)
+	is.Equal("lo", result)
+}
+
+func TestFuncWithIndex(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	f := FuncWithIndex(func(x string) string {
+		return x
+	})
+	is.Equal("lo", f("lo", 0))
+}


### PR DESCRIPTION
Hey! I regularly write some functions that I pass to `lo.Map` and it's a hassle to have to pass the index every time.

Currently:
```go
lo.Map(slice, func (v string, _ int) string {
	return doThing(v)
})
```

With the PR:
```go
lo.Map(slice, lo.FuncWithIndex(doThing))
```

I'm not sure about the naming, it could simply be `WithIndex`.

I hope you like the idea.