### PR TITLE
add FilterKeys for map

### DIFF
--- a/map.go
+++ b/map.go
@@ -342,3 +342,17 @@ func FilterMapToSlice[K comparable, V any, R any](in map[K]V, iteratee func(key 
 
 	return result
 }
+
+// FilterKeys transforms a map into a slice based on predicate returns truthy for specific elements.
+// Play: https://go.dev/play/p/OFlKXlPrBAe
+func FilterKeys[K comparable, V any](in map[K]V, predicate func(key K, value V) bool) []V {
+	result := make([]V, 0)
+
+	for k := range in {
+		if predicate(k, in[k]) {
+			result = append(result, in[k])
+		}
+	}
+
+	return result
+}

--- a/map_test.go
+++ b/map_test.go
@@ -530,6 +530,23 @@ func TestFilterMapToSlice(t *testing.T) {
 	is.ElementsMatch(result2, []string{"2", "4"})
 }
 
+func TestFilterKeys(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	result1 := FilterKeys(map[int]string{1: "foo", 2: "bar", 3: "baz"}, func(k int, v string) bool {
+		return v == "foo"
+	})
+	is.Equal([]string{"foo"}, result1)
+	is.Len(result1, 1)
+
+	result2 := FilterKeys(map[string]int{"foo": 1, "bar": 2, "baz": 3}, func(k string, v int) bool {
+		return false
+	})
+	is.Equal([]int{}, result2)
+	is.Len(result2, 0)
+}
+
 func BenchmarkAssign(b *testing.B) {
 	counts := []int{32768, 1024, 128, 32, 2}
 


### PR DESCRIPTION
Added FilterKeys transforms a map into a slice based on predicate returns truthy for specific elements.

Solves https://github.com/samber/lo/issues/614


from PR: https://github.com/samber/lo/pull/615