### PR TITLE
feat: add EnsureNotNilPtr

### DIFF
--- a/type_manipulation.go
+++ b/type_manipulation.go
@@ -53,6 +53,15 @@ func FromPtrOr[T any](x *T, fallback T) T {
 	return *x
 }
 
+// EnsureNotNilPtr returns a pointer that is not nil.
+// When given a nil pointer, a pointer to the zero value is returned.
+func EnsureNotNilPtr[T any](x *T) *T {
+	if x == nil {
+		return new(T)
+	}
+	return x
+}
+
 // ToSlicePtr returns a slice of pointer copy of value.
 func ToSlicePtr[T any](collection []T) []*T {
 	result := make([]*T, len(collection))

--- a/type_manipulation_test.go
+++ b/type_manipulation_test.go
@@ -134,6 +134,17 @@ func TestFromPtrOr(t *testing.T) {
 	is.Equal(fallbackInt, FromPtrOr(nil, fallbackInt))
 }
 
+func TestEnsureNotNilPtr(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	num := 42
+	var nilPtr *string
+
+	is.Equal(&num, EnsureNotNilPtr(&num))
+	is.Equal(new(string), EnsureNotNilPtr(nilPtr))
+}
+
 func TestToSlicePtr(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)


### PR DESCRIPTION
First of thanks for this library!

While working on math with optional fields generated by go-swagger (e.g. `*int`) I wrote this `EnsureNotNilPtr` helper, it's roughly equivalent to this:
```go
ptr = lo.ToPtr(lo.FromPtr(ptr))
```
If you feel like it belongs here have at it.
I'm not fully convinced by the function's name and documentation though, so I'll welcome any suggestions!