### PR TITLE
Perf(slice): Optimize iteration function parameters and add test cases

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -38,8 +38,8 @@ func UniqMap[T any, R comparable](collection []T, iteratee func(item T, index in
 	result := make([]R, 0, len(collection))
 	seen := make(map[R]struct{}, len(collection))
 
-	for i, item := range collection {
-		r := iteratee(item, i)
+	for i := range collection {
+		r := iteratee(collection[i], i)
 		if _, ok := seen[r]; !ok {
 			result = append(result, r)
 			seen[r] = struct{}{}
@@ -189,11 +189,12 @@ func GroupBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee func(it
 }
 
 // GroupByMap returns an object composed of keys generated from the results of running each element of collection through iteratee.
-func GroupByMap[T any, K comparable, V any](arr []T, iteratee func(item T) (K, V)) map[K][]V {
+func GroupByMap[T any, K comparable, V any](collection []T, iteratee func(item T) (K, V)) map[K][]V {
 	result := map[K][]V{}
 
-	for _, item := range arr {
-		k, v := iteratee(item)
+	for i := range collection {
+		k, v := iteratee(collection[i])
+
 		result[k] = append(result[k], v)
 	}
 
@@ -420,8 +421,8 @@ func FilterSliceToMap[T any, K comparable, V any](collection []T, transform func
 func Keyify[T comparable, Slice ~[]T](collection Slice) map[T]struct{} {
 	result := make(map[T]struct{}, len(collection))
 
-	for _, item := range collection {
-		result[item] = struct{}{}
+	for i := range collection {
+		result[collection[i]] = struct{}{}
 	}
 
 	return result

--- a/slice_test.go
+++ b/slice_test.go
@@ -268,6 +268,41 @@ func TestGroupByMap(t *testing.T) {
 		1: {"1", "4"},
 		2: {"2", "5"},
 	})
+
+	type myInt int
+	type myInts []myInt
+	result2 := GroupByMap(myInts{1, 0, 2, 3, 4, 5}, func(i myInt) (int, string) {
+		return int(i % 3), strconv.Itoa(int(i))
+	})
+
+	is.Equal(len(result2), 3)
+	is.Equal(result2, map[int][]string{
+		0: {"0", "3"},
+		1: {"1", "4"},
+		2: {"2", "5"},
+	})
+
+	type product struct {
+		ID         int64
+		CategoryID int64
+	}
+	products := []product{
+		{ID: 1, CategoryID: 1},
+		{ID: 2, CategoryID: 1},
+		{ID: 3, CategoryID: 2},
+		{ID: 4, CategoryID: 3},
+		{ID: 5, CategoryID: 3},
+	}
+	result3 := GroupByMap(products, func(item product) (int64, string) {
+		return item.CategoryID, "Product " + strconv.FormatInt(item.ID, 10)
+	})
+
+	is.Equal(len(result3), 3)
+	is.Equal(result3, map[int64][]string{
+		1: {"Product 1", "Product 2"},
+		2: {"Product 3"},
+		3: {"Product 4", "Product 5"},
+	})
 }
 
 func TestChunk(t *testing.T) {


### PR DESCRIPTION
- Modify the iteration function parameters in the `UniqueBy`, `GroupByMap`, and `Keyify` functions to use index access for collection elements. See: #428 #475 
- Optimize parameter naming in the `GroupByMap` function to improve code readability. See: #443 
- Add test cases for the `GroupByMap` function to cover different types of inputs. See: #443 