### PR TITLE
lint: pin golangci-lint version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
+          version: 'v2.4'
           args: --timeout 120s --max-same-issues 50
 
       - name: Bearer


### PR DESCRIPTION
Pin the golangci-lint version so that contributors aren't blocked by unrelated CI issues if a new version happens to be released. This PR pins it to the previous version `v2.4` which this codebase passes. Version `v2.5` was released a couple of days ago with new issues to be addressed.