### PR TITLE
docs: fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4052,7 +4052,7 @@ ok  	github.com/samber/lo	6.657s
 ```
 
 - `lo.Map` is way faster (x7) than `go-funk`, a reflection-based Map implementation.
-- `lo.Map` have the same allocation profile than `for`.
+- `lo.Map` has the same allocation profile as `for`.
 - `lo.Map` is 4% slower than `for`.
 - `lop.Map` is slower than `lo.Map` because it implies more memory allocation and locks. `lop.Map` will be useful for long-running callbacks, such as i/o bound processing.
 - `for` beats other implementations for memory and CPU.


### PR DESCRIPTION
The change corrects a grammatical error in the description of `lo.Map`. 

Corrected "have" to "has" and "than" to "as" in the sentence describing the allocation profile of `lo.Map`.