### PR TITLE
lint: Apply testifylint linter recommendations

### DIFF
--- a/channel_test.go
+++ b/channel_test.go
@@ -21,13 +21,13 @@ func TestChannelDispatcher(t *testing.T) {
 	ch <- 2
 	ch <- 3
 
-	is.Equal(4, len(ch))
+	is.Len(ch, 4)
 
 	children := ChannelDispatcher(ch, 5, 10, DispatchingStrategyRoundRobin[int])
 	time.Sleep(10 * time.Millisecond)
 
 	// check channels allocation
-	is.Equal(5, len(children))
+	is.Len(children, 5)
 
 	is.Equal(10, cap(children[0]))
 	is.Equal(10, cap(children[1]))
@@ -35,34 +35,34 @@ func TestChannelDispatcher(t *testing.T) {
 	is.Equal(10, cap(children[3]))
 	is.Equal(10, cap(children[4]))
 
-	is.Equal(1, len(children[0]))
-	is.Equal(1, len(children[1]))
-	is.Equal(1, len(children[2]))
-	is.Equal(1, len(children[3]))
-	is.Equal(0, len(children[4]))
+	is.Len(children[0], 1)
+	is.Len(children[1], 1)
+	is.Len(children[2], 1)
+	is.Len(children[3], 1)
+	is.Empty(children[4])
 
 	// check channels content
-	is.Equal(0, len(ch))
+	is.Empty(ch)
 
 	msg0, ok0 := <-children[0]
-	is.Equal(ok0, true)
-	is.Equal(msg0, 0)
+	is.True(ok0)
+	is.Zero(msg0)
 
 	msg1, ok1 := <-children[1]
-	is.Equal(ok1, true)
-	is.Equal(msg1, 1)
+	is.True(ok1)
+	is.Equal(1, msg1)
 
 	msg2, ok2 := <-children[2]
-	is.Equal(ok2, true)
-	is.Equal(msg2, 2)
+	is.True(ok2)
+	is.Equal(2, msg2)
 
 	msg3, ok3 := <-children[3]
-	is.Equal(ok3, true)
-	is.Equal(msg3, 3)
+	is.True(ok3)
+	is.Equal(3, msg3)
 
 	// msg4, ok4 := <-children[4]
-	// is.Equal(ok4, false)
-	// is.Equal(msg4, 0)
+	// is.False(ok4)
+	// is.Zero(msg4)
 	// is.Nil(children[4])
 
 	// check it is closed
@@ -73,28 +73,28 @@ func TestChannelDispatcher(t *testing.T) {
 	})
 
 	msg0, ok0 = <-children[0]
-	is.Equal(ok0, false)
-	is.Equal(msg0, 0)
+	is.False(ok0)
+	is.Zero(msg0)
 
 	msg1, ok1 = <-children[1]
-	is.Equal(ok1, false)
-	is.Equal(msg1, 0)
+	is.False(ok1)
+	is.Zero(msg1)
 
 	msg2, ok2 = <-children[2]
-	is.Equal(ok2, false)
-	is.Equal(msg2, 0)
+	is.False(ok2)
+	is.Zero(msg2)
 
 	msg3, ok3 = <-children[3]
-	is.Equal(ok3, false)
-	is.Equal(msg3, 0)
+	is.False(ok3)
+	is.Zero(msg3)
 
 	msg4, ok4 := <-children[4]
-	is.Equal(ok4, false)
-	is.Equal(msg4, 0)
+	is.False(ok4)
+	is.Zero(msg4)
 
 	// unbuffered channels
 	children = ChannelDispatcher(ch, 5, 0, DispatchingStrategyRoundRobin[int])
-	is.Equal(0, cap(children[0]))
+	is.Zero(cap(children[0]))
 }
 
 func TestDispatchingStrategyRoundRobin(t *testing.T) {
@@ -106,10 +106,10 @@ func TestDispatchingStrategyRoundRobin(t *testing.T) {
 	rochildren := channelsToReadOnly(children)
 	defer closeChannels(children)
 
-	is.Equal(0, DispatchingStrategyRoundRobin(42, 0, rochildren))
+	is.Zero(DispatchingStrategyRoundRobin(42, 0, rochildren))
 	is.Equal(1, DispatchingStrategyRoundRobin(42, 1, rochildren))
 	is.Equal(2, DispatchingStrategyRoundRobin(42, 2, rochildren))
-	is.Equal(0, DispatchingStrategyRoundRobin(42, 3, rochildren))
+	is.Zero(DispatchingStrategyRoundRobin(42, 3, rochildren))
 }
 
 func TestDispatchingStrategyRandom(t *testing.T) {
@@ -127,7 +127,7 @@ func TestDispatchingStrategyRandom(t *testing.T) {
 		children[1] <- i
 	}
 
-	is.Equal(0, DispatchingStrategyRandom(42, 0, rochildren))
+	is.Zero(DispatchingStrategyRandom(42, 0, rochildren))
 }
 
 func TestDispatchingStrategyWeightedRandom(t *testing.T) {
@@ -157,9 +157,9 @@ func TestDispatchingStrategyFirst(t *testing.T) {
 	rochildren := channelsToReadOnly(children)
 	defer closeChannels(children)
 
-	is.Equal(0, DispatchingStrategyFirst(42, 0, rochildren))
+	is.Zero(DispatchingStrategyFirst(42, 0, rochildren))
 	children[0] <- 0
-	is.Equal(0, DispatchingStrategyFirst(42, 0, rochildren))
+	is.Zero(DispatchingStrategyFirst(42, 0, rochildren))
 	children[0] <- 1
 	is.Equal(1, DispatchingStrategyFirst(42, 0, rochildren))
 }
@@ -173,15 +173,15 @@ func TestDispatchingStrategyLeast(t *testing.T) {
 	rochildren := channelsToReadOnly(children)
 	defer closeChannels(children)
 
-	is.Equal(0, DispatchingStrategyLeast(42, 0, rochildren))
+	is.Zero(DispatchingStrategyLeast(42, 0, rochildren))
 	children[0] <- 0
 	is.Equal(1, DispatchingStrategyLeast(42, 0, rochildren))
 	children[1] <- 0
-	is.Equal(0, DispatchingStrategyLeast(42, 0, rochildren))
+	is.Zero(DispatchingStrategyLeast(42, 0, rochildren))
 	children[0] <- 1
 	is.Equal(1, DispatchingStrategyLeast(42, 0, rochildren))
 	children[1] <- 1
-	is.Equal(0, DispatchingStrategyLeast(42, 0, rochildren))
+	is.Zero(DispatchingStrategyLeast(42, 0, rochildren))
 }
 
 func TestDispatchingStrategyMost(t *testing.T) {
@@ -193,15 +193,15 @@ func TestDispatchingStrategyMost(t *testing.T) {
 	rochildren := channelsToReadOnly(children)
 	defer closeChannels(children)
 
-	is.Equal(0, DispatchingStrategyMost(42, 0, rochildren))
+	is.Zero(DispatchingStrategyMost(42, 0, rochildren))
 	children[0] <- 0
-	is.Equal(0, DispatchingStrategyMost(42, 0, rochildren))
+	is.Zero(DispatchingStrategyMost(42, 0, rochildren))
 	children[1] <- 0
-	is.Equal(0, DispatchingStrategyMost(42, 0, rochildren))
+	is.Zero(DispatchingStrategyMost(42, 0, rochildren))
 	children[0] <- 1
-	is.Equal(0, DispatchingStrategyMost(42, 0, rochildren))
+	is.Zero(DispatchingStrategyMost(42, 0, rochildren))
 	children[1] <- 1
-	is.Equal(0, DispatchingStrategyMost(42, 0, rochildren))
+	is.Zero(DispatchingStrategyMost(42, 0, rochildren))
 }
 
 func TestSliceToChannel(t *testing.T) {
@@ -255,7 +255,7 @@ func TestGenerate(t *testing.T) {
 		i++
 	}
 
-	is.Equal(i, 4)
+	is.Equal(4, i)
 }
 
 func TestBuffer(t *testing.T) {
@@ -276,7 +276,7 @@ func TestBuffer(t *testing.T) {
 	is.Equal(1, length2)
 	is.False(ok2)
 	is.Equal([]int{}, items3)
-	is.Equal(0, length3)
+	is.Zero(length3)
 	is.False(ok3)
 }
 
@@ -336,7 +336,7 @@ func TestBufferWithTimeout(t *testing.T) {
 
 	items2, length2, _, ok2 := BufferWithTimeout(ch, 20, 2*time.Millisecond)
 	is.Equal([]int{}, items2)
-	is.Equal(0, length2)
+	is.Zero(length2)
 	is.True(ok2)
 
 	items3, length3, _, ok3 := BufferWithTimeout(ch, 1, 30*time.Millisecond)
@@ -351,7 +351,7 @@ func TestBufferWithTimeout(t *testing.T) {
 
 	items5, length5, _, ok5 := BufferWithTimeout(ch, 3, 25*time.Millisecond)
 	is.Equal([]int{}, items5)
-	is.Equal(0, length5)
+	is.Zero(length5)
 	is.False(ok5)
 }
 
@@ -373,26 +373,26 @@ func TestFanIn(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// check input channels
-	is.Equal(0, len(roupstreams[0]))
-	is.Equal(0, len(roupstreams[1]))
-	is.Equal(0, len(roupstreams[2]))
+	is.Empty(roupstreams[0])
+	is.Empty(roupstreams[1])
+	is.Empty(roupstreams[2])
 
 	// check channels allocation
-	is.Equal(6, len(out))
+	is.Len(out, 6)
 	is.Equal(10, cap(out))
 
 	// check channels content
 	for i := 0; i < 6; i++ {
 		msg0, ok0 := <-out
-		is.Equal(true, ok0)
+		is.True(ok0)
 		is.Equal(1, msg0)
 	}
 
 	// check it is closed
 	time.Sleep(10 * time.Millisecond)
 	msg0, ok0 := <-out
-	is.Equal(false, ok0)
-	is.Equal(0, msg0)
+	is.False(ok0)
+	is.Zero(msg0)
 }
 
 func TestFanOut(t *testing.T) {
@@ -406,11 +406,11 @@ func TestFanOut(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// check output channels
-	is.Equal(3, len(rodownstreams))
+	is.Len(rodownstreams, 3)
 
 	// check channels allocation
 	for i := range rodownstreams {
-		is.Equal(6, len(rodownstreams[i]))
+		is.Len(rodownstreams[i], 6)
 		is.Equal(10, cap(rodownstreams[i]))
 		is.Equal([]int{0, 1, 2, 3, 4, 5}, ChannelToSlice(rodownstreams[i]))
 	}
@@ -421,7 +421,7 @@ func TestFanOut(t *testing.T) {
 	// check channels allocation
 	for i := range rodownstreams {
 		msg, ok := <-rodownstreams[i]
-		is.Equal(false, ok)
-		is.Equal(0, msg)
+		is.False(ok)
+		is.Zero(msg)
 	}
 }

--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -78,7 +78,7 @@ func TestAsync(t *testing.T) {
 
 	select {
 	case result := <-ch:
-		is.Equal(result, 10)
+		is.Equal(10, result)
 	case <-time.After(time.Millisecond):
 		is.Fail("Async should not block")
 	}
@@ -117,7 +117,7 @@ func TestAsyncX(t *testing.T) {
 
 		select {
 		case result := <-ch:
-			is.Equal(result, 10)
+			is.Equal(10, result)
 		case <-time.After(time.Millisecond):
 			is.Fail("Async1 should not block")
 		}
@@ -135,7 +135,7 @@ func TestAsyncX(t *testing.T) {
 
 		select {
 		case result := <-ch:
-			is.Equal(result, Tuple2[int, string]{10, "Hello"})
+			is.Equal(Tuple2[int, string]{10, "Hello"}, result)
 		case <-time.After(time.Millisecond):
 			is.Fail("Async2 should not block")
 		}
@@ -153,7 +153,7 @@ func TestAsyncX(t *testing.T) {
 
 		select {
 		case result := <-ch:
-			is.Equal(result, Tuple3[int, string, bool]{10, "Hello", true})
+			is.Equal(Tuple3[int, string, bool]{10, "Hello", true}, result)
 		case <-time.After(time.Millisecond):
 			is.Fail("Async3 should not block")
 		}
@@ -171,7 +171,7 @@ func TestAsyncX(t *testing.T) {
 
 		select {
 		case result := <-ch:
-			is.Equal(result, Tuple4[int, string, bool, float64]{10, "Hello", true, 3.14})
+			is.Equal(Tuple4[int, string, bool, float64]{10, "Hello", true, 3.14}, result)
 		case <-time.After(time.Millisecond):
 			is.Fail("Async4 should not block")
 		}
@@ -189,7 +189,7 @@ func TestAsyncX(t *testing.T) {
 
 		select {
 		case result := <-ch:
-			is.Equal(result, Tuple5[int, string, bool, float64, string]{10, "Hello", true, 3.14, "World"})
+			is.Equal(Tuple5[int, string, bool, float64, string]{10, "Hello", true, 3.14, "World"}, result)
 		case <-time.After(time.Millisecond):
 			is.Fail("Async5 should not block")
 		}
@@ -207,7 +207,7 @@ func TestAsyncX(t *testing.T) {
 
 		select {
 		case result := <-ch:
-			is.Equal(result, Tuple6[int, string, bool, float64, string, int]{10, "Hello", true, 3.14, "World", 100})
+			is.Equal(Tuple6[int, string, bool, float64, string, int]{10, "Hello", true, 3.14, "World", 100}, result)
 		case <-time.After(time.Millisecond):
 			is.Fail("Async6 should not block")
 		}
@@ -266,7 +266,7 @@ func TestWaitFor(t *testing.T) {
 		is := assert.New(t)
 
 		iter, duration, ok := WaitFor(alwaysFalse, shortTimeout, 10*time.Millisecond)
-		is.Equal(0, iter, "unexpected iteration count")
+		is.Zero(iter, "unexpected iteration count")
 		is.InEpsilon(10*time.Millisecond, duration, float64(500*time.Microsecond))
 		is.False(ok)
 	})
@@ -279,7 +279,7 @@ func TestWaitFor(t *testing.T) {
 
 		shortTimeout := 4 * time.Millisecond
 		iter, duration, ok := WaitFor(alwaysFalse, shortTimeout, 10*time.Millisecond)
-		is.Equal(0, iter, "unexpected iteration count")
+		is.Zero(iter, "unexpected iteration count")
 		is.InEpsilon(10*time.Millisecond, duration, float64(500*time.Microsecond))
 		is.False(ok)
 	})
@@ -349,7 +349,7 @@ func TestWaitForWithContext(t *testing.T) {
 		is := assert.New(t)
 
 		iter, duration, ok := WaitForWithContext(context.Background(), alwaysFalse, shortTimeout, 10*time.Millisecond)
-		is.Equal(0, iter, "unexpected iteration count")
+		is.Zero(iter, "unexpected iteration count")
 		is.InEpsilon(10*time.Millisecond, duration, float64(500*time.Microsecond))
 		is.False(ok)
 	})
@@ -362,7 +362,7 @@ func TestWaitForWithContext(t *testing.T) {
 
 		shortTimeout := 4 * time.Millisecond
 		iter, duration, ok := WaitForWithContext(context.Background(), alwaysFalse, shortTimeout, 10*time.Millisecond)
-		is.Equal(0, iter, "unexpected iteration count")
+		is.Zero(iter, "unexpected iteration count")
 		is.InEpsilon(10*time.Millisecond, duration, float64(500*time.Microsecond))
 		is.False(ok)
 	})
@@ -406,7 +406,7 @@ func TestWaitForWithContext(t *testing.T) {
 		cancel()
 
 		iter, duration, ok := WaitForWithContext(canceledCtx, alwaysFalse, 100*time.Millisecond, 1050*time.Microsecond)
-		is.Equal(0, iter, "unexpected iteration count")
+		is.Zero(iter, "unexpected iteration count")
 		is.InEpsilon(1*time.Millisecond, duration, float64(5*time.Microsecond))
 		is.False(ok)
 	})

--- a/condition_test.go
+++ b/condition_test.go
@@ -13,8 +13,8 @@ func TestTernary(t *testing.T) {
 	result1 := Ternary(true, "a", "b")
 	result2 := Ternary(false, "a", "b")
 
-	is.Equal(result1, "a")
-	is.Equal(result2, "b")
+	is.Equal("a", result1)
+	is.Equal("b", result2)
 }
 
 func TestTernaryF(t *testing.T) {
@@ -23,8 +23,8 @@ func TestTernaryF(t *testing.T) {
 	result1 := TernaryF(true, func() string { return "a" }, func() string { return "b" })
 	result2 := TernaryF(false, func() string { return "a" }, func() string { return "b" })
 
-	is.Equal(result1, "a")
-	is.Equal(result2, "b")
+	is.Equal("a", result1)
+	is.Equal("b", result2)
 }
 
 func TestIfElse(t *testing.T) {
@@ -36,10 +36,10 @@ func TestIfElse(t *testing.T) {
 	result3 := If(false, 1).ElseIf(true, 2).Else(3)
 	result4 := If(false, 1).ElseIf(false, 2).Else(3)
 
-	is.Equal(result1, 1)
-	is.Equal(result2, 1)
-	is.Equal(result3, 2)
-	is.Equal(result4, 3)
+	is.Equal(1, result1)
+	is.Equal(1, result2)
+	is.Equal(2, result3)
+	is.Equal(3, result4)
 }
 
 func TestIfFElseF(t *testing.T) {
@@ -51,10 +51,10 @@ func TestIfFElseF(t *testing.T) {
 	result3 := IfF(false, func() int { return 1 }).ElseIfF(true, func() int { return 2 }).ElseF(func() int { return 3 })
 	result4 := IfF(false, func() int { return 1 }).ElseIfF(false, func() int { return 2 }).ElseF(func() int { return 3 })
 
-	is.Equal(result1, 1)
-	is.Equal(result2, 1)
-	is.Equal(result3, 2)
-	is.Equal(result4, 3)
+	is.Equal(1, result1)
+	is.Equal(1, result2)
+	is.Equal(2, result3)
+	is.Equal(3, result4)
 }
 
 func TestSwitchCase(t *testing.T) {
@@ -66,10 +66,10 @@ func TestSwitchCase(t *testing.T) {
 	result3 := Switch[int, int](42).Case(1, 1).Case(42, 2).Default(3)
 	result4 := Switch[int, int](42).Case(1, 1).Case(1, 2).Default(3)
 
-	is.Equal(result1, 1)
-	is.Equal(result2, 1)
-	is.Equal(result3, 2)
-	is.Equal(result4, 3)
+	is.Equal(1, result1)
+	is.Equal(1, result2)
+	is.Equal(2, result3)
+	is.Equal(3, result4)
 }
 
 func TestSwitchCaseF(t *testing.T) {
@@ -81,8 +81,8 @@ func TestSwitchCaseF(t *testing.T) {
 	result3 := Switch[int, int](42).CaseF(1, func() int { return 1 }).CaseF(42, func() int { return 2 }).DefaultF(func() int { return 3 })
 	result4 := Switch[int, int](42).CaseF(1, func() int { return 1 }).CaseF(1, func() int { return 2 }).DefaultF(func() int { return 3 })
 
-	is.Equal(result1, 1)
-	is.Equal(result2, 1)
-	is.Equal(result3, 2)
-	is.Equal(result4, 3)
+	is.Equal(1, result1)
+	is.Equal(1, result2)
+	is.Equal(2, result3)
+	is.Equal(3, result4)
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -407,17 +407,17 @@ func TestTryOrX(t *testing.T) {
 
 		is.Equal(42, a1)
 		is.Equal("hello", b1)
-		is.Equal(false, c1)
+		is.False(c1)
 		is.False(ok1)
 
 		is.Equal(42, a2)
 		is.Equal("hello", b2)
-		is.Equal(false, c2)
+		is.False(c2)
 		is.False(ok2)
 
 		is.Equal(21, a3)
 		is.Equal("world", b3)
-		is.Equal(true, c3)
+		is.True(c3)
 		is.True(ok3)
 	}
 
@@ -428,19 +428,19 @@ func TestTryOrX(t *testing.T) {
 
 		is.Equal(42, a1)
 		is.Equal("hello", b1)
-		is.Equal(false, c1)
+		is.False(c1)
 		is.Equal(42, d1)
 		is.False(ok1)
 
 		is.Equal(42, a2)
 		is.Equal("hello", b2)
-		is.Equal(false, c2)
+		is.False(c2)
 		is.Equal(42, d2)
 		is.False(ok2)
 
 		is.Equal(21, a3)
 		is.Equal("world", b3)
-		is.Equal(true, c3)
+		is.True(c3)
 		is.Equal(21, d3)
 		is.True(ok3)
 	}
@@ -452,21 +452,21 @@ func TestTryOrX(t *testing.T) {
 
 		is.Equal(42, a1)
 		is.Equal("hello", b1)
-		is.Equal(false, c1)
+		is.False(c1)
 		is.Equal(42, d1)
 		is.Equal(42, e1)
 		is.False(ok1)
 
 		is.Equal(42, a2)
 		is.Equal("hello", b2)
-		is.Equal(false, c2)
+		is.False(c2)
 		is.Equal(42, d2)
 		is.Equal(42, e2)
 		is.False(ok2)
 
 		is.Equal(21, a3)
 		is.Equal("world", b3)
-		is.Equal(true, c3)
+		is.True(c3)
 		is.Equal(21, d3)
 		is.Equal(21, e3)
 		is.True(ok3)
@@ -479,7 +479,7 @@ func TestTryOrX(t *testing.T) {
 
 		is.Equal(42, a1)
 		is.Equal("hello", b1)
-		is.Equal(false, c1)
+		is.False(c1)
 		is.Equal(42, d1)
 		is.Equal(42, e1)
 		is.Equal(42, f1)
@@ -487,7 +487,7 @@ func TestTryOrX(t *testing.T) {
 
 		is.Equal(42, a2)
 		is.Equal("hello", b2)
-		is.Equal(false, c2)
+		is.False(c2)
 		is.Equal(42, d2)
 		is.Equal(42, e2)
 		is.Equal(42, f2)
@@ -495,7 +495,7 @@ func TestTryOrX(t *testing.T) {
 
 		is.Equal(21, a3)
 		is.Equal("world", b3)
-		is.Equal(true, c3)
+		is.True(c3)
 		is.Equal(21, d3)
 		is.Equal(21, e3)
 		is.Equal(21, f3)
@@ -524,7 +524,7 @@ func TestTryWithErrorValue(t *testing.T) {
 		return nil
 	})
 	is.True(ok)
-	is.Equal(nil, err)
+	is.Nil(err)
 }
 
 func TestTryCatch(t *testing.T) {
@@ -587,7 +587,7 @@ func TestErrorsAs(t *testing.T) {
 
 	err, ok := ErrorsAs[*internalError](fmt.Errorf("hello world"))
 	is.False(ok)
-	is.Nil(nil, err)
+	is.Nil(err)
 
 	err, ok = ErrorsAs[*internalError](&internalError{foobar: "foobar"})
 	is.True(ok)
@@ -595,7 +595,7 @@ func TestErrorsAs(t *testing.T) {
 
 	err, ok = ErrorsAs[*internalError](nil)
 	is.False(ok)
-	is.Nil(nil, err)
+	is.Nil(err)
 }
 
 func TestAssert(t *testing.T) {

--- a/find_test.go
+++ b/find_test.go
@@ -17,8 +17,8 @@ func TestIndexOf(t *testing.T) {
 	result1 := IndexOf([]int{0, 1, 2, 1, 2, 3}, 2)
 	result2 := IndexOf([]int{0, 1, 2, 1, 2, 3}, 6)
 
-	is.Equal(result1, 2)
-	is.Equal(result2, -1)
+	is.Equal(2, result1)
+	is.Equal(-1, result2)
 }
 
 func TestLastIndexOf(t *testing.T) {
@@ -28,8 +28,8 @@ func TestLastIndexOf(t *testing.T) {
 	result1 := LastIndexOf([]int{0, 1, 2, 1, 2, 3}, 2)
 	result2 := LastIndexOf([]int{0, 1, 2, 1, 2, 3}, 6)
 
-	is.Equal(result1, 4)
-	is.Equal(result2, -1)
+	is.Equal(4, result1)
+	is.Equal(-1, result2)
 }
 
 func TestFind(t *testing.T) {
@@ -48,10 +48,10 @@ func TestFind(t *testing.T) {
 		return item == "b"
 	})
 
-	is.Equal(ok1, true)
-	is.Equal(result1, "b")
-	is.Equal(ok2, false)
-	is.Equal(result2, "")
+	is.True(ok1)
+	is.Equal("b", result1)
+	is.False(ok2)
+	is.Empty(result2)
 }
 
 func TestFindIndexOf(t *testing.T) {
@@ -69,11 +69,11 @@ func TestFindIndexOf(t *testing.T) {
 		return item == "b"
 	})
 
-	is.Equal(item1, "b")
-	is.Equal(ok1, true)
-	is.Equal(index1, 1)
-	is.Equal(item2, "")
-	is.Equal(ok2, false)
+	is.Equal("b", item1)
+	is.True(ok1)
+	is.Equal(1, index1)
+	is.Empty(item2)
+	is.False(ok2)
 	is.Equal(index2, -1)
 }
 
@@ -92,11 +92,11 @@ func TestFindLastIndexOf(t *testing.T) {
 		return item == "b"
 	})
 
-	is.Equal(item1, "b")
-	is.Equal(ok1, true)
-	is.Equal(index1, 4)
-	is.Equal(item2, "")
-	is.Equal(ok2, false)
+	is.Equal("b", item1)
+	is.True(ok1)
+	is.Equal(4, index1)
+	is.Empty(item2)
+	is.False(ok2)
 	is.Equal(index2, -1)
 }
 
@@ -115,8 +115,8 @@ func TestFindOrElse(t *testing.T) {
 		return item == "b"
 	})
 
-	is.Equal(result1, "b")
-	is.Equal(result2, "x")
+	is.Equal("b", result1)
+	is.Equal("x", result2)
 }
 
 func TestFindKey(t *testing.T) {
@@ -128,7 +128,7 @@ func TestFindKey(t *testing.T) {
 	is.True(ok1)
 
 	result2, ok2 := FindKey(map[string]int{"foo": 1, "bar": 2, "baz": 3}, 42)
-	is.Equal("", result2)
+	is.Empty(result2)
 	is.False(ok2)
 
 	type test struct {
@@ -140,7 +140,7 @@ func TestFindKey(t *testing.T) {
 	is.True(ok3)
 
 	result4, ok4 := FindKey(map[string]test{"foo": {"foo"}, "bar": {"bar"}, "baz": {"baz"}}, test{"hello world"})
-	is.Equal("", result4)
+	is.Empty(result4)
 	is.False(ok4)
 }
 
@@ -157,7 +157,7 @@ func TestFindKeyBy(t *testing.T) {
 	result2, ok2 := FindKeyBy(map[string]int{"foo": 1, "bar": 2, "baz": 3}, func(k string, v int) bool {
 		return false
 	})
-	is.Equal("", result2)
+	is.Empty(result2)
 	is.False(ok2)
 }
 
@@ -167,22 +167,22 @@ func TestFindUniques(t *testing.T) {
 
 	result1 := FindUniques([]int{1, 2, 3})
 
-	is.Equal(3, len(result1))
+	is.Len(result1, 3)
 	is.Equal([]int{1, 2, 3}, result1)
 
 	result2 := FindUniques([]int{1, 2, 2, 3, 1, 2})
 
-	is.Equal(1, len(result2))
+	is.Len(result2, 1)
 	is.Equal([]int{3}, result2)
 
 	result3 := FindUniques([]int{1, 2, 2, 1})
 
-	is.Equal(0, len(result3))
+	is.Empty(result3)
 	is.Equal([]int{}, result3)
 
 	result4 := FindUniques([]int{})
 
-	is.Equal(0, len(result4))
+	is.Empty(result4)
 	is.Equal([]int{}, result4)
 
 	type myStrings []string
@@ -199,28 +199,28 @@ func TestFindUniquesBy(t *testing.T) {
 		return i % 3
 	})
 
-	is.Equal(3, len(result1))
+	is.Len(result1, 3)
 	is.Equal([]int{0, 1, 2}, result1)
 
 	result2 := FindUniquesBy([]int{0, 1, 2, 3, 4}, func(i int) int {
 		return i % 3
 	})
 
-	is.Equal(1, len(result2))
+	is.Len(result2, 1)
 	is.Equal([]int{2}, result2)
 
 	result3 := FindUniquesBy([]int{0, 1, 2, 3, 4, 5}, func(i int) int {
 		return i % 3
 	})
 
-	is.Equal(0, len(result3))
+	is.Empty(result3)
 	is.Equal([]int{}, result3)
 
 	result4 := FindUniquesBy([]int{}, func(i int) int {
 		return i % 3
 	})
 
-	is.Equal(0, len(result4))
+	is.Empty(result4)
 	is.Equal([]int{}, result4)
 
 	type myStrings []string
@@ -237,17 +237,17 @@ func TestFindDuplicates(t *testing.T) {
 
 	result1 := FindDuplicates([]int{1, 2, 2, 1, 2, 3})
 
-	is.Equal(2, len(result1))
+	is.Len(result1, 2)
 	is.Equal([]int{1, 2}, result1)
 
 	result2 := FindDuplicates([]int{1, 2, 3})
 
-	is.Equal(0, len(result2))
+	is.Empty(result2)
 	is.Equal([]int{}, result2)
 
 	result3 := FindDuplicates([]int{})
 
-	is.Equal(0, len(result3))
+	is.Empty(result3)
 	is.Equal([]int{}, result3)
 
 	type myStrings []string
@@ -264,21 +264,21 @@ func TestFindDuplicatesBy(t *testing.T) {
 		return i % 3
 	})
 
-	is.Equal(2, len(result1))
+	is.Len(result1, 2)
 	is.Equal([]int{3, 4}, result1)
 
 	result2 := FindDuplicatesBy([]int{0, 1, 2, 3, 4}, func(i int) int {
 		return i % 5
 	})
 
-	is.Equal(0, len(result2))
+	is.Empty(result2)
 	is.Equal([]int{}, result2)
 
 	result3 := FindDuplicatesBy([]int{}, func(i int) int {
 		return i % 3
 	})
 
-	is.Equal(0, len(result3))
+	is.Empty(result3)
 	is.Equal([]int{}, result3)
 
 	type myStrings []string
@@ -298,10 +298,10 @@ func TestMin(t *testing.T) {
 	result3 := Min([]time.Duration{time.Second, time.Minute, time.Hour})
 	result4 := Min([]int{})
 
-	is.Equal(result1, 1)
-	is.Equal(result2, 1)
-	is.Equal(result3, time.Second)
-	is.Equal(result4, 0)
+	is.Equal(1, result1)
+	is.Equal(1, result2)
+	is.Equal(time.Second, result3)
+	is.Zero(result4)
 }
 
 func TestMinIndex(t *testing.T) {
@@ -313,16 +313,16 @@ func TestMinIndex(t *testing.T) {
 	result3, index3 := MinIndex([]time.Duration{time.Second, time.Minute, time.Hour})
 	result4, index4 := MinIndex([]int{})
 
-	is.Equal(result1, 1)
-	is.Equal(index1, 0)
+	is.Equal(1, result1)
+	is.Zero(index1)
 
-	is.Equal(result2, 1)
-	is.Equal(index2, 2)
+	is.Equal(1, result2)
+	is.Equal(2, index2)
 
-	is.Equal(result3, time.Second)
-	is.Equal(index3, 0)
+	is.Equal(time.Second, result3)
+	is.Zero(index3)
 
-	is.Equal(result4, 0)
+	is.Zero(result4)
 	is.Equal(index4, -1)
 }
 
@@ -340,9 +340,9 @@ func TestMinBy(t *testing.T) {
 		return len(item) < len(min)
 	})
 
-	is.Equal(result1, "s1")
-	is.Equal(result2, "s3")
-	is.Equal(result3, "")
+	is.Equal("s1", result1)
+	is.Equal("s3", result2)
+	is.Empty(result3)
 }
 
 func TestMinIndexBy(t *testing.T) {
@@ -359,13 +359,13 @@ func TestMinIndexBy(t *testing.T) {
 		return len(item) < len(min)
 	})
 
-	is.Equal(result1, "s1")
-	is.Equal(index1, 0)
+	is.Equal("s1", result1)
+	is.Zero(index1)
 
-	is.Equal(result2, "s3")
-	is.Equal(index2, 2)
+	is.Equal("s3", result2)
+	is.Equal(2, index2)
 
-	is.Equal(result3, "")
+	is.Empty(result3)
 	is.Equal(index3, -1)
 }
 
@@ -378,8 +378,8 @@ func TestEarliest(t *testing.T) {
 	result1 := Earliest(a, b)
 	result2 := Earliest()
 
-	is.Equal(result1, a)
-	is.Equal(result2, time.Time{})
+	is.Equal(a, result1)
+	is.Equal(time.Time{}, result2)
 }
 
 func TestEarliestBy(t *testing.T) {
@@ -403,9 +403,9 @@ func TestEarliestBy(t *testing.T) {
 		return i.bar
 	})
 
-	is.Equal(result1, foo{t3})
-	is.Equal(result2, foo{t1})
-	is.Equal(result3, foo{})
+	is.Equal(foo{t3}, result1)
+	is.Equal(foo{t1}, result2)
+	is.Equal(foo{}, result3)
 }
 
 func TestMax(t *testing.T) {
@@ -417,10 +417,10 @@ func TestMax(t *testing.T) {
 	result3 := Max([]time.Duration{time.Second, time.Minute, time.Hour})
 	result4 := Max([]int{})
 
-	is.Equal(result1, 3)
-	is.Equal(result2, 3)
-	is.Equal(result3, time.Hour)
-	is.Equal(result4, 0)
+	is.Equal(3, result1)
+	is.Equal(3, result2)
+	is.Equal(time.Hour, result3)
+	is.Zero(result4)
 }
 
 func TestMaxIndex(t *testing.T) {
@@ -432,16 +432,16 @@ func TestMaxIndex(t *testing.T) {
 	result3, index3 := MaxIndex([]time.Duration{time.Second, time.Minute, time.Hour})
 	result4, index4 := MaxIndex([]int{})
 
-	is.Equal(result1, 3)
-	is.Equal(index1, 2)
+	is.Equal(3, result1)
+	is.Equal(2, index1)
 
-	is.Equal(result2, 3)
-	is.Equal(index2, 0)
+	is.Equal(3, result2)
+	is.Zero(index2)
 
-	is.Equal(result3, time.Hour)
-	is.Equal(index3, 2)
+	is.Equal(time.Hour, result3)
+	is.Equal(2, index3)
 
-	is.Equal(result4, 0)
+	is.Zero(result4)
 	is.Equal(index4, -1)
 }
 
@@ -459,9 +459,9 @@ func TestMaxBy(t *testing.T) {
 		return len(item) > len(max)
 	})
 
-	is.Equal(result1, "string2")
-	is.Equal(result2, "string1")
-	is.Equal(result3, "")
+	is.Equal("string2", result1)
+	is.Equal("string1", result2)
+	is.Empty(result3)
 }
 
 func TestMaxIndexBy(t *testing.T) {
@@ -478,13 +478,13 @@ func TestMaxIndexBy(t *testing.T) {
 		return len(item) > len(max)
 	})
 
-	is.Equal(result1, "string2")
-	is.Equal(index1, 1)
+	is.Equal("string2", result1)
+	is.Equal(1, index1)
 
-	is.Equal(result2, "string1")
-	is.Equal(index2, 0)
+	is.Equal("string1", result2)
+	is.Zero(index2)
 
-	is.Equal(result3, "")
+	is.Empty(result3)
 	is.Equal(index3, -1)
 }
 
@@ -497,8 +497,8 @@ func TestLatest(t *testing.T) {
 	result1 := Latest(a, b)
 	result2 := Latest()
 
-	is.Equal(result1, b)
-	is.Equal(result2, time.Time{})
+	is.Equal(b, result1)
+	is.Equal(time.Time{}, result2)
 }
 
 func TestLatestBy(t *testing.T) {
@@ -522,9 +522,9 @@ func TestLatestBy(t *testing.T) {
 		return i.bar
 	})
 
-	is.Equal(result1, foo{t2})
-	is.Equal(result2, foo{t1})
-	is.Equal(result3, foo{})
+	is.Equal(foo{t2}, result1)
+	is.Equal(foo{t1}, result2)
+	is.Equal(foo{}, result3)
 }
 
 func TestFirst(t *testing.T) {
@@ -534,10 +534,10 @@ func TestFirst(t *testing.T) {
 	result1, ok1 := First([]int{1, 2, 3})
 	result2, ok2 := First([]int{})
 
-	is.Equal(result1, 1)
-	is.Equal(ok1, true)
-	is.Equal(result2, 0)
-	is.Equal(ok2, false)
+	is.Equal(1, result1)
+	is.True(ok1)
+	is.Zero(result2)
+	is.False(ok2)
 }
 
 func TestFirstOrEmpty(t *testing.T) {
@@ -548,9 +548,9 @@ func TestFirstOrEmpty(t *testing.T) {
 	result2 := FirstOrEmpty([]int{})
 	result3 := FirstOrEmpty([]string{})
 
-	is.Equal(result1, 1)
-	is.Equal(result2, 0)
-	is.Equal(result3, "")
+	is.Equal(1, result1)
+	is.Zero(result2)
+	is.Empty(result3)
 }
 
 func TestFirstOr(t *testing.T) {
@@ -561,9 +561,9 @@ func TestFirstOr(t *testing.T) {
 	result2 := FirstOr([]int{}, 23)
 	result3 := FirstOr([]string{}, "test")
 
-	is.Equal(result1, 1)
-	is.Equal(result2, 23)
-	is.Equal(result3, "test")
+	is.Equal(1, result1)
+	is.Equal(23, result2)
+	is.Equal("test", result3)
 }
 
 func TestLast(t *testing.T) {
@@ -573,9 +573,9 @@ func TestLast(t *testing.T) {
 	result1, ok1 := Last([]int{1, 2, 3})
 	result2, ok2 := Last([]int{})
 
-	is.Equal(result1, 3)
+	is.Equal(3, result1)
 	is.True(ok1)
-	is.Equal(result2, 0)
+	is.Zero(result2)
 	is.False(ok2)
 }
 
@@ -587,9 +587,9 @@ func TestLastOrEmpty(t *testing.T) {
 	result2 := LastOrEmpty([]int{})
 	result3 := LastOrEmpty([]string{})
 
-	is.Equal(result1, 3)
-	is.Equal(result2, 0)
-	is.Equal(result3, "")
+	is.Equal(3, result1)
+	is.Zero(result2)
+	is.Empty(result3)
 }
 
 func TestLastOr(t *testing.T) {
@@ -600,9 +600,9 @@ func TestLastOr(t *testing.T) {
 	result2 := LastOr([]int{}, 23)
 	result3 := LastOr([]string{}, "test")
 
-	is.Equal(result1, 3)
-	is.Equal(result2, 23)
-	is.Equal(result3, "test")
+	is.Equal(3, result1)
+	is.Equal(23, result2)
+	is.Equal("test", result3)
 }
 
 func TestNth(t *testing.T) {
@@ -616,18 +616,18 @@ func TestNth(t *testing.T) {
 	result5, err5 := Nth([]int{42}, 0)
 	result6, err6 := Nth([]int{42}, -1)
 
-	is.Equal(result1, 2)
-	is.Equal(err1, nil)
-	is.Equal(result2, 2)
-	is.Equal(err2, nil)
-	is.Equal(result3, 0)
+	is.Equal(2, result1)
+	is.NoError(err1)
+	is.Equal(2, result2)
+	is.NoError(err2)
+	is.Zero(result3)
 	is.Equal(err3, fmt.Errorf("nth: 42 out of slice bounds"))
-	is.Equal(result4, 0)
+	is.Zero(result4)
 	is.Equal(err4, fmt.Errorf("nth: 0 out of slice bounds"))
-	is.Equal(result5, 42)
-	is.Equal(err5, nil)
-	is.Equal(result6, 42)
-	is.Equal(err6, nil)
+	is.Equal(42, result5)
+	is.NoError(err5)
+	is.Equal(42, result6)
+	is.NoError(err6)
 }
 
 func TestNthOr(t *testing.T) {
@@ -726,7 +726,7 @@ func TestSample(t *testing.T) {
 	result2 := Sample([]string{})
 
 	is.True(Contains([]string{"a", "b", "c"}, result1))
-	is.Equal(result2, "")
+	is.Empty(result2)
 }
 
 func TestSampleBy(t *testing.T) {
@@ -739,7 +739,7 @@ func TestSampleBy(t *testing.T) {
 	result2 := SampleBy([]string{}, rand.Intn)
 
 	is.True(Contains([]string{"a", "b", "c"}, result1))
-	is.Equal(result2, "")
+	is.Empty(result2)
 }
 
 func TestSamples(t *testing.T) {
@@ -753,8 +753,8 @@ func TestSamples(t *testing.T) {
 
 	sort.Strings(result1)
 
-	is.Equal(result1, []string{"a", "b", "c"})
-	is.Equal(result2, []string{})
+	is.Equal([]string{"a", "b", "c"}, result1)
+	is.Equal([]string{}, result2)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -773,8 +773,8 @@ func TestSamplesBy(t *testing.T) {
 
 	sort.Strings(result1)
 
-	is.Equal(result1, []string{"a", "b", "c"})
-	is.Equal(result2, []string{})
+	is.Equal([]string{"a", "b", "c"}, result1)
+	is.Equal([]string{}, result2)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}

--- a/intersect_test.go
+++ b/intersect_test.go
@@ -13,8 +13,8 @@ func TestContains(t *testing.T) {
 	result1 := Contains([]int{0, 1, 2, 3, 4, 5}, 5)
 	result2 := Contains([]int{0, 1, 2, 3, 4, 5}, 6)
 
-	is.Equal(result1, true)
-	is.Equal(result2, false)
+	is.True(result1)
+	is.False(result2)
 }
 
 func TestContainsBy(t *testing.T) {
@@ -34,10 +34,10 @@ func TestContainsBy(t *testing.T) {
 	result3 := ContainsBy(a2, func(t string) bool { return t == "ccc" })
 	result4 := ContainsBy(a2, func(t string) bool { return t == "ddd" })
 
-	is.Equal(result1, false)
-	is.Equal(result2, true)
-	is.Equal(result3, true)
-	is.Equal(result4, false)
+	is.False(result1)
+	is.True(result2)
+	is.True(result3)
+	is.False(result4)
 }
 
 func TestEvery(t *testing.T) {
@@ -182,11 +182,11 @@ func TestIntersect(t *testing.T) {
 	result4 := Intersect([]int{0, 6}, []int{0, 1, 2, 3, 4, 5})
 	result5 := Intersect([]int{0, 6, 0}, []int{0, 1, 2, 3, 4, 5})
 
-	is.Equal(result1, []int{0, 2})
-	is.Equal(result2, []int{0})
-	is.Equal(result3, []int{})
-	is.Equal(result4, []int{0})
-	is.Equal(result5, []int{0})
+	is.Equal([]int{0, 2}, result1)
+	is.Equal([]int{0}, result2)
+	is.Equal([]int{}, result3)
+	is.Equal([]int{0}, result4)
+	is.Equal([]int{0}, result5)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -199,16 +199,16 @@ func TestDifference(t *testing.T) {
 	is := assert.New(t)
 
 	left1, right1 := Difference([]int{0, 1, 2, 3, 4, 5}, []int{0, 2, 6})
-	is.Equal(left1, []int{1, 3, 4, 5})
-	is.Equal(right1, []int{6})
+	is.Equal([]int{1, 3, 4, 5}, left1)
+	is.Equal([]int{6}, right1)
 
 	left2, right2 := Difference([]int{1, 2, 3, 4, 5}, []int{0, 6})
-	is.Equal(left2, []int{1, 2, 3, 4, 5})
-	is.Equal(right2, []int{0, 6})
+	is.Equal([]int{1, 2, 3, 4, 5}, left2)
+	is.Equal([]int{0, 6}, right2)
 
 	left3, right3 := Difference([]int{0, 1, 2, 3, 4, 5}, []int{0, 1, 2, 3, 4, 5})
-	is.Equal(left3, []int{})
-	is.Equal(right3, []int{})
+	is.Equal([]int{}, left3)
+	is.Equal([]int{}, right3)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -227,23 +227,23 @@ func TestUnion(t *testing.T) {
 	result4 := Union([]int{0, 1, 2}, []int{0, 1, 2, 3, 3})
 	result5 := Union([]int{0, 1, 2}, []int{0, 1, 2})
 	result6 := Union([]int{}, []int{})
-	is.Equal(result1, []int{0, 1, 2, 3, 4, 5, 10})
-	is.Equal(result2, []int{0, 1, 2, 3, 4, 5, 6, 7})
-	is.Equal(result3, []int{0, 1, 2, 3, 4, 5})
-	is.Equal(result4, []int{0, 1, 2, 3})
-	is.Equal(result5, []int{0, 1, 2})
-	is.Equal(result6, []int{})
+	is.Equal([]int{0, 1, 2, 3, 4, 5, 10}, result1)
+	is.Equal([]int{0, 1, 2, 3, 4, 5, 6, 7}, result2)
+	is.Equal([]int{0, 1, 2, 3, 4, 5}, result3)
+	is.Equal([]int{0, 1, 2, 3}, result4)
+	is.Equal([]int{0, 1, 2}, result5)
+	is.Equal([]int{}, result6)
 
 	result11 := Union([]int{0, 1, 2, 3, 4, 5}, []int{0, 2, 10}, []int{0, 1, 11})
 	result12 := Union([]int{0, 1, 2, 3, 4, 5}, []int{6, 7}, []int{8, 9})
 	result13 := Union([]int{0, 1, 2, 3, 4, 5}, []int{}, []int{})
 	result14 := Union([]int{0, 1, 2}, []int{0, 1, 2}, []int{0, 1, 2})
 	result15 := Union([]int{}, []int{}, []int{})
-	is.Equal(result11, []int{0, 1, 2, 3, 4, 5, 10, 11})
-	is.Equal(result12, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
-	is.Equal(result13, []int{0, 1, 2, 3, 4, 5})
-	is.Equal(result14, []int{0, 1, 2})
-	is.Equal(result15, []int{})
+	is.Equal([]int{0, 1, 2, 3, 4, 5, 10, 11}, result11)
+	is.Equal([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, result12)
+	is.Equal([]int{0, 1, 2, 3, 4, 5}, result13)
+	is.Equal([]int{0, 1, 2}, result14)
+	is.Equal([]int{}, result15)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -260,11 +260,11 @@ func TestWithout(t *testing.T) {
 	result3 := Without([]int{}, 0, 1, 2, 3, 4, 5)
 	result4 := Without([]int{0, 1, 2}, 0, 1, 2)
 	result5 := Without([]int{})
-	is.Equal(result1, []int{10})
-	is.Equal(result2, []int{7})
-	is.Equal(result3, []int{})
-	is.Equal(result4, []int{})
-	is.Equal(result5, []int{})
+	is.Equal([]int{10}, result1)
+	is.Equal([]int{7}, result2)
+	is.Equal([]int{}, result3)
+	is.Equal([]int{}, result4)
+	is.Equal([]int{}, result5)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -287,9 +287,9 @@ func TestWithoutBy(t *testing.T) {
 		}, "nick", "lily")
 	result2 := WithoutBy([]User{}, func(item User) int { return item.Age }, 1, 2, 3)
 	result3 := WithoutBy([]User{}, func(item User) string { return item.Name })
-	is.Equal(result1, []User{{Name: "peter"}})
-	is.Equal(result2, []User{})
-	is.Equal(result3, []User{})
+	is.Equal([]User{{Name: "peter"}}, result1)
+	is.Equal([]User{}, result2)
+	is.Equal([]User{}, result3)
 }
 
 func TestWithoutEmpty(t *testing.T) {
@@ -300,10 +300,10 @@ func TestWithoutEmpty(t *testing.T) {
 	result2 := WithoutEmpty([]int{1, 2})
 	result3 := WithoutEmpty([]int{})
 	result4 := WithoutEmpty([]*int{ToPtr(0), ToPtr(1), nil, ToPtr(2)})
-	is.Equal(result1, []int{1, 2})
-	is.Equal(result2, []int{1, 2})
-	is.Equal(result3, []int{})
-	is.Equal(result4, []*int{ToPtr(0), ToPtr(1), ToPtr(2)})
+	is.Equal([]int{1, 2}, result1)
+	is.Equal([]int{1, 2}, result2)
+	is.Equal([]int{}, result3)
+	is.Equal([]*int{ToPtr(0), ToPtr(1), ToPtr(2)}, result4)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}

--- a/map_test.go
+++ b/map_test.go
@@ -15,21 +15,21 @@ func TestKeys(t *testing.T) {
 
 	r1 := Keys(map[string]int{"foo": 1, "bar": 2})
 	sort.Strings(r1)
-	is.Equal(r1, []string{"bar", "foo"})
+	is.Equal([]string{"bar", "foo"}, r1)
 
 	r2 := Keys(map[string]int{})
 	is.Empty(r2)
 
 	r3 := Keys(map[string]int{"foo": 1, "bar": 2}, map[string]int{"baz": 3})
 	sort.Strings(r3)
-	is.Equal(r3, []string{"bar", "baz", "foo"})
+	is.Equal([]string{"bar", "baz", "foo"}, r3)
 
 	r4 := Keys[string, int]()
-	is.Equal(r4, []string{})
+	is.Equal([]string{}, r4)
 
 	r5 := Keys(map[string]int{"foo": 1, "bar": 2}, map[string]int{"bar": 3})
 	sort.Strings(r5)
-	is.Equal(r5, []string{"bar", "bar", "foo"})
+	is.Equal([]string{"bar", "bar", "foo"}, r5)
 }
 
 func TestUniqKeys(t *testing.T) {
@@ -38,25 +38,25 @@ func TestUniqKeys(t *testing.T) {
 
 	r1 := UniqKeys(map[string]int{"foo": 1, "bar": 2})
 	sort.Strings(r1)
-	is.Equal(r1, []string{"bar", "foo"})
+	is.Equal([]string{"bar", "foo"}, r1)
 
 	r2 := UniqKeys(map[string]int{})
 	is.Empty(r2)
 
 	r3 := UniqKeys(map[string]int{"foo": 1, "bar": 2}, map[string]int{"baz": 3})
 	sort.Strings(r3)
-	is.Equal(r3, []string{"bar", "baz", "foo"})
+	is.Equal([]string{"bar", "baz", "foo"}, r3)
 
 	r4 := UniqKeys[string, int]()
-	is.Equal(r4, []string{})
+	is.Equal([]string{}, r4)
 
 	r5 := UniqKeys(map[string]int{"foo": 1, "bar": 2}, map[string]int{"foo": 1, "bar": 3})
 	sort.Strings(r5)
-	is.Equal(r5, []string{"bar", "foo"})
+	is.Equal([]string{"bar", "foo"}, r5)
 
 	// check order
 	r6 := UniqKeys(map[string]int{"foo": 1}, map[string]int{"bar": 3})
-	is.Equal(r6, []string{"foo", "bar"})
+	is.Equal([]string{"foo", "bar"}, r6)
 }
 
 func TestHasKey(t *testing.T) {
@@ -76,21 +76,21 @@ func TestValues(t *testing.T) {
 
 	r1 := Values(map[string]int{"foo": 1, "bar": 2})
 	sort.Ints(r1)
-	is.Equal(r1, []int{1, 2})
+	is.Equal([]int{1, 2}, r1)
 
 	r2 := Values(map[string]int{})
 	is.Empty(r2)
 
 	r3 := Values(map[string]int{"foo": 1, "bar": 2}, map[string]int{"baz": 3})
 	sort.Ints(r3)
-	is.Equal(r3, []int{1, 2, 3})
+	is.Equal([]int{1, 2, 3}, r3)
 
 	r4 := Values[string, int]()
-	is.Equal(r4, []int{})
+	is.Equal([]int{}, r4)
 
 	r5 := Values(map[string]int{"foo": 1, "bar": 2}, map[string]int{"foo": 1, "bar": 3})
 	sort.Ints(r5)
-	is.Equal(r5, []int{1, 1, 2, 3})
+	is.Equal([]int{1, 1, 2, 3}, r5)
 }
 
 func TestUniqValues(t *testing.T) {
@@ -99,29 +99,29 @@ func TestUniqValues(t *testing.T) {
 
 	r1 := UniqValues(map[string]int{"foo": 1, "bar": 2})
 	sort.Ints(r1)
-	is.Equal(r1, []int{1, 2})
+	is.Equal([]int{1, 2}, r1)
 
 	r2 := UniqValues(map[string]int{})
 	is.Empty(r2)
 
 	r3 := UniqValues(map[string]int{"foo": 1, "bar": 2}, map[string]int{"baz": 3})
 	sort.Ints(r3)
-	is.Equal(r3, []int{1, 2, 3})
+	is.Equal([]int{1, 2, 3}, r3)
 
 	r4 := UniqValues[string, int]()
-	is.Equal(r4, []int{})
+	is.Equal([]int{}, r4)
 
 	r5 := UniqValues(map[string]int{"foo": 1, "bar": 2}, map[string]int{"foo": 1, "bar": 3})
 	sort.Ints(r5)
-	is.Equal(r5, []int{1, 2, 3})
+	is.Equal([]int{1, 2, 3}, r5)
 
 	r6 := UniqValues(map[string]int{"foo": 1, "bar": 1}, map[string]int{"foo": 1, "bar": 3})
 	sort.Ints(r6)
-	is.Equal(r6, []int{1, 3})
+	is.Equal([]int{1, 3}, r6)
 
 	// check order
 	r7 := UniqValues(map[string]int{"foo": 1}, map[string]int{"bar": 3})
-	is.Equal(r7, []int{1, 3})
+	is.Equal([]int{1, 3}, r7)
 }
 
 func TestValueOr(t *testing.T) {
@@ -129,10 +129,10 @@ func TestValueOr(t *testing.T) {
 	is := assert.New(t)
 
 	r1 := ValueOr(map[string]int{"foo": 1}, "bar", 2)
-	is.Equal(r1, 2)
+	is.Equal(2, r1)
 
 	r2 := ValueOr(map[string]int{"foo": 1}, "foo", 2)
-	is.Equal(r2, 1)
+	is.Equal(1, r2)
 }
 
 func TestPickBy(t *testing.T) {
@@ -143,7 +143,7 @@ func TestPickBy(t *testing.T) {
 		return value%2 == 1
 	})
 
-	is.Equal(r1, map[string]int{"foo": 1, "baz": 3})
+	is.Equal(map[string]int{"foo": 1, "baz": 3}, r1)
 
 	type myMap map[string]int
 	before := myMap{"": 0, "foobar": 6, "baz": 3}
@@ -157,7 +157,7 @@ func TestPickByKeys(t *testing.T) {
 
 	r1 := PickByKeys(map[string]int{"foo": 1, "bar": 2, "baz": 3}, []string{"foo", "baz", "qux"})
 
-	is.Equal(r1, map[string]int{"foo": 1, "baz": 3})
+	is.Equal(map[string]int{"foo": 1, "baz": 3}, r1)
 
 	type myMap map[string]int
 	before := myMap{"": 0, "foobar": 6, "baz": 3}
@@ -171,7 +171,7 @@ func TestPickByValues(t *testing.T) {
 
 	r1 := PickByValues(map[string]int{"foo": 1, "bar": 2, "baz": 3}, []int{1, 3})
 
-	is.Equal(r1, map[string]int{"foo": 1, "baz": 3})
+	is.Equal(map[string]int{"foo": 1, "baz": 3}, r1)
 
 	type myMap map[string]int
 	before := myMap{"": 0, "foobar": 6, "baz": 3}
@@ -187,7 +187,7 @@ func TestOmitBy(t *testing.T) {
 		return value%2 == 1
 	})
 
-	is.Equal(r1, map[string]int{"bar": 2})
+	is.Equal(map[string]int{"bar": 2}, r1)
 
 	type myMap map[string]int
 	before := myMap{"": 0, "foobar": 6, "baz": 3}
@@ -201,7 +201,7 @@ func TestOmitByKeys(t *testing.T) {
 
 	r1 := OmitByKeys(map[string]int{"foo": 1, "bar": 2, "baz": 3}, []string{"foo", "baz", "qux"})
 
-	is.Equal(r1, map[string]int{"bar": 2})
+	is.Equal(map[string]int{"bar": 2}, r1)
 
 	type myMap map[string]int
 	before := myMap{"": 0, "foobar": 6, "baz": 3}
@@ -215,7 +215,7 @@ func TestOmitByValues(t *testing.T) {
 
 	r1 := OmitByValues(map[string]int{"foo": 1, "bar": 2, "baz": 3}, []int{1, 3})
 
-	is.Equal(r1, map[string]int{"bar": 2})
+	is.Equal(map[string]int{"bar": 2}, r1)
 
 	type myMap map[string]int
 	before := myMap{"": 0, "foobar": 6, "baz": 3}
@@ -232,7 +232,7 @@ func TestEntries(t *testing.T) {
 	sort.Slice(r1, func(i, j int) bool {
 		return r1[i].Value < r1[j].Value
 	})
-	is.EqualValues(r1, []Entry[string, int]{
+	is.Equal([]Entry[string, int]{
 		{
 			Key:   "foo",
 			Value: 1,
@@ -241,7 +241,7 @@ func TestEntries(t *testing.T) {
 			Key:   "bar",
 			Value: 2,
 		},
-	})
+	}, r1)
 }
 
 func TestToPairs(t *testing.T) {
@@ -253,7 +253,7 @@ func TestToPairs(t *testing.T) {
 	sort.Slice(r1, func(i, j int) bool {
 		return r1[i].Value < r1[j].Value
 	})
-	is.EqualValues(r1, []Entry[string, int]{
+	is.Equal([]Entry[string, int]{
 		{
 			Key:   "baz",
 			Value: 3,
@@ -262,7 +262,7 @@ func TestToPairs(t *testing.T) {
 			Key:   "qux",
 			Value: 4,
 		},
-	})
+	}, r1)
 }
 
 func TestFromEntries(t *testing.T) {
@@ -281,8 +281,8 @@ func TestFromEntries(t *testing.T) {
 	})
 
 	is.Len(r1, 2)
-	is.Equal(r1["foo"], 1)
-	is.Equal(r1["bar"], 2)
+	is.Equal(1, r1["foo"])
+	is.Equal(2, r1["bar"])
 }
 
 func TestFromPairs(t *testing.T) {
@@ -301,8 +301,8 @@ func TestFromPairs(t *testing.T) {
 	})
 
 	is.Len(r1, 2)
-	is.Equal(r1["baz"], 3)
-	is.Equal(r1["qux"], 4)
+	is.Equal(3, r1["baz"])
+	is.Equal(4, r1["qux"])
 }
 
 func TestInvert(t *testing.T) {
@@ -313,7 +313,7 @@ func TestInvert(t *testing.T) {
 	r2 := Invert(map[string]int{"a": 1, "b": 2, "c": 1})
 
 	is.Len(r1, 2)
-	is.EqualValues(map[int]string{1: "a", 2: "b"}, r1)
+	is.Equal(map[int]string{1: "a", 2: "b"}, r1)
 	is.Len(r2, 2)
 }
 
@@ -324,7 +324,7 @@ func TestAssign(t *testing.T) {
 	result1 := Assign(map[string]int{"a": 1, "b": 2}, map[string]int{"b": 3, "c": 4})
 
 	is.Len(result1, 3)
-	is.Equal(result1, map[string]int{"a": 1, "b": 3, "c": 4})
+	is.Equal(map[string]int{"a": 1, "b": 3, "c": 4}, result1)
 
 	type myMap map[string]int
 	before := myMap{"": 0, "foobar": 6, "baz": 3}
@@ -375,7 +375,7 @@ func TestChunkEntries(t *testing.T) {
 	for k := range result6[0] {
 		result6[0][k] = 10
 	}
-	is.Equal(originalMap, map[string]int{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5})
+	is.Equal(map[string]int{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}, originalMap)
 }
 
 func TestMapKeys(t *testing.T) {
@@ -389,9 +389,9 @@ func TestMapKeys(t *testing.T) {
 		return strconv.FormatInt(int64(v), 10)
 	})
 
-	is.Equal(len(result1), 1)
-	is.Equal(len(result2), 4)
-	is.Equal(result2, map[string]int{"1": 1, "2": 2, "3": 3, "4": 4})
+	is.Len(result1, 1)
+	is.Len(result2, 4)
+	is.Equal(map[string]int{"1": 1, "2": 2, "3": 3, "4": 4}, result2)
 }
 
 func TestMapValues(t *testing.T) {
@@ -405,16 +405,16 @@ func TestMapValues(t *testing.T) {
 		return strconv.FormatInt(int64(x), 10)
 	})
 
-	is.Equal(len(result1), 4)
-	is.Equal(len(result2), 4)
-	is.Equal(result1, map[int]string{1: "Hello", 2: "Hello", 3: "Hello", 4: "Hello"})
-	is.Equal(result2, map[int]string{1: "1", 2: "2", 3: "3", 4: "4"})
+	is.Len(result1, 4)
+	is.Len(result2, 4)
+	is.Equal(map[int]string{1: "Hello", 2: "Hello", 3: "Hello", 4: "Hello"}, result1)
+	is.Equal(map[int]string{1: "1", 2: "2", 3: "3", 4: "4"}, result2)
 }
 
 func mapEntriesTest[I any, O any](t *testing.T, in map[string]I, iteratee func(string, I) (string, O), expected map[string]O) {
 	is := assert.New(t)
 	result := MapEntries(in, iteratee)
-	is.Equal(result, expected)
+	is.Equal(expected, result)
 }
 
 func TestMapEntries(t *testing.T) {
@@ -435,7 +435,7 @@ func TestMapEntries(t *testing.T) {
 		MapEntries(r1, func(k string, v int) (string, string) {
 			return k, strconv.Itoa(v) + "!!"
 		})
-		is.Equal(r1, map[string]int{"foo": 1, "bar": 2})
+		is.Equal(map[string]int{"foo": 1, "bar": 2}, r1)
 	}
 	// EmptyInput
 	{
@@ -507,8 +507,8 @@ func TestMapToSlice(t *testing.T) {
 		return strconv.FormatInt(int64(k), 10)
 	})
 
-	is.Equal(len(result1), 4)
-	is.Equal(len(result2), 4)
+	is.Len(result1, 4)
+	is.Len(result2, 4)
 	is.ElementsMatch(result1, []string{"1_5", "2_6", "3_7", "4_8"})
 	is.ElementsMatch(result2, []string{"1", "2", "3", "4"})
 }
@@ -524,8 +524,8 @@ func TestFilterMapToSlice(t *testing.T) {
 		return strconv.FormatInt(int64(k), 10), k%2 == 0
 	})
 
-	is.Equal(len(result1), 2)
-	is.Equal(len(result2), 2)
+	is.Len(result1, 2)
+	is.Len(result2, 2)
 	is.ElementsMatch(result1, []string{"2_6", "4_8"})
 	is.ElementsMatch(result2, []string{"2", "4"})
 }
@@ -544,7 +544,7 @@ func TestFilterKeys(t *testing.T) {
 		return false
 	})
 	is.Equal([]string{}, result2)
-	is.Len(result2, 0)
+	is.Empty(result2)
 }
 
 func TestFilterValues(t *testing.T) {
@@ -561,7 +561,7 @@ func TestFilterValues(t *testing.T) {
 		return false
 	})
 	is.Equal([]int{}, result2)
-	is.Len(result2, 0)
+	is.Empty(result2)
 }
 
 func BenchmarkAssign(b *testing.B) {

--- a/math_test.go
+++ b/math_test.go
@@ -13,9 +13,9 @@ func TestRange(t *testing.T) {
 	result1 := Range(4)
 	result2 := Range(-4)
 	result3 := Range(0)
-	is.Equal(result1, []int{0, 1, 2, 3})
-	is.Equal(result2, []int{0, -1, -2, -3})
-	is.Equal(result3, []int{})
+	is.Equal([]int{0, 1, 2, 3}, result1)
+	is.Equal([]int{0, -1, -2, -3}, result2)
+	is.Equal([]int{}, result3)
 }
 
 func TestRangeFrom(t *testing.T) {
@@ -27,11 +27,11 @@ func TestRangeFrom(t *testing.T) {
 	result3 := RangeFrom(10, 0)
 	result4 := RangeFrom(2.0, 3)
 	result5 := RangeFrom(-2.0, -3)
-	is.Equal(result1, []int{1, 2, 3, 4, 5})
-	is.Equal(result2, []int{-1, -2, -3, -4, -5})
-	is.Equal(result3, []int{})
-	is.Equal(result4, []float64{2.0, 3.0, 4.0})
-	is.Equal(result5, []float64{-2.0, -3.0, -4.0})
+	is.Equal([]int{1, 2, 3, 4, 5}, result1)
+	is.Equal([]int{-1, -2, -3, -4, -5}, result2)
+	is.Equal([]int{}, result3)
+	is.Equal([]float64{2.0, 3.0, 4.0}, result4)
+	is.Equal([]float64{-2.0, -3.0, -4.0}, result5)
 }
 
 func TestRangeClose(t *testing.T) {
@@ -60,9 +60,9 @@ func TestClamp(t *testing.T) {
 	result2 := Clamp(-42, -10, 10)
 	result3 := Clamp(42, -10, 10)
 
-	is.Equal(result1, 0)
-	is.Equal(result2, -10)
-	is.Equal(result3, 10)
+	is.Zero(result1)
+	is.Equal(-10, result2)
+	is.Equal(10, result3)
 }
 
 func TestSum(t *testing.T) {
@@ -74,11 +74,11 @@ func TestSum(t *testing.T) {
 	result4 := Sum([]uint32{})
 	result5 := Sum([]complex128{4_4, 2_2})
 
-	is.Equal(result1, float32(14.900001))
-	is.Equal(result2, int32(14))
-	is.Equal(result3, uint32(14))
-	is.Equal(result4, uint32(0))
-	is.Equal(result5, complex128(6_6))
+	is.InEpsilon(14.9, result1, 1e-7)
+	is.Equal(int32(14), result2)
+	is.Equal(uint32(14), result3)
+	is.Equal(uint32(0), result4)
+	is.Equal(complex128(6_6), result5)
 }
 
 func TestSumBy(t *testing.T) {
@@ -91,11 +91,11 @@ func TestSumBy(t *testing.T) {
 	result4 := SumBy([]uint32{}, func(n uint32) uint32 { return n })
 	result5 := SumBy([]complex128{4_4, 2_2}, func(n complex128) complex128 { return n })
 
-	is.Equal(result1, float32(14.900001))
-	is.Equal(result2, int32(14))
-	is.Equal(result3, uint32(14))
-	is.Equal(result4, uint32(0))
-	is.Equal(result5, complex128(6_6))
+	is.InEpsilon(14.9, result1, 1e-7)
+	is.Equal(int32(14), result2)
+	is.Equal(uint32(14), result3)
+	is.Equal(uint32(0), result4)
+	is.Equal(complex128(6_6), result5)
 }
 
 func TestProduct(t *testing.T) {
@@ -110,14 +110,14 @@ func TestProduct(t *testing.T) {
 	result7 := Product([]complex128{4_4, 2_2})
 	result8 := Product[uint32](nil)
 
-	is.Equal(result1, float32(160.908))
-	is.Equal(result2, int32(120))
-	is.Equal(result3, int32(0))
-	is.Equal(result4, int32(-126))
-	is.Equal(result5, uint32(120))
-	is.Equal(result6, uint32(1))
-	is.Equal(result7, complex128(96_8))
-	is.Equal(result8, uint32(1))
+	is.InEpsilon(160.908, result1, 1e-7)
+	is.Equal(int32(120), result2)
+	is.Equal(int32(0), result3)
+	is.Equal(int32(-126), result4)
+	is.Equal(uint32(120), result5)
+	is.Equal(uint32(1), result6)
+	is.Equal(complex128(96_8), result7)
+	is.Equal(uint32(1), result8)
 }
 
 func TestProductBy(t *testing.T) {
@@ -132,14 +132,14 @@ func TestProductBy(t *testing.T) {
 	result7 := ProductBy([]complex128{4_4, 2_2}, func(n complex128) complex128 { return n })
 	result8 := ProductBy(nil, func(n uint32) uint32 { return n })
 
-	is.Equal(result1, float32(160.908))
-	is.Equal(result2, int32(120))
-	is.Equal(result3, int32(0))
-	is.Equal(result4, int32(-126))
-	is.Equal(result5, uint32(120))
-	is.Equal(result6, uint32(1))
-	is.Equal(result7, complex128(96_8))
-	is.Equal(result8, uint32(1))
+	is.InEpsilon(160.908, result1, 1e-7)
+	is.Equal(int32(120), result2)
+	is.Equal(int32(0), result3)
+	is.Equal(int32(-126), result4)
+	is.Equal(uint32(120), result5)
+	is.Equal(uint32(1), result6)
+	is.Equal(complex128(96_8), result7)
+	is.Equal(uint32(1), result8)
 }
 
 func TestMean(t *testing.T) {
@@ -151,10 +151,10 @@ func TestMean(t *testing.T) {
 	result3 := Mean([]uint32{2, 3, 4, 5})
 	result4 := Mean([]uint32{})
 
-	is.Equal(result1, float32(3.7250001))
-	is.Equal(result2, int32(3))
-	is.Equal(result3, uint32(3))
-	is.Equal(result4, uint32(0))
+	is.InEpsilon(3.725, result1, 1e-7)
+	is.Equal(int32(3), result2)
+	is.Equal(uint32(3), result3)
+	is.Equal(uint32(0), result4)
 }
 
 func TestMeanBy(t *testing.T) {
@@ -166,10 +166,10 @@ func TestMeanBy(t *testing.T) {
 	result3 := MeanBy([]uint32{2, 3, 4, 5}, func(n uint32) uint32 { return n })
 	result4 := MeanBy([]uint32{}, func(n uint32) uint32 { return n })
 
-	is.Equal(result1, float32(3.7250001))
-	is.Equal(result2, int32(3))
-	is.Equal(result3, uint32(3))
-	is.Equal(result4, uint32(0))
+	is.InEpsilon(3.725, result1, 1e-7)
+	is.Equal(int32(3), result2)
+	is.Equal(uint32(3), result3)
+	is.Equal(uint32(0), result4)
 }
 
 func TestMode(t *testing.T) {
@@ -182,9 +182,9 @@ func TestMode(t *testing.T) {
 	result4 := Mode([]uint32{})
 	result5 := Mode([]int{1, 2, 3, 4, 5, 6, 7, 8, 9})
 
-	is.Equal(result1, []float32{3.3})
-	is.Equal(result2, []int32{2})
-	is.Equal(result3, []uint32{2, 3})
-	is.Equal(result4, []uint32{})
-	is.Equal(result5, []int{1, 2, 3, 4, 5, 6, 7, 8, 9})
+	is.Equal([]float32{3.3}, result1)
+	is.Equal([]int32{2}, result2)
+	is.Equal([]uint32{2, 3}, result3)
+	is.Equal([]uint32{}, result4)
+	is.Equal([]int{1, 2, 3, 4, 5, 6, 7, 8, 9}, result5)
 }

--- a/mutable/slice_test.go
+++ b/mutable/slice_test.go
@@ -15,16 +15,16 @@ func TestFilter(t *testing.T) {
 		return x%2 == 0
 	})
 
-	is.Equal(input1, []int{2, 4, 3, 4})
-	is.Equal(r1, []int{2, 4})
+	is.Equal([]int{2, 4, 3, 4}, input1)
+	is.Equal([]int{2, 4}, r1)
 
 	input2 := []string{"", "foo", "", "bar", ""}
 	r2 := Filter(input2, func(x string) bool {
 		return len(x) > 0
 	})
 
-	is.Equal(input2, []string{"foo", "bar", "", "bar", ""})
-	is.Equal(r2, []string{"foo", "bar"})
+	is.Equal([]string{"foo", "bar", "", "bar", ""}, input2)
+	is.Equal([]string{"foo", "bar"}, r2)
 }
 
 func TestFilterI(t *testing.T) {
@@ -36,7 +36,7 @@ func TestFilterI(t *testing.T) {
 		return x%2 == 0
 	})
 
-	is.Equal(r1, []int{2, 4})
+	is.Equal([]int{2, 4}, r1)
 }
 
 func TestMap(t *testing.T) {
@@ -47,15 +47,15 @@ func TestMap(t *testing.T) {
 	Map(list, func(x int) int {
 		return x * 2
 	})
-	is.Equal(len(list), 4)
-	is.Equal(list, []int{2, 4, 6, 8})
+	is.Len(list, 4)
+	is.Equal([]int{2, 4, 6, 8}, list)
 
 	list = []int{1, 2, 3, 4}
 	Map(list, func(x int) int {
 		return x * 4
 	})
-	is.Equal(len(list), 4)
-	is.Equal(list, []int{4, 8, 12, 16})
+	is.Len(list, 4)
+	is.Equal([]int{4, 8, 12, 16}, list)
 }
 
 func TestMapI(t *testing.T) {
@@ -67,16 +67,16 @@ func TestMapI(t *testing.T) {
 		is.Equal(index, x-1)
 		return x * 2
 	})
-	is.Equal(len(list), 4)
-	is.Equal(list, []int{2, 4, 6, 8})
+	is.Len(list, 4)
+	is.Equal([]int{2, 4, 6, 8}, list)
 
 	list = []int{1, 2, 3, 4}
 	MapI(list, func(x int, index int) int {
 		is.Equal(index, x-1)
 		return x * 4
 	})
-	is.Equal(len(list), 4)
-	is.Equal(list, []int{4, 8, 12, 16})
+	is.Len(list, 4)
+	is.Equal([]int{4, 8, 12, 16}, list)
 }
 
 func TestShuffle(t *testing.T) {
@@ -85,11 +85,11 @@ func TestShuffle(t *testing.T) {
 
 	list := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	Shuffle(list)
-	is.NotEqual(list, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+	is.NotEqual([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, list)
 
 	list = []int{}
 	Shuffle(list)
-	is.Equal(list, []int{})
+	is.Equal([]int{}, list)
 }
 
 func TestReverse(t *testing.T) {
@@ -98,15 +98,15 @@ func TestReverse(t *testing.T) {
 
 	list := []int{0, 1, 2, 3, 4, 5}
 	Reverse(list)
-	is.Equal(list, []int{5, 4, 3, 2, 1, 0})
+	is.Equal([]int{5, 4, 3, 2, 1, 0}, list)
 
 	list = []int{0, 1, 2, 3, 4, 5, 6}
 	Reverse(list)
-	is.Equal(list, []int{6, 5, 4, 3, 2, 1, 0})
+	is.Equal([]int{6, 5, 4, 3, 2, 1, 0}, list)
 
 	list = []int{}
 	Reverse(list)
-	is.Equal(list, []int{})
+	is.Equal([]int{}, list)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}

--- a/parallel/slice_test.go
+++ b/parallel/slice_test.go
@@ -19,10 +19,10 @@ func TestMap(t *testing.T) {
 		return strconv.FormatInt(x, 10)
 	})
 
-	is.Equal(len(result1), 4)
-	is.Equal(len(result2), 4)
-	is.Equal(result1, []string{"Hello", "Hello", "Hello", "Hello"})
-	is.Equal(result2, []string{"1", "2", "3", "4"})
+	is.Len(result1, 4)
+	is.Len(result2, 4)
+	is.Equal([]string{"Hello", "Hello", "Hello", "Hello"}, result1)
+	is.Equal([]string{"1", "2", "3", "4"}, result2)
 }
 
 func TestForEach(t *testing.T) {
@@ -44,8 +44,8 @@ func TestTimes(t *testing.T) {
 		return strconv.FormatInt(int64(i), 10)
 	})
 
-	is.Equal(len(result1), 3)
-	is.Equal(result1, []string{"0", "1", "2"})
+	is.Len(result1, 3)
+	is.Equal([]string{"0", "1", "2"}, result1)
 }
 
 func TestGroupBy(t *testing.T) {
@@ -62,12 +62,12 @@ func TestGroupBy(t *testing.T) {
 		})
 	}
 
-	is.EqualValues(len(result1), 3)
-	is.EqualValues(result1, map[int][]int{
+	is.Len(result1, 3)
+	is.Equal(map[int][]int{
 		0: {0, 3},
 		1: {1, 4},
 		2: {2, 5},
-	})
+	}, result1)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -103,7 +103,7 @@ func TestPartitionBy(t *testing.T) {
 	}
 
 	is.ElementsMatch(result1, [][]int{{-2, -1}, {0, 2, 4}, {1, 3, 5}})
-	is.Equal(result2, [][]int{})
+	is.Equal([][]int{}, result2)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}

--- a/retry_test.go
+++ b/retry_test.go
@@ -40,14 +40,14 @@ func TestAttempt(t *testing.T) {
 		return nil
 	})
 
-	is.Equal(iter1, 1)
-	is.Equal(err1, nil)
-	is.Equal(iter2, 6)
-	is.Equal(err2, nil)
-	is.Equal(iter3, 2)
+	is.Equal(1, iter1)
+	is.NoError(err1)
+	is.Equal(6, iter2)
+	is.NoError(err2)
+	is.Equal(2, iter3)
 	is.Equal(err3, err)
-	is.Equal(iter4, 43)
-	is.Equal(err4, nil)
+	is.Equal(43, iter4)
+	is.NoError(err4)
 }
 
 func TestAttemptWithDelay(t *testing.T) {
@@ -81,22 +81,22 @@ func TestAttemptWithDelay(t *testing.T) {
 		return nil
 	})
 
-	is.Equal(iter1, 1)
+	is.Equal(1, iter1)
 	is.GreaterOrEqual(dur1, 0*time.Millisecond)
 	is.Less(dur1, 1*time.Millisecond)
-	is.Equal(err1, nil)
-	is.Equal(iter2, 6)
+	is.NoError(err1)
+	is.Equal(6, iter2)
 	is.Greater(dur2, 50*time.Millisecond)
 	is.Less(dur2, 60*time.Millisecond)
-	is.Equal(err2, nil)
-	is.Equal(iter3, 2)
+	is.NoError(err2)
+	is.Equal(2, iter3)
 	is.Greater(dur3, 10*time.Millisecond)
 	is.Less(dur3, 20*time.Millisecond)
 	is.Equal(err3, err)
-	is.Equal(iter4, 11)
+	is.Equal(11, iter4)
 	is.Greater(dur4, 100*time.Millisecond)
 	is.Less(dur4, 115*time.Millisecond)
-	is.Equal(err4, nil)
+	is.NoError(err4)
 }
 
 func TestAttemptWhile(t *testing.T) {
@@ -108,8 +108,8 @@ func TestAttemptWhile(t *testing.T) {
 		return nil, true
 	})
 
-	is.Equal(iter1, 1)
-	is.Nil(err1)
+	is.Equal(1, iter1)
+	is.NoError(err1)
 
 	iter2, err2 := AttemptWhile(42, func(i int) (error, bool) {
 		if i == 5 {
@@ -119,8 +119,8 @@ func TestAttemptWhile(t *testing.T) {
 		return err, true
 	})
 
-	is.Equal(iter2, 6)
-	is.Nil(err2)
+	is.Equal(6, iter2)
+	is.NoError(err2)
 
 	iter3, err3 := AttemptWhile(2, func(i int) (error, bool) {
 		if i == 5 {
@@ -130,7 +130,7 @@ func TestAttemptWhile(t *testing.T) {
 		return err, true
 	})
 
-	is.Equal(iter3, 2)
+	is.Equal(2, iter3)
 	is.Equal(err3, err)
 
 	iter4, err4 := AttemptWhile(0, func(i int) (error, bool) {
@@ -141,8 +141,8 @@ func TestAttemptWhile(t *testing.T) {
 		return nil, true
 	})
 
-	is.Equal(iter4, 43)
-	is.Nil(err4)
+	is.Equal(43, iter4)
+	is.NoError(err4)
 
 	iter5, err5 := AttemptWhile(0, func(i int) (error, bool) {
 		if i == 5 {
@@ -152,15 +152,15 @@ func TestAttemptWhile(t *testing.T) {
 		return err, true
 	})
 
-	is.Equal(iter5, 6)
-	is.Nil(err5)
+	is.Equal(6, iter5)
+	is.NoError(err5)
 
 	iter6, err6 := AttemptWhile(0, func(i int) (error, bool) {
 		return nil, false
 	})
 
-	is.Equal(iter6, 1)
-	is.Nil(err6)
+	is.Equal(1, iter6)
+	is.NoError(err6)
 
 	iter7, err7 := AttemptWhile(42, func(i int) (error, bool) {
 		if i == 42 {
@@ -173,8 +173,8 @@ func TestAttemptWhile(t *testing.T) {
 		return nil, true
 	})
 
-	is.Equal(iter7, 42)
-	is.Nil(err7)
+	is.Equal(42, iter7)
+	is.NoError(err7)
 }
 
 func TestAttemptWhileWithDelay(t *testing.T) {
@@ -186,10 +186,10 @@ func TestAttemptWhileWithDelay(t *testing.T) {
 		return nil, true
 	})
 
-	is.Equal(iter1, 1)
+	is.Equal(1, iter1)
 	is.GreaterOrEqual(dur1, 0*time.Millisecond)
 	is.Less(dur1, 1*time.Millisecond)
-	is.Nil(err1)
+	is.NoError(err1)
 
 	iter2, dur2, err2 := AttemptWhileWithDelay(42, 10*time.Millisecond, func(i int, d time.Duration) (error, bool) {
 		if i == 5 {
@@ -199,10 +199,10 @@ func TestAttemptWhileWithDelay(t *testing.T) {
 		return err, true
 	})
 
-	is.Equal(iter2, 6)
+	is.Equal(6, iter2)
 	is.Greater(dur2, 50*time.Millisecond)
 	is.Less(dur2, 60*time.Millisecond)
-	is.Nil(err2)
+	is.NoError(err2)
 
 	iter3, dur3, err3 := AttemptWhileWithDelay(2, 10*time.Millisecond, func(i int, d time.Duration) (error, bool) {
 		if i == 5 {
@@ -212,7 +212,7 @@ func TestAttemptWhileWithDelay(t *testing.T) {
 		return err, true
 	})
 
-	is.Equal(iter3, 2)
+	is.Equal(2, iter3)
 	is.Greater(dur3, 10*time.Millisecond)
 	is.Less(dur3, 20*time.Millisecond)
 	is.Equal(err3, err)
@@ -225,10 +225,10 @@ func TestAttemptWhileWithDelay(t *testing.T) {
 		return nil, true
 	})
 
-	is.Equal(iter4, 11)
+	is.Equal(11, iter4)
 	is.Greater(dur4, 100*time.Millisecond)
 	is.Less(dur4, 115*time.Millisecond)
-	is.Nil(err4)
+	is.NoError(err4)
 
 	iter5, dur5, err5 := AttemptWhileWithDelay(0, 10*time.Millisecond, func(i int, d time.Duration) (error, bool) {
 		if i == 5 {
@@ -238,19 +238,19 @@ func TestAttemptWhileWithDelay(t *testing.T) {
 		return err, true
 	})
 
-	is.Equal(iter5, 6)
+	is.Equal(6, iter5)
 	is.Greater(dur5, 10*time.Millisecond)
 	is.Less(dur5, 115*time.Millisecond)
-	is.Nil(err5)
+	is.NoError(err5)
 
 	iter6, dur6, err6 := AttemptWhileWithDelay(0, 10*time.Millisecond, func(i int, d time.Duration) (error, bool) {
 		return nil, false
 	})
 
-	is.Equal(iter6, 1)
+	is.Equal(1, iter6)
 	is.Less(dur6, 10*time.Millisecond)
 	is.Less(dur6, 115*time.Millisecond)
-	is.Nil(err6)
+	is.NoError(err6)
 
 	iter7, dur7, err7 := AttemptWhileWithDelay(42, 10*time.Millisecond, func(i int, d time.Duration) (error, bool) {
 		if i == 42 {
@@ -263,9 +263,9 @@ func TestAttemptWhileWithDelay(t *testing.T) {
 		return nil, true
 	})
 
-	is.Equal(iter7, 42)
+	is.Equal(42, iter7)
 	is.Less(dur7, 500*time.Millisecond)
-	is.Nil(err7)
+	is.NoError(err7)
 }
 
 func TestDebounce(t *testing.T) {
@@ -355,9 +355,9 @@ func TestDebounceBy(t *testing.T) {
 	}
 
 	mu.Lock()
-	is.EqualValues(output[0], 30)
-	is.EqualValues(output[1], 30)
-	is.EqualValues(output[2], 30)
+	is.Equal(30, output[0])
+	is.Equal(30, output[1])
+	is.Equal(30, output[2])
 	mu.Unlock()
 
 	d2, _ := NewDebounceBy(10*time.Millisecond, f2)
@@ -375,9 +375,9 @@ func TestDebounceBy(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	mu.Lock()
-	is.EqualValues(output[0], 45)
-	is.EqualValues(output[1], 45)
-	is.EqualValues(output[2], 45)
+	is.Equal(45, output[0])
+	is.Equal(45, output[1])
+	is.Equal(45, output[2])
 	mu.Unlock()
 
 	// execute once because it is canceled after 200ms.
@@ -398,9 +398,9 @@ func TestDebounceBy(t *testing.T) {
 	}
 
 	mu.Lock()
-	is.EqualValues(output[0], 75)
-	is.EqualValues(output[1], 75)
-	is.EqualValues(output[2], 75)
+	is.Equal(75, output[0])
+	is.Equal(75, output[1])
+	is.Equal(75, output[2])
 	mu.Unlock()
 }
 
@@ -429,7 +429,7 @@ func TestTransaction(t *testing.T) {
 
 		state, err := transaction.Process(21)
 		is.Equal(142, state)
-		is.Equal(nil, err)
+		is.NoError(err)
 	}
 
 	// with error
@@ -508,7 +508,7 @@ func TestNewThrottle(t *testing.T) {
 	}
 	th, reset := NewThrottle(10*time.Millisecond, f1)
 
-	is.Equal(0, callCount)
+	is.Zero(callCount)
 	for j := 0; j < 100; j++ {
 		th()
 	}
@@ -574,8 +574,8 @@ func TestNewThrottleBy(t *testing.T) {
 	}
 	th, reset := NewThrottleBy(10*time.Millisecond, f1)
 
-	is.Equal(0, callCountA)
-	is.Equal(0, callCountB)
+	is.Zero(callCountA)
+	is.Zero(callCountB)
 	for j := 0; j < 100; j++ {
 		th("a")
 		th("b")

--- a/slice_test.go
+++ b/slice_test.go
@@ -18,12 +18,12 @@ func TestFilter(t *testing.T) {
 	r1 := Filter([]int{1, 2, 3, 4}, func(x int, _ int) bool {
 		return x%2 == 0
 	})
-	is.Equal(r1, []int{2, 4})
+	is.Equal([]int{2, 4}, r1)
 
 	r2 := Filter([]string{"", "foo", "", "bar", ""}, func(x string, _ int) bool {
 		return len(x) > 0
 	})
-	is.Equal(r2, []string{"foo", "bar"})
+	is.Equal([]string{"foo", "bar"}, r2)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -44,10 +44,10 @@ func TestMap(t *testing.T) {
 		return strconv.FormatInt(x, 10)
 	})
 
-	is.Equal(len(result1), 4)
-	is.Equal(len(result2), 4)
-	is.Equal(result1, []string{"Hello", "Hello", "Hello", "Hello"})
-	is.Equal(result2, []string{"1", "2", "3", "4"})
+	is.Len(result1, 4)
+	is.Len(result2, 4)
+	is.Equal([]string{"Hello", "Hello", "Hello", "Hello"}, result1)
+	is.Equal([]string{"1", "2", "3", "4"}, result2)
 }
 
 func TestUniqMap(t *testing.T) {
@@ -64,7 +64,7 @@ func TestUniqMap(t *testing.T) {
 		return item.Name
 	})
 
-	is.Equal(result, []string{"Alice", "Alex"})
+	is.Equal([]string{"Alice", "Alex"}, result)
 }
 
 func TestFilterMap(t *testing.T) {
@@ -84,10 +84,10 @@ func TestFilterMap(t *testing.T) {
 		return "", false
 	})
 
-	is.Equal(len(r1), 2)
-	is.Equal(len(r2), 2)
-	is.Equal(r1, []string{"2", "4"})
-	is.Equal(r2, []string{"xpu", "xpu"})
+	is.Len(r1, 2)
+	is.Len(r2, 2)
+	is.Equal([]string{"2", "4"}, r1)
+	is.Equal([]string{"xpu", "xpu"}, r2)
 }
 
 func TestFlatMap(t *testing.T) {
@@ -105,10 +105,10 @@ func TestFlatMap(t *testing.T) {
 		return result
 	})
 
-	is.Equal(len(result1), 5)
-	is.Equal(len(result2), 10)
-	is.Equal(result1, []string{"Hello", "Hello", "Hello", "Hello", "Hello"})
-	is.Equal(result2, []string{"1", "2", "2", "3", "3", "3", "4", "4", "4", "4"})
+	is.Len(result1, 5)
+	is.Len(result2, 10)
+	is.Equal([]string{"Hello", "Hello", "Hello", "Hello", "Hello"}, result1)
+	is.Equal([]string{"1", "2", "2", "3", "3", "3", "4", "4", "4", "4"}, result2)
 }
 
 func TestTimes(t *testing.T) {
@@ -119,8 +119,8 @@ func TestTimes(t *testing.T) {
 		return strconv.FormatInt(int64(i), 10)
 	})
 
-	is.Equal(len(result1), 3)
-	is.Equal(result1, []string{"0", "1", "2"})
+	is.Len(result1, 3)
+	is.Equal([]string{"0", "1", "2"}, result1)
 }
 
 func TestReduce(t *testing.T) {
@@ -134,8 +134,8 @@ func TestReduce(t *testing.T) {
 		return agg + item
 	}, 10)
 
-	is.Equal(result1, 10)
-	is.Equal(result2, 20)
+	is.Equal(10, result1)
+	is.Equal(20, result2)
 }
 
 func TestReduceRight(t *testing.T) {
@@ -146,13 +146,13 @@ func TestReduceRight(t *testing.T) {
 		return append(agg, item...)
 	}, []int{})
 
-	is.Equal(result1, []int{4, 5, 2, 3, 0, 1})
+	is.Equal([]int{4, 5, 2, 3, 0, 1}, result1)
 
 	type collection []int
 	result3 := ReduceRight(collection{1, 2, 3, 4}, func(agg int, item int, _ int) int {
 		return agg + item
 	}, 10)
-	is.Equal(result3, 20)
+	is.Equal(20, result3)
 }
 
 func TestForEach(t *testing.T) {
@@ -203,8 +203,8 @@ func TestUniq(t *testing.T) {
 
 	result1 := Uniq([]int{1, 2, 2, 1})
 
-	is.Equal(len(result1), 2)
-	is.Equal(result1, []int{1, 2})
+	is.Len(result1, 2)
+	is.Equal([]int{1, 2}, result1)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -220,8 +220,8 @@ func TestUniqBy(t *testing.T) {
 		return i % 3
 	})
 
-	is.Equal(len(result1), 3)
-	is.Equal(result1, []int{0, 1, 2})
+	is.Len(result1, 3)
+	is.Equal([]int{0, 1, 2}, result1)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -239,12 +239,12 @@ func TestGroupBy(t *testing.T) {
 		return i % 3
 	})
 
-	is.Equal(len(result1), 3)
-	is.Equal(result1, map[int][]int{
+	is.Len(result1, 3)
+	is.Equal(map[int][]int{
 		0: {0, 3},
 		1: {1, 4},
 		2: {2, 5},
-	})
+	}, result1)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -262,12 +262,12 @@ func TestGroupByMap(t *testing.T) {
 		return i % 3, strconv.Itoa(i)
 	})
 
-	is.Equal(len(result1), 3)
-	is.Equal(result1, map[int][]string{
+	is.Len(result1, 3)
+	is.Equal(map[int][]string{
 		0: {"0", "3"},
 		1: {"1", "4"},
 		2: {"2", "5"},
-	})
+	}, result1)
 
 	type myInt int
 	type myInts []myInt
@@ -275,12 +275,12 @@ func TestGroupByMap(t *testing.T) {
 		return int(i % 3), strconv.Itoa(int(i))
 	})
 
-	is.Equal(len(result2), 3)
-	is.Equal(result2, map[int][]string{
+	is.Len(result2, 3)
+	is.Equal(map[int][]string{
 		0: {"0", "3"},
 		1: {"1", "4"},
 		2: {"2", "5"},
-	})
+	}, result2)
 
 	type product struct {
 		ID         int64
@@ -297,12 +297,12 @@ func TestGroupByMap(t *testing.T) {
 		return item.CategoryID, "Product " + strconv.FormatInt(item.ID, 10)
 	})
 
-	is.Equal(len(result3), 3)
-	is.Equal(result3, map[int64][]string{
+	is.Len(result3, 3)
+	is.Equal(map[int64][]string{
 		1: {"Product 1", "Product 2"},
 		2: {"Product 3"},
 		3: {"Product 4", "Product 5"},
-	})
+	}, result3)
 }
 
 func TestChunk(t *testing.T) {
@@ -314,10 +314,10 @@ func TestChunk(t *testing.T) {
 	result3 := Chunk([]int{}, 2)
 	result4 := Chunk([]int{0}, 2)
 
-	is.Equal(result1, [][]int{{0, 1}, {2, 3}, {4, 5}})
-	is.Equal(result2, [][]int{{0, 1}, {2, 3}, {4, 5}, {6}})
-	is.Equal(result3, [][]int{})
-	is.Equal(result4, [][]int{{0}})
+	is.Equal([][]int{{0, 1}, {2, 3}, {4, 5}}, result1)
+	is.Equal([][]int{{0, 1}, {2, 3}, {4, 5}, {6}}, result2)
+	is.Equal([][]int{}, result3)
+	is.Equal([][]int{{0}}, result4)
 	is.PanicsWithValue("Second parameter must be greater than 0", func() {
 		Chunk([]int{0}, 0)
 	})
@@ -331,7 +331,7 @@ func TestChunk(t *testing.T) {
 	originalArray := []int{0, 1, 2, 3, 4, 5}
 	result5 := Chunk(originalArray, 2)
 	result5[0] = append(result5[0], 6)
-	is.Equal(originalArray, []int{0, 1, 2, 3, 4, 5})
+	is.Equal([]int{0, 1, 2, 3, 4, 5}, originalArray)
 }
 
 func TestPartitionBy(t *testing.T) {
@@ -350,8 +350,8 @@ func TestPartitionBy(t *testing.T) {
 	result1 := PartitionBy([]int{-2, -1, 0, 1, 2, 3, 4, 5}, oddEven)
 	result2 := PartitionBy([]int{}, oddEven)
 
-	is.Equal(result1, [][]int{{-2, -1}, {0, 2, 4}, {1, 3, 5}})
-	is.Equal(result2, [][]int{})
+	is.Equal([][]int{{-2, -1}, {0, 2, 4}, {1, 3, 5}}, result1)
+	is.Equal([][]int{}, result2)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -367,7 +367,7 @@ func TestFlatten(t *testing.T) {
 
 	result1 := Flatten([][]int{{0, 1}, {2, 3, 4, 5}})
 
-	is.Equal(result1, []int{0, 1, 2, 3, 4, 5})
+	is.Equal([]int{0, 1, 2, 3, 4, 5}, result1)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -435,8 +435,8 @@ func TestShuffle(t *testing.T) {
 	result1 := Shuffle([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
 	result2 := Shuffle([]int{})
 
-	is.NotEqual(result1, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
-	is.Equal(result2, []int{})
+	is.NotEqual([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, result1)
+	is.Equal([]int{}, result2)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -452,9 +452,9 @@ func TestReverse(t *testing.T) {
 	result2 := Reverse([]int{0, 1, 2, 3, 4, 5, 6})
 	result3 := Reverse([]int{})
 
-	is.Equal(result1, []int{5, 4, 3, 2, 1, 0})
-	is.Equal(result2, []int{6, 5, 4, 3, 2, 1, 0})
-	is.Equal(result3, []int{})
+	is.Equal([]int{5, 4, 3, 2, 1, 0}, result1)
+	is.Equal([]int{6, 5, 4, 3, 2, 1, 0}, result2)
+	is.Equal([]int{}, result3)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -469,8 +469,8 @@ func TestFill(t *testing.T) {
 	result1 := Fill([]foo{{"a"}, {"a"}}, foo{"b"})
 	result2 := Fill([]foo{}, foo{"a"})
 
-	is.Equal(result1, []foo{{"b"}, {"b"}})
-	is.Equal(result2, []foo{})
+	is.Equal([]foo{{"b"}, {"b"}}, result1)
+	is.Equal([]foo{}, result2)
 }
 
 func TestRepeat(t *testing.T) {
@@ -480,8 +480,8 @@ func TestRepeat(t *testing.T) {
 	result1 := Repeat(2, foo{"a"})
 	result2 := Repeat(0, foo{"a"})
 
-	is.Equal(result1, []foo{{"a"}, {"a"}})
-	is.Equal(result2, []foo{})
+	is.Equal([]foo{{"a"}, {"a"}}, result1)
+	is.Equal([]foo{}, result2)
 }
 
 func TestRepeatBy(t *testing.T) {
@@ -509,7 +509,7 @@ func TestKeyBy(t *testing.T) {
 		return len(str)
 	})
 
-	is.Equal(result1, map[int]string{1: "a", 2: "aa", 3: "aaa"})
+	is.Equal(map[int]string{1: "a", 2: "aa", 3: "aaa"}, result1)
 }
 
 func TestAssociate(t *testing.T) {
@@ -624,9 +624,9 @@ func TestKeyify(t *testing.T) {
 	result1 := Keyify([]int{1, 2, 3, 4})
 	result2 := Keyify([]int{1, 1, 1, 2})
 	result3 := Keyify([]int{})
-	is.Equal(result1, map[int]struct{}{1: {}, 2: {}, 3: {}, 4: {}})
-	is.Equal(result2, map[int]struct{}{1: {}, 2: {}})
-	is.Equal(result3, map[int]struct{}{})
+	is.Equal(map[int]struct{}{1: {}, 2: {}, 3: {}, 4: {}}, result1)
+	is.Equal(map[int]struct{}{1: {}, 2: {}}, result2)
+	is.Equal(map[int]struct{}{}, result3)
 }
 
 func TestDrop(t *testing.T) {
@@ -744,13 +744,13 @@ func TestReject(t *testing.T) {
 		return x%2 == 0
 	})
 
-	is.Equal(r1, []int{1, 3})
+	is.Equal([]int{1, 3}, r1)
 
 	r2 := Reject([]string{"Smith", "foo", "Domin", "bar", "Olivia"}, func(x string, _ int) bool {
 		return len(x) > 3
 	})
 
-	is.Equal(r2, []string{"foo", "bar"})
+	is.Equal([]string{"foo", "bar"}, r2)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -777,10 +777,10 @@ func TestRejectMap(t *testing.T) {
 		return "", true
 	})
 
-	is.Equal(len(r1), 2)
-	is.Equal(len(r2), 2)
-	is.Equal(r1, []string{"2", "4"})
-	is.Equal(r2, []string{"xpu", "xpu"})
+	is.Len(r1, 2)
+	is.Len(r2, 2)
+	is.Equal([]string{"2", "4"}, r1)
+	is.Equal([]string{"xpu", "xpu"}, r2)
 }
 
 func TestFilterReject(t *testing.T) {
@@ -791,15 +791,15 @@ func TestFilterReject(t *testing.T) {
 		return x%2 == 0
 	})
 
-	is.Equal(left1, []int{2, 4})
-	is.Equal(right1, []int{1, 3})
+	is.Equal([]int{2, 4}, left1)
+	is.Equal([]int{1, 3}, right1)
 
 	left2, right2 := FilterReject([]string{"Smith", "foo", "Domin", "bar", "Olivia"}, func(x string, _ int) bool {
 		return len(x) > 3
 	})
 
-	is.Equal(left2, []string{"Smith", "Domin", "Olivia"})
-	is.Equal(right2, []string{"foo", "bar"})
+	is.Equal([]string{"Smith", "Domin", "Olivia"}, left2)
+	is.Equal([]string{"foo", "bar"}, right2)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -818,9 +818,9 @@ func TestCount(t *testing.T) {
 	count2 := Count([]int{1, 2, 1}, 3)
 	count3 := Count([]int{}, 1)
 
-	is.Equal(count1, 2)
-	is.Equal(count2, 0)
-	is.Equal(count3, 0)
+	is.Equal(2, count1)
+	is.Zero(count2)
+	is.Zero(count3)
 }
 
 func TestCountBy(t *testing.T) {
@@ -839,9 +839,9 @@ func TestCountBy(t *testing.T) {
 		return i <= 2
 	})
 
-	is.Equal(count1, 2)
-	is.Equal(count2, 0)
-	is.Equal(count3, 0)
+	is.Equal(2, count1)
+	is.Zero(count2)
+	is.Zero(count3)
 }
 
 func TestCountValues(t *testing.T) {
@@ -1025,15 +1025,15 @@ func TestCompact(t *testing.T) {
 
 	r1 := Compact([]int{2, 0, 4, 0})
 
-	is.Equal(r1, []int{2, 4})
+	is.Equal([]int{2, 4}, r1)
 
 	r2 := Compact([]string{"", "foo", "", "bar", ""})
 
-	is.Equal(r2, []string{"foo", "bar"})
+	is.Equal([]string{"foo", "bar"}, r2)
 
 	r3 := Compact([]bool{true, false, true, false})
 
-	is.Equal(r3, []bool{true, true})
+	is.Equal([]bool{true, true}, r3)
 
 	type foo struct {
 		bar int
@@ -1049,7 +1049,7 @@ func TestCompact(t *testing.T) {
 		{bar: 2, baz: ""},  // bar is non-zero
 	})
 
-	is.Equal(r4, []foo{{bar: 1, baz: "a"}, {bar: 2, baz: ""}})
+	is.Equal([]foo{{bar: 1, baz: "a"}, {bar: 2, baz: ""}}, r4)
 
 	// slice of pointers to structs
 	// If an element is nil, Compact removes it.
@@ -1058,7 +1058,7 @@ func TestCompact(t *testing.T) {
 	// NOTE: e2 is a zero value of foo, but its pointer &e2 is not a zero value of *foo.
 	r5 := Compact([]*foo{&e1, &e2, nil, &e3})
 
-	is.Equal(r5, []*foo{&e1, &e2, &e3})
+	is.Equal([]*foo{&e1, &e2, &e3}, r5)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -1114,21 +1114,21 @@ func TestSplice(t *testing.T) {
 	// positive overflow
 	results = Splice(sample, 42, "1", "2")
 	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, sample)
-	is.Equal(results, []string{"a", "b", "c", "d", "e", "f", "g", "1", "2"})
+	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g", "1", "2"}, results)
 
 	// negative overflow
 	results = Splice(sample, -42, "1", "2")
 	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, sample)
-	is.Equal(results, []string{"1", "2", "a", "b", "c", "d", "e", "f", "g"})
+	is.Equal([]string{"1", "2", "a", "b", "c", "d", "e", "f", "g"}, results)
 
 	// backward
 	results = Splice(sample, -2, "1", "2")
 	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, sample)
-	is.Equal(results, []string{"a", "b", "c", "d", "e", "1", "2", "f", "g"})
+	is.Equal([]string{"a", "b", "c", "d", "e", "1", "2", "f", "g"}, results)
 
 	results = Splice(sample, -7, "1", "2")
 	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, sample)
-	is.Equal(results, []string{"1", "2", "a", "b", "c", "d", "e", "f", "g"})
+	is.Equal([]string{"1", "2", "a", "b", "c", "d", "e", "f", "g"}, results)
 
 	// other
 	is.Equal([]string{"1", "2"}, Splice([]string{}, 0, "1", "2"))

--- a/string_test.go
+++ b/string_test.go
@@ -78,8 +78,8 @@ func TestSubstring(t *testing.T) {
 	str14 := Substring("你好，世界", 0, 3)
 	str15 := Substring("hello", 5, 1)
 
-	is.Equal("", str1)
-	is.Equal("", str2)
+	is.Empty(str1)
+	is.Empty(str2)
 	is.Equal("he", str3)
 	is.Equal("hello", str4)
 	is.Equal("he", str5)
@@ -92,7 +92,7 @@ func TestSubstring(t *testing.T) {
 	is.Equal("ello", str12)
 	is.Equal("🏠🐶", str13)
 	is.Equal("你好，", str14)
-	is.Equal("", str15)
+	is.Empty(str15)
 }
 
 func TestRuneLength(t *testing.T) {
@@ -100,7 +100,7 @@ func TestRuneLength(t *testing.T) {
 	is := assert.New(t)
 
 	is.Equal(5, RuneLength("hellô"))
-	is.Equal(6, len("hellô"))
+	is.Len("hellô", 6)
 }
 
 func TestAllCase(t *testing.T) {

--- a/tuples_test.go
+++ b/tuples_test.go
@@ -19,14 +19,14 @@ func TestT(t *testing.T) {
 	r7 := T8[string, int, float32]("j", 7, 8.0, true, "k", 9, 10.0, false)
 	r8 := T9[string, int, float32]("l", 8, 9.0, false, "m", 10, 11.0, true, "n")
 
-	is.Equal(r1, Tuple2[string, int]{A: "a", B: 1})
-	is.Equal(r2, Tuple3[string, int, float32]{A: "b", B: 2, C: 3.0})
-	is.Equal(r3, Tuple4[string, int, float32, bool]{A: "c", B: 3, C: 4.0, D: true})
-	is.Equal(r4, Tuple5[string, int, float32, bool, string]{A: "d", B: 4, C: 5.0, D: false, E: "e"})
-	is.Equal(r5, Tuple6[string, int, float32, bool, string, int]{A: "f", B: 5, C: 6.0, D: true, E: "g", F: 7})
-	is.Equal(r6, Tuple7[string, int, float32, bool, string, int, float64]{A: "h", B: 6, C: 7.0, D: false, E: "i", F: 8, G: 9.0})
-	is.Equal(r7, Tuple8[string, int, float32, bool, string, int, float64, bool]{A: "j", B: 7, C: 8.0, D: true, E: "k", F: 9, G: 10.0, H: false})
-	is.Equal(r8, Tuple9[string, int, float32, bool, string, int, float64, bool, string]{A: "l", B: 8, C: 9.0, D: false, E: "m", F: 10, G: 11.0, H: true, I: "n"})
+	is.Equal(Tuple2[string, int]{A: "a", B: 1}, r1)
+	is.Equal(Tuple3[string, int, float32]{A: "b", B: 2, C: 3.0}, r2)
+	is.Equal(Tuple4[string, int, float32, bool]{A: "c", B: 3, C: 4.0, D: true}, r3)
+	is.Equal(Tuple5[string, int, float32, bool, string]{A: "d", B: 4, C: 5.0, D: false, E: "e"}, r4)
+	is.Equal(Tuple6[string, int, float32, bool, string, int]{A: "f", B: 5, C: 6.0, D: true, E: "g", F: 7}, r5)
+	is.Equal(Tuple7[string, int, float32, bool, string, int, float64]{A: "h", B: 6, C: 7.0, D: false, E: "i", F: 8, G: 9.0}, r6)
+	is.Equal(Tuple8[string, int, float32, bool, string, int, float64, bool]{A: "j", B: 7, C: 8.0, D: true, E: "k", F: 9, G: 10.0, H: false}, r7)
+	is.Equal(Tuple9[string, int, float32, bool, string, int, float64, bool, string]{A: "l", B: 8, C: 9.0, D: false, E: "m", F: 10, G: 11.0, H: true, I: "n"}, r8)
 }
 
 func TestUnpack(t *testing.T) {
@@ -71,14 +71,14 @@ func TestUnpack(t *testing.T) {
 		is.Equal("a", r1)
 		is.Equal(1, r2)
 		is.Equal(1.0, r3)
-		is.Equal(true, r4)
+		is.True(r4)
 
 		r1, r2, r3, r4 = tuple.Unpack()
 
 		is.Equal("a", r1)
 		is.Equal(1, r2)
 		is.Equal(1.0, r3)
-		is.Equal(true, r4)
+		is.True(r4)
 	}
 
 	{
@@ -89,7 +89,7 @@ func TestUnpack(t *testing.T) {
 		is.Equal("a", r1)
 		is.Equal(1, r2)
 		is.Equal(1.0, r3)
-		is.Equal(true, r4)
+		is.True(r4)
 		is.Equal("b", r5)
 
 		r1, r2, r3, r4, r5 = tuple.Unpack()
@@ -97,7 +97,7 @@ func TestUnpack(t *testing.T) {
 		is.Equal("a", r1)
 		is.Equal(1, r2)
 		is.Equal(1.0, r3)
-		is.Equal(true, r4)
+		is.True(r4)
 		is.Equal("b", r5)
 	}
 
@@ -109,7 +109,7 @@ func TestUnpack(t *testing.T) {
 		is.Equal("a", r1)
 		is.Equal(1, r2)
 		is.Equal(1.0, r3)
-		is.Equal(true, r4)
+		is.True(r4)
 		is.Equal("b", r5)
 		is.Equal(2, r6)
 
@@ -118,7 +118,7 @@ func TestUnpack(t *testing.T) {
 		is.Equal("a", r1)
 		is.Equal(1, r2)
 		is.Equal(1.0, r3)
-		is.Equal(true, r4)
+		is.True(r4)
 		is.Equal("b", r5)
 		is.Equal(2, r6)
 	}
@@ -131,7 +131,7 @@ func TestUnpack(t *testing.T) {
 		is.Equal("a", r1)
 		is.Equal(1, r2)
 		is.Equal(1.0, r3)
-		is.Equal(true, r4)
+		is.True(r4)
 		is.Equal("b", r5)
 		is.Equal(2, r6)
 		is.Equal(3.0, r7)
@@ -141,7 +141,7 @@ func TestUnpack(t *testing.T) {
 		is.Equal("a", r1)
 		is.Equal(1, r2)
 		is.Equal(1.0, r3)
-		is.Equal(true, r4)
+		is.True(r4)
 		is.Equal("b", r5)
 		is.Equal(2, r6)
 		is.Equal(3.0, r7)
@@ -155,22 +155,22 @@ func TestUnpack(t *testing.T) {
 		is.Equal("a", r1)
 		is.Equal(1, r2)
 		is.Equal(1.0, r3)
-		is.Equal(true, r4)
+		is.True(r4)
 		is.Equal("b", r5)
 		is.Equal(2, r6)
 		is.Equal(3.0, r7)
-		is.Equal(true, r8)
+		is.True(r8)
 
 		r1, r2, r3, r4, r5, r6, r7, r8 = tuple.Unpack()
 
 		is.Equal("a", r1)
 		is.Equal(1, r2)
 		is.Equal(1.0, r3)
-		is.Equal(true, r4)
+		is.True(r4)
 		is.Equal("b", r5)
 		is.Equal(2, r6)
 		is.Equal(3.0, r7)
-		is.Equal(true, r8)
+		is.True(r8)
 	}
 
 	{
@@ -181,11 +181,11 @@ func TestUnpack(t *testing.T) {
 		is.Equal("a", r1)
 		is.Equal(1, r2)
 		is.Equal(1.0, r3)
-		is.Equal(true, r4)
+		is.True(r4)
 		is.Equal("b", r5)
 		is.Equal(2, r6)
 		is.Equal(3.0, r7)
-		is.Equal(true, r8)
+		is.True(r8)
 		is.Equal("c", r9)
 
 		r1, r2, r3, r4, r5, r6, r7, r8, r9 = tuple.Unpack()
@@ -193,11 +193,11 @@ func TestUnpack(t *testing.T) {
 		is.Equal("a", r1)
 		is.Equal(1, r2)
 		is.Equal(1.0, r3)
-		is.Equal(true, r4)
+		is.True(r4)
 		is.Equal("b", r5)
 		is.Equal(2, r6)
 		is.Equal(3.0, r7)
-		is.Equal(true, r8)
+		is.True(r8)
 		is.Equal("c", r9)
 	}
 }
@@ -274,42 +274,42 @@ func TestZip(t *testing.T) {
 		[]int32{1, 2, 3, 4, 5, 6, 7, 8, 9},
 	)
 
-	is.Equal(r1, []Tuple2[string, int]{
+	is.Equal([]Tuple2[string, int]{
 		{A: "a", B: 1},
 		{A: "b", B: 2},
-	})
+	}, r1)
 
-	is.Equal(r2, []Tuple3[string, int, int]{
+	is.Equal([]Tuple3[string, int, int]{
 		{A: "a", B: 1, C: 4},
 		{A: "b", B: 2, C: 5},
 		{A: "c", B: 3, C: 6},
-	})
+	}, r2)
 
-	is.Equal(r3, []Tuple4[string, int, int, bool]{
+	is.Equal([]Tuple4[string, int, int, bool]{
 		{A: "a", B: 1, C: 5, D: true},
 		{A: "b", B: 2, C: 6, D: true},
 		{A: "c", B: 3, C: 7, D: true},
 		{A: "d", B: 4, C: 8, D: true},
-	})
+	}, r3)
 
-	is.Equal(r4, []Tuple5[string, int, int, bool, float32]{
+	is.Equal([]Tuple5[string, int, int, bool, float32]{
 		{A: "a", B: 1, C: 6, D: true, E: 0.1},
 		{A: "b", B: 2, C: 7, D: true, E: 0.2},
 		{A: "c", B: 3, C: 8, D: true, E: 0.3},
 		{A: "d", B: 4, C: 9, D: true, E: 0.4},
 		{A: "e", B: 5, C: 10, D: true, E: 0.5},
-	})
+	}, r4)
 
-	is.Equal(r5, []Tuple6[string, int, int, bool, float32, float64]{
+	is.Equal([]Tuple6[string, int, int, bool, float32, float64]{
 		{A: "a", B: 1, C: 7, D: true, E: 0.1, F: 0.01},
 		{A: "b", B: 2, C: 8, D: true, E: 0.2, F: 0.02},
 		{A: "c", B: 3, C: 9, D: true, E: 0.3, F: 0.03},
 		{A: "d", B: 4, C: 10, D: true, E: 0.4, F: 0.04},
 		{A: "e", B: 5, C: 11, D: true, E: 0.5, F: 0.05},
 		{A: "f", B: 6, C: 12, D: true, E: 0.6, F: 0.06},
-	})
+	}, r5)
 
-	is.Equal(r6, []Tuple7[string, int, int, bool, float32, float64, int8]{
+	is.Equal([]Tuple7[string, int, int, bool, float32, float64, int8]{
 		{A: "a", B: 1, C: 8, D: true, E: 0.1, F: 0.01, G: 1},
 		{A: "b", B: 2, C: 9, D: true, E: 0.2, F: 0.02, G: 2},
 		{A: "c", B: 3, C: 10, D: true, E: 0.3, F: 0.03, G: 3},
@@ -317,9 +317,9 @@ func TestZip(t *testing.T) {
 		{A: "e", B: 5, C: 12, D: true, E: 0.5, F: 0.05, G: 5},
 		{A: "f", B: 6, C: 13, D: true, E: 0.6, F: 0.06, G: 6},
 		{A: "g", B: 7, C: 14, D: true, E: 0.7, F: 0.07, G: 7},
-	})
+	}, r6)
 
-	is.Equal(r7, []Tuple8[string, int, int, bool, float32, float64, int8, int16]{
+	is.Equal([]Tuple8[string, int, int, bool, float32, float64, int8, int16]{
 		{A: "a", B: 1, C: 9, D: true, E: 0.1, F: 0.01, G: 1, H: 1},
 		{A: "b", B: 2, C: 10, D: true, E: 0.2, F: 0.02, G: 2, H: 2},
 		{A: "c", B: 3, C: 11, D: true, E: 0.3, F: 0.03, G: 3, H: 3},
@@ -328,9 +328,9 @@ func TestZip(t *testing.T) {
 		{A: "f", B: 6, C: 14, D: true, E: 0.6, F: 0.06, G: 6, H: 6},
 		{A: "g", B: 7, C: 15, D: true, E: 0.7, F: 0.07, G: 7, H: 7},
 		{A: "h", B: 8, C: 16, D: true, E: 0.8, F: 0.08, G: 8, H: 8},
-	})
+	}, r7)
 
-	is.Equal(r8, []Tuple9[string, int, int, bool, float32, float64, int8, int16, int32]{
+	is.Equal([]Tuple9[string, int, int, bool, float32, float64, int8, int16, int32]{
 		{A: "a", B: 1, C: 10, D: true, E: 0.1, F: 0.01, G: 1, H: 1, I: 1},
 		{A: "b", B: 2, C: 11, D: true, E: 0.2, F: 0.02, G: 2, H: 2, I: 2},
 		{A: "c", B: 3, C: 12, D: true, E: 0.3, F: 0.03, G: 3, H: 3, I: 3},
@@ -340,7 +340,7 @@ func TestZip(t *testing.T) {
 		{A: "g", B: 7, C: 16, D: true, E: 0.7, F: 0.07, G: 7, H: 7, I: 7},
 		{A: "h", B: 8, C: 17, D: true, E: 0.8, F: 0.08, G: 8, H: 8, I: 8},
 		{A: "i", B: 9, C: 18, D: true, E: 0.9, F: 0.09, G: 9, H: 9, I: 9},
-	})
+	}, r8)
 }
 
 func TestZipBy(t *testing.T) {
@@ -439,42 +439,42 @@ func TestZipBy(t *testing.T) {
 		},
 	)
 
-	is.Equal(r1, []Tuple2[string, int]{
+	is.Equal([]Tuple2[string, int]{
 		{A: "a", B: 1},
 		{A: "b", B: 2},
-	})
+	}, r1)
 
-	is.Equal(r2, []Tuple3[string, int, int]{
+	is.Equal([]Tuple3[string, int, int]{
 		{A: "a", B: 1, C: 4},
 		{A: "b", B: 2, C: 5},
 		{A: "c", B: 3, C: 6},
-	})
+	}, r2)
 
-	is.Equal(r3, []Tuple4[string, int, int, bool]{
+	is.Equal([]Tuple4[string, int, int, bool]{
 		{A: "a", B: 1, C: 5, D: true},
 		{A: "b", B: 2, C: 6, D: true},
 		{A: "c", B: 3, C: 7, D: true},
 		{A: "d", B: 4, C: 8, D: true},
-	})
+	}, r3)
 
-	is.Equal(r4, []Tuple5[string, int, int, bool, float32]{
+	is.Equal([]Tuple5[string, int, int, bool, float32]{
 		{A: "a", B: 1, C: 6, D: true, E: 0.1},
 		{A: "b", B: 2, C: 7, D: true, E: 0.2},
 		{A: "c", B: 3, C: 8, D: true, E: 0.3},
 		{A: "d", B: 4, C: 9, D: true, E: 0.4},
 		{A: "e", B: 5, C: 10, D: true, E: 0.5},
-	})
+	}, r4)
 
-	is.Equal(r5, []Tuple6[string, int, int, bool, float32, float64]{
+	is.Equal([]Tuple6[string, int, int, bool, float32, float64]{
 		{A: "a", B: 1, C: 7, D: true, E: 0.1, F: 0.01},
 		{A: "b", B: 2, C: 8, D: true, E: 0.2, F: 0.02},
 		{A: "c", B: 3, C: 9, D: true, E: 0.3, F: 0.03},
 		{A: "d", B: 4, C: 10, D: true, E: 0.4, F: 0.04},
 		{A: "e", B: 5, C: 11, D: true, E: 0.5, F: 0.05},
 		{A: "f", B: 6, C: 12, D: true, E: 0.6, F: 0.06},
-	})
+	}, r5)
 
-	is.Equal(r6, []Tuple7[string, int, int, bool, float32, float64, int8]{
+	is.Equal([]Tuple7[string, int, int, bool, float32, float64, int8]{
 		{A: "a", B: 1, C: 8, D: true, E: 0.1, F: 0.01, G: 1},
 		{A: "b", B: 2, C: 9, D: true, E: 0.2, F: 0.02, G: 2},
 		{A: "c", B: 3, C: 10, D: true, E: 0.3, F: 0.03, G: 3},
@@ -482,9 +482,9 @@ func TestZipBy(t *testing.T) {
 		{A: "e", B: 5, C: 12, D: true, E: 0.5, F: 0.05, G: 5},
 		{A: "f", B: 6, C: 13, D: true, E: 0.6, F: 0.06, G: 6},
 		{A: "g", B: 7, C: 14, D: true, E: 0.7, F: 0.07, G: 7},
-	})
+	}, r6)
 
-	is.Equal(r7, []Tuple8[string, int, int, bool, float32, float64, int8, int16]{
+	is.Equal([]Tuple8[string, int, int, bool, float32, float64, int8, int16]{
 		{A: "a", B: 1, C: 9, D: true, E: 0.1, F: 0.01, G: 1, H: 1},
 		{A: "b", B: 2, C: 10, D: true, E: 0.2, F: 0.02, G: 2, H: 2},
 		{A: "c", B: 3, C: 11, D: true, E: 0.3, F: 0.03, G: 3, H: 3},
@@ -493,9 +493,9 @@ func TestZipBy(t *testing.T) {
 		{A: "f", B: 6, C: 14, D: true, E: 0.6, F: 0.06, G: 6, H: 6},
 		{A: "g", B: 7, C: 15, D: true, E: 0.7, F: 0.07, G: 7, H: 7},
 		{A: "h", B: 8, C: 16, D: true, E: 0.8, F: 0.08, G: 8, H: 8},
-	})
+	}, r7)
 
-	is.Equal(r8, []Tuple9[string, int, int, bool, float32, float64, int8, int16, int32]{
+	is.Equal([]Tuple9[string, int, int, bool, float32, float64, int8, int16, int32]{
 		{A: "a", B: 1, C: 10, D: true, E: 0.1, F: 0.01, G: 1, H: 1, I: 1},
 		{A: "b", B: 2, C: 11, D: true, E: 0.2, F: 0.02, G: 2, H: 2, I: 2},
 		{A: "c", B: 3, C: 12, D: true, E: 0.3, F: 0.03, G: 3, H: 3, I: 3},
@@ -505,7 +505,7 @@ func TestZipBy(t *testing.T) {
 		{A: "g", B: 7, C: 16, D: true, E: 0.7, F: 0.07, G: 7, H: 7, I: 7},
 		{A: "h", B: 8, C: 17, D: true, E: 0.8, F: 0.08, G: 8, H: 8, I: 8},
 		{A: "i", B: 9, C: 18, D: true, E: 0.9, F: 0.09, G: 9, H: 9, I: 9},
-	})
+	}, r8)
 }
 
 func TestUnzip(t *testing.T) {
@@ -514,8 +514,8 @@ func TestUnzip(t *testing.T) {
 
 	r1, r2 := Unzip2([]Tuple2[string, int]{{A: "a", B: 1}, {A: "b", B: 2}})
 
-	is.Equal(r1, []string{"a", "b"})
-	is.Equal(r2, []int{1, 2})
+	is.Equal([]string{"a", "b"}, r1)
+	is.Equal([]int{1, 2}, r2)
 }
 
 func TestUnzipBy(t *testing.T) {
@@ -526,8 +526,8 @@ func TestUnzipBy(t *testing.T) {
 		return i.A + i.A, i.B + i.B
 	})
 
-	is.Equal(r1, []string{"aa", "bb"})
-	is.Equal(r2, []int{2, 4})
+	is.Equal([]string{"aa", "bb"}, r1)
+	is.Equal([]int{2, 4}, r2)
 }
 
 func TestCrossJoin(t *testing.T) {
@@ -540,13 +540,13 @@ func TestCrossJoin(t *testing.T) {
 	mixedList := []any{9.6, 4, "foobar"}
 
 	results1 := CrossJoin2(emptyList, listTwo)
-	is.Len(results1, 0)
+	is.Empty(results1)
 
 	results2 := CrossJoin2(listOne, emptyList)
-	is.Len(results2, 0)
+	is.Empty(results2)
 
 	results3 := CrossJoin2(emptyList, emptyList)
-	is.Len(results3, 0)
+	is.Empty(results3)
 
 	results4 := CrossJoin2([]string{"a"}, listTwo)
 	is.Equal([]Tuple2[string, int]{T2("a", 1), T2("a", 2), T2("a", 3)}, results4)
@@ -571,13 +571,13 @@ func TestCrossJoinBy(t *testing.T) {
 	mixedList := []any{9.6, 4, "foobar"}
 
 	results1 := CrossJoinBy2(emptyList, listTwo, T2[any, int])
-	is.Len(results1, 0)
+	is.Empty(results1)
 
 	results2 := CrossJoinBy2(listOne, emptyList, T2[string, any])
-	is.Len(results2, 0)
+	is.Empty(results2)
 
 	results3 := CrossJoinBy2(emptyList, emptyList, T2[any, any])
-	is.Len(results3, 0)
+	is.Empty(results3)
 
 	results4 := CrossJoinBy2([]string{"a"}, listTwo, T2[string, int])
 	is.Equal([]Tuple2[string, int]{T2("a", 1), T2("a", 2), T2("a", 3)}, results4)

--- a/type_manipulation_test.go
+++ b/type_manipulation_test.go
@@ -60,7 +60,7 @@ func TestToPtr(t *testing.T) {
 
 	result1 := ToPtr([]int{1, 2})
 
-	is.Equal(*result1, []int{1, 2})
+	is.Equal([]int{1, 2}, *result1)
 }
 
 func TestNil(t *testing.T) {
@@ -94,11 +94,11 @@ func TestEmptyableToPtr(t *testing.T) {
 	is.Nil(EmptyableToPtr[map[int]int](nil))
 	is.Nil(EmptyableToPtr[error](nil))
 
-	is.Equal(*EmptyableToPtr(42), 42)
-	is.Equal(*EmptyableToPtr("nonempty"), "nonempty")
-	is.Equal(*EmptyableToPtr([]int{}), []int{})
-	is.Equal(*EmptyableToPtr([]int{1, 2}), []int{1, 2})
-	is.Equal(*EmptyableToPtr(map[int]int{}), map[int]int{})
+	is.Equal(42, *EmptyableToPtr(42))
+	is.Equal("nonempty", *EmptyableToPtr("nonempty"))
+	is.Equal([]int{}, *EmptyableToPtr([]int{}))
+	is.Equal([]int{1, 2}, *EmptyableToPtr([]int{1, 2}))
+	is.Equal(map[int]int{}, *EmptyableToPtr(map[int]int{}))
 	is.Equal(*EmptyableToPtr(assert.AnError), assert.AnError)
 }
 
@@ -110,10 +110,10 @@ func TestFromPtr(t *testing.T) {
 	ptr := &str1
 
 	is.Equal("foo", FromPtr(ptr))
-	is.Equal("", FromPtr[string](nil))
-	is.Equal(0, FromPtr[int](nil))
+	is.Empty(FromPtr[string](nil))
+	is.Zero(FromPtr[int](nil))
 	is.Nil(FromPtr[*string](nil))
-	is.EqualValues(ptr, FromPtr(&ptr))
+	is.Equal(ptr, FromPtr(&ptr))
 }
 
 func TestFromPtrOr(t *testing.T) {
@@ -142,7 +142,7 @@ func TestToSlicePtr(t *testing.T) {
 	str2 := "bar"
 	result1 := ToSlicePtr([]string{str1, str2})
 
-	is.Equal(result1, []*string{&str1, &str2})
+	is.Equal([]*string{&str1, &str2}, result1)
 }
 
 func TestFromSlicePtr(t *testing.T) {
@@ -152,7 +152,7 @@ func TestFromSlicePtr(t *testing.T) {
 	str2 := "bar"
 	result1 := FromSlicePtr([]*string{&str1, &str2, nil})
 
-	is.Equal(result1, []string{str1, str2, ""})
+	is.Equal([]string{str1, str2, ""}, result1)
 }
 
 func TestFromSlicePtrOr(t *testing.T) {
@@ -162,7 +162,7 @@ func TestFromSlicePtrOr(t *testing.T) {
 	str2 := "bar"
 	result1 := FromSlicePtrOr([]*string{&str1, &str2, nil}, "fallback")
 
-	is.Equal(result1, []string{str1, str2, "fallback"})
+	is.Equal([]string{str1, str2, "fallback"}, result1)
 }
 
 func TestToAnySlice(t *testing.T) {
@@ -270,7 +270,7 @@ func TestCoalesce(t *testing.T) {
 	result9, ok9 := Coalesce(zeroStruct, struct1)
 	result10, ok10 := Coalesce(zeroStruct, struct1, struct2)
 
-	is.Equal(0, result1)
+	is.Zero(result1)
 	is.False(ok1)
 
 	is.Equal(3, result2)
@@ -288,16 +288,16 @@ func TestCoalesce(t *testing.T) {
 	is.Equal(str1, result6)
 	is.True(ok6)
 
-	is.Equal(result7, 1)
+	is.Equal(1, result7)
 	is.True(ok7)
 
-	is.Equal(result8, zeroStruct)
+	is.Zero(result8)
 	is.False(ok8)
 
-	is.Equal(result9, struct1)
+	is.Equal(struct1, result9)
 	is.True(ok9)
 
-	is.Equal(result10, struct1)
+	is.Equal(struct1, result10)
 	is.True(ok10)
 }
 
@@ -329,16 +329,16 @@ func TestCoalesceOrEmpty(t *testing.T) {
 	result9 := CoalesceOrEmpty(zeroStruct, struct1)
 	result10 := CoalesceOrEmpty(zeroStruct, struct1, struct2)
 
-	is.Equal(0, result1)
+	is.Zero(result1)
 	is.Equal(3, result2)
 	is.Nil(result3)
 	is.Equal(str1, result4)
 	is.Equal(str1, result5)
 	is.Equal(str1, result6)
-	is.Equal(result7, 1)
-	is.Equal(result8, zeroStruct)
-	is.Equal(result9, struct1)
-	is.Equal(result10, struct1)
+	is.Equal(1, result7)
+	is.Zero(result8)
+	is.Equal(struct1, result9)
+	is.Equal(struct1, result10)
 }
 
 func TestCoalesceSlice(t *testing.T) {


### PR DESCRIPTION
Made some minor tweaks to the unit tests based on recommendations from the `testifylint` golangci-lint linter.
The most common issue was reversed `expected` and `actual` arguments, which can cause confusing failure messages.