### PR TITLE
Fixed the error in the usage example of lo.Latest in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2773,7 +2773,7 @@ Search the maximum time.Time of a collection.
 Returns zero value when the collection is empty.
 
 ```go
-latest := lo.Latest([]time.Time{time.Now(), time.Time{}})
+latest := lo.Latest([]time.Time{time.Now(), time.Time{}}...)
 // 2023-04-01 01:02:03 +0000 UTC
 ```
 

--- a/README.md
+++ b/README.md
@@ -2773,7 +2773,7 @@ Search the maximum time.Time of a collection.
 Returns zero value when the collection is empty.
 
 ```go
-latest := lo.Latest([]time.Time{time.Now(), time.Time{}}...)
+latest := lo.Latest(time.Now(), time.Time{})
 // 2023-04-01 01:02:03 +0000 UTC
 ```
 


### PR DESCRIPTION
Fixed the error in the usage example of `lo.Latest` in readme.md

```go
use []time.Time{…} (value of type []time.Time) as time.Time value in argument to lo.Latest
```