### PR TITLE
docs: fix wrong variable name for mutable map example

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ import lom "github.com/samber/lo/mutable"
 
 list := []int{1, 2, 3, 4}
 lom.Map(list, func(x int) int {
-    return i*2
+    return x*2
 })
 // []int{2, 4, 6, 8}
 ```


### PR DESCRIPTION
Change wrong variable name `i` -> `x` for mutable map example.