### PR TITLE
Preallocate result in FilterMap

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -55,7 +55,7 @@ func UniqMap[T any, R comparable](collection []T, iteratee func(item T, index in
 //
 // Play: https://go.dev/play/p/-AuYXfy7opz
 func FilterMap[T any, R any](collection []T, callback func(item T, index int) (R, bool)) []R {
-	result := []R{}
+	result := make([]R, 0, len(collection))
 
 	for i := range collection {
 		if r, ok := callback(collection[i], i); ok {


### PR DESCRIPTION
Filter / Map already preallocate the result slice, don't see why FilterMap shouldn't work the same way