### PR TITLE
docs: modify mutable.shuffle example code and Go Playground links

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,11 +670,14 @@ Returns an array of shuffled values. Uses the Fisher-Yates shuffle algorithm.
 ```go
 import lom "github.com/samber/lo/mutable"
 
-randomOrder := lom.Shuffle([]int{0, 1, 2, 3, 4, 5})
+list := []int{0, 1, 2, 3, 4, 5}
+lom.Shuffle(list)
+
+list
 // []int{1, 4, 0, 3, 5, 2}
 ```
 
-[[play](https://go.dev/play/p/ZTGG7OUCdnp)]
+[[play](https://go.dev/play/p/2xb3WdLjeSJ)]
 
 ### Reverse
 
@@ -692,7 +695,7 @@ list
 // []int{5, 4, 3, 2, 1, 0}
 ```
 
-[[play](https://go.dev/play/p/iv2e9jslfBM)]
+[[play](https://go.dev/play/p/O-M5pmCRgzV)]
 
 ### Fill
 

--- a/mutable/slice.go
+++ b/mutable/slice.go
@@ -3,7 +3,7 @@ package mutable
 import "github.com/samber/lo/internal/rand"
 
 // Shuffle returns an array of shuffled values. Uses the Fisher-Yates shuffle algorithm.
-// Play: https://go.dev/play/p/ZTGG7OUCdnp
+// Play: https://go.dev/play/p/2xb3WdLjeSJ
 func Shuffle[T any, Slice ~[]T](collection Slice) {
 	rand.Shuffle(len(collection), func(i, j int) {
 		collection[i], collection[j] = collection[j], collection[i]
@@ -11,7 +11,7 @@ func Shuffle[T any, Slice ~[]T](collection Slice) {
 }
 
 // Reverse reverses array so that the first element becomes the last, the second element becomes the second to last, and so on.
-// Play: https://go.dev/play/p/iv2e9jslfBM
+// Play: https://go.dev/play/p/O-M5pmCRgzV
 func Reverse[T any, Slice ~[]T](collection Slice) {
 	length := len(collection)
 	half := length / 2


### PR DESCRIPTION
Replaced the lom.Shuffle usage example and GO Playground code that was incorrect.
(`Shuffle` Playground was a compile error, `Reverse` Playground was old code using lo package)