### PR TITLE
Add Clone function to return shallow copy of slice collections

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -682,6 +682,11 @@ func ReplaceAll[T comparable, Slice ~[]T](collection Slice, old T, new T) Slice 
 	return Replace(collection, old, new, -1)
 }
 
+// Clone returns a shallow copy of the collection.
+func Clone[T any](collection []T) []T {
+	return append(collection[:0:0], collection...)
+}
+
 // Compact returns a slice of all non-zero elements.
 // Play: https://go.dev/play/p/tXiy-iK6PAc
 func Compact[T comparable, Slice ~[]T](collection Slice) Slice {

--- a/slice_example_test.go
+++ b/slice_example_test.go
@@ -518,6 +518,15 @@ func ExampleReplaceAll() {
 	// Output: [foo bar]
 }
 
+func ExampleClone() {
+	list := []int{1, 2, 3, 4, 5}
+
+	result := Clone(list)
+
+	fmt.Printf("%v", result)
+	// Output: [1 2 3 4 5]
+}
+
 func ExampleIsSorted() {
 	list := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 

--- a/slice_test.go
+++ b/slice_test.go
@@ -1019,6 +1019,44 @@ func TestReplaceAll(t *testing.T) {
 	is.IsType(nonempty, allStrings, "type preserved")
 }
 
+func TestClone(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	// Test with int slice
+	original1 := []int{1, 2, 3, 4, 5}
+	result1 := Clone(original1)
+	is.Equal(result1, []int{1, 2, 3, 4, 5})
+
+	// Verify it's a different slice by checking that modifying one doesn't affect the other
+	original1[0] = 99
+	is.Equal(original1, []int{99, 2, 3, 4, 5})
+	is.Equal(result1, []int{1, 2, 3, 4, 5})
+
+	// Test with string slice
+	original2 := []string{"a", "b", "c"}
+	result2 := Clone(original2)
+	is.Equal(result2, []string{"a", "b", "c"})
+
+	// Test with empty slice
+	original3 := []int{}
+	result3 := Clone(original3)
+	is.Equal(result3, []int{})
+	is.Equal(len(result3), 0)
+
+	// Test with nil slice
+	var original4 []int
+	result4 := Clone(original4)
+	is.Nil(result4)
+
+	// Verify shallow copy behavior - modifying clone doesn't affect original
+	original5 := []int{1, 2, 3}
+	result5 := Clone(original5)
+	result5[0] = 99
+	is.Equal(original5, []int{1, 2, 3}) // Original unchanged
+	is.Equal(result5, []int{99, 2, 3})  // Clone changed
+}
+
 func TestCompact(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)


### PR DESCRIPTION
This PR adds a new `Clone` function to the slice utilities that returns a shallow copy of any slice collection.

## Implementation

The `Clone` function uses the efficient `append(collection[:0:0], collection...)` pattern to create a shallow copy:

```go
// Clone returns a shallow copy of the collection.
func Clone[T any](collection []T) []T {
	return append(collection[:0:0], collection...)
}
```

## Usage

```go
original := []int{1, 2, 3, 4, 5}
cloned := lo.Clone(original)

// Modifying the clone doesn't affect the original
cloned[0] = 99
fmt.Println(original) // [1 2 3 4 5]
fmt.Println(cloned)   // [99 2 3 4 5]
```

## Features

- **Type-safe**: Works with any slice type using Go generics
- **Efficient**: Uses the slice reslicing pattern for optimal performance
- **Nil-safe**: Properly handles nil slices by returning nil
- **Independence**: Creates truly independent copies that don't share underlying arrays

## Testing

Added comprehensive tests covering:
- Various slice types (int, string)
- Empty slices
- Nil slices  
- Verification that modifications to cloned slices don't affect originals
- Example tests demonstrating usage

All existing tests continue to pass, ensuring no regressions.

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Share your feedback on Copilot coding agent for the chance to win a $200 gift card! Click [here](https://survey.alchemer.com/s3/8343779/Copilot-Coding-agent) to start the survey.