### PR TITLE
docs: grammar improvements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
+          version: 'v2.4'
           args: --timeout 120s --max-same-issues 50
 
       - name: Bearer

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: 'v2.4'
           args: --timeout 120s --max-same-issues 50
 
       - name: Bearer

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Constraints:
 
 ### Filter
 
-Iterates over a collection and returns an array of all the elements the predicate function returns `true` for.
+Iterates over a collection and returns a slice of all the elements the predicate function returns `true` for.
 
 ```go
 even := lo.Filter([]int{1, 2, 3, 4}, func(x int, index int) bool {
@@ -535,7 +535,7 @@ lo.ForEachWhile(list, func(x int64, _ int) bool {
 
 ### Times
 
-Times invokes the iteratee n times, returning an array of the results of each invocation. The iteratee is invoked with index as argument.
+Times invokes the iteratee n times, returning a slice of the results of each invocation. The iteratee is invoked with index as argument.
 
 ```go
 import "github.com/samber/lo"
@@ -561,7 +561,7 @@ lop.Times(3, func(i int) string {
 
 ### Uniq
 
-Returns a duplicate-free version of an array, in which only the first occurrence of each element is kept. The order of result values is determined by the order they occur in the array.
+Returns a duplicate-free version of a slice, in which only the first occurrence of each element is kept. The order of result values is determined by the order they occur in the slice.
 
 ```go
 uniqValues := lo.Uniq([]int{1, 2, 2, 1})
@@ -572,7 +572,7 @@ uniqValues := lo.Uniq([]int{1, 2, 2, 1})
 
 ### UniqBy
 
-Returns a duplicate-free version of an array, in which only the first occurrence of each element is kept. The order of result values is determined by the order they occur in the array. It accepts `iteratee` which is invoked for each element in array to generate the criterion by which uniqueness is computed.
+Returns a duplicate-free version of a slice, in which only the first occurrence of each element is kept. The order of result values is determined by the order they occur in the slice. It accepts `iteratee` which is invoked for each element in slice to generate the criterion by which uniqueness is computed.
 
 ```go
 uniqValues := lo.UniqBy([]int{0, 1, 2, 3, 4, 5}, func(i int) int {
@@ -626,7 +626,7 @@ groups := lo.GroupByMap([]int{0, 1, 2, 3, 4, 5}, func(i int) (int, int) {
 
 ### Chunk
 
-Returns an array of elements split into groups of length size. If array can't be split evenly, the final chunk will be the remaining elements.
+Returns a slice of elements split into groups of length size. If slice can't be split evenly, the final chunk will be the remaining elements.
 
 ```go
 lo.Chunk([]int{0, 1, 2, 3, 4, 5}, 2)
@@ -646,7 +646,7 @@ lo.Chunk([]int{0}, 2)
 
 ### PartitionBy
 
-Returns an array of elements split into groups. The order of grouped values is determined by the order they occur in collection. The grouping is generated from the results of running each element of collection through iteratee.
+Returns a slice of elements split into groups. The order of grouped values is determined by the order they occur in collection. The grouping is generated from the results of running each element of collection through iteratee.
 
 ```go
 import lo "github.com/samber/lo"
@@ -682,7 +682,7 @@ partitions := lop.PartitionBy([]int{-2, -1, 0, 1, 2, 3, 4, 5}, func(x int) strin
 
 ### Flatten
 
-Returns an array a single level deep.
+Returns a slice a single level deep.
 
 ```go
 flat := lo.Flatten([][]int{{0, 1}, {2, 3, 4, 5}})
@@ -707,7 +707,7 @@ interleaved := lo.Interleave([]int{1}, []int{2, 5, 8}, []int{3, 6}, []int{4, 7, 
 
 ### Shuffle
 
-Returns an array of shuffled values. Uses the Fisher-Yates shuffle algorithm.
+Returns a slice of shuffled values. Uses the Fisher-Yates shuffle algorithm.
 
 ⚠️ This helper is **mutable**.
 
@@ -725,7 +725,7 @@ list
 
 ### Reverse
 
-Reverses array so that the first element becomes the last, the second element becomes the second to last, and so on.
+Reverses slice so that the first element becomes the last, the second element becomes the second to last, and so on.
 
 ⚠️ This helper is **mutable**.
 
@@ -743,7 +743,7 @@ list
 
 ### Fill
 
-Fills elements of array with `initial` value.
+Fills elements of slice with `initial` value.
 
 ```go
 type foo struct {
@@ -799,7 +799,7 @@ slice := lo.RepeatBy(5, func(i int) string {
 
 ### KeyBy
 
-Transforms a slice or an array of structs to a map based on a pivot callback.
+Transforms a slice or a slice of structs to a map based on a pivot callback.
 
 ```go
 m := lo.KeyBy([]string{"a", "aa", "aaa"}, func(str string) int {
@@ -828,7 +828,7 @@ result := lo.KeyBy(characters, func(char Character) string {
 Returns a map containing key-value pairs provided by transform function applied to elements of the given slice.
 If any of two pairs have the same key the last one gets added to the map.
 
-The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+The order of keys in returned map is not specified and is not guaranteed to be the same from the original slice.
 
 ```go
 in := []*foo{{baz: "apple", bar: 1}, {baz: "banana", bar: 2}}
@@ -847,7 +847,7 @@ Returns a map containing key-value pairs provided by transform function applied 
 
 If any of two pairs have the same key the last one gets added to the map.
 
-The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+The order of keys in returned map is not specified and is not guaranteed to be the same from the original slice.
 
 The third return value of the transform function is a boolean that indicates whether the key-value pair should be included in the map.
 
@@ -876,7 +876,7 @@ set := lo.Keyify([]int{1, 1, 2, 3, 4})
 
 ### Drop
 
-Drops n elements from the beginning of a slice or array.
+Drops n elements from the beginning of a slice.
 
 ```go
 l := lo.Drop([]int{0, 1, 2, 3, 4, 5}, 2)
@@ -887,7 +887,7 @@ l := lo.Drop([]int{0, 1, 2, 3, 4, 5}, 2)
 
 ### DropRight
 
-Drops n elements from the end of a slice or array.
+Drops n elements from the end of a slice.
 
 ```go
 l := lo.DropRight([]int{0, 1, 2, 3, 4, 5}, 2)
@@ -898,7 +898,7 @@ l := lo.DropRight([]int{0, 1, 2, 3, 4, 5}, 2)
 
 ### DropWhile
 
-Drop elements from the beginning of a slice or array while the predicate returns true.
+Drop elements from the beginning of a slice while the predicate returns true.
 
 ```go
 l := lo.DropWhile([]string{"a", "aa", "aaa", "aa", "aa"}, func(val string) bool {
@@ -911,7 +911,7 @@ l := lo.DropWhile([]string{"a", "aa", "aaa", "aa", "aa"}, func(val string) bool 
 
 ### DropRightWhile
 
-Drop elements from the end of a slice or array while the predicate returns true.
+Drop elements from the end of a slice while the predicate returns true.
 
 ```go
 l := lo.DropRightWhile([]string{"a", "aa", "aaa", "aa", "aa"}, func(val string) bool {
@@ -924,7 +924,7 @@ l := lo.DropRightWhile([]string{"a", "aa", "aaa", "aa", "aa"}, func(val string) 
 
 ### DropByIndex
 
-Drops elements from a slice or array by the index. A negative index will drop elements from the end of the slice.
+Drops elements from a slice by the index. A negative index will drop elements from the end of the slice.
 
 ```go
 l := lo.DropByIndex([]int{0, 1, 2, 3, 4, 5}, 2, 4, -1)
@@ -1208,7 +1208,7 @@ keys := lo.Keys(map[string]int{"foo": 1, "bar": 2}, map[string]int{"bar": 3})
 
 ### UniqKeys
 
-Creates an array of unique map keys.
+Creates a slice of unique map keys.
 
 ```go
 keys := lo.UniqKeys(map[string]int{"foo": 1, "bar": 2}, map[string]int{"baz": 3})
@@ -1236,7 +1236,7 @@ exists := lo.HasKey(map[string]int{"foo": 1, "bar": 2}, "baz")
 
 ### Values
 
-Creates an array of the map values.
+Creates a slice of the map values.
 
 Use the UniqValues variant to deduplicate common values.
 
@@ -1255,7 +1255,7 @@ values := lo.Values(map[string]int{"foo": 1, "bar": 2}, map[string]int{"bar": 2}
 
 ### UniqValues
 
-Creates an array of unique map values.
+Creates a slice of unique map values.
 
 ```go
 values := lo.UniqValues(map[string]int{"foo": 1, "bar": 2})
@@ -1356,7 +1356,7 @@ m := lo.OmitByValues(map[string]int{"foo": 1, "bar": 2, "baz": 3}, []int{1, 3})
 
 ### Entries (alias: ToPairs)
 
-Transforms a map into array of key/value pairs.
+Transforms a map into a slice of key/value pairs.
 
 ```go
 entries := lo.Entries(map[string]int{"foo": 1, "bar": 2})
@@ -1376,7 +1376,7 @@ entries := lo.Entries(map[string]int{"foo": 1, "bar": 2})
 
 ### FromEntries (alias: FromPairs)
 
-Transforms an array of key/value pairs into a map.
+Transforms a slice of key/value pairs into a map.
 
 ```go
 m := lo.FromEntries([]lo.Entry[string, int]{
@@ -1424,7 +1424,7 @@ mergedMaps := lo.Assign(
 
 ### ChunkEntries
 
-Splits a map into an array of elements in groups of length equal to its size. If the map cannot be split evenly, the final chunk will contain the remaining elements.
+Splits a map into a slice of elements in groups of length equal to its size. If the map cannot be split evenly, the final chunk will contain the remaining elements.
 
 ```go
 maps := lo.ChunkEntries(
@@ -1549,7 +1549,7 @@ result := FilterValues(kv, func(k int, v string) bool {
 
 ### Range / RangeFrom / RangeWithSteps
 
-Creates an array of numbers (positive and/or negative) progressing from start up to, but not including end.
+Creates a slice of numbers (positive and/or negative) progressing from start up to, but not including end.
 
 ```go
 result := lo.Range(4)
@@ -1746,7 +1746,7 @@ sub := lo.Substring("hello", -2, math.MaxUint)
 
 ### ChunkString
 
-Returns an array of strings split into groups of length size. If the string can't be split evenly, the final chunk will be the remaining characters.
+Returns a slice of strings split into groups of length size. If the string can't be split evenly, the final chunk will be the remaining characters.
 
 ```go
 lo.ChunkString("123456", 2)
@@ -1824,7 +1824,7 @@ str := lo.SnakeCase("HelloWorld")
 
 ### Words
 
-Splits string into an array of its words.
+Splits string into a slice of its words.
 
 ```go
 str := lo.Words("helloWorld")
@@ -1897,7 +1897,7 @@ a, b := tuple2.Unpack()
 
 ### Zip2 -> Zip9
 
-Zip creates a slice of grouped elements, the first of which contains the first elements of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+Zip creates a slice of grouped elements, the first of which contains the first elements of the given slices, the second of which contains the second elements of the given slices, and so on.
 
 When collections are different sizes, the Tuple attributes are filled with zero value.
 
@@ -1910,7 +1910,7 @@ tuples := lo.Zip2([]string{"a", "b"}, []int{1, 2})
 
 ### ZipBy2 -> ZipBy9
 
-ZipBy creates a slice of transformed elements, the first of which contains the first elements of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+ZipBy creates a slice of transformed elements, the first of which contains the first elements of the given slices, the second of which contains the second elements of the given slices, and so on.
 
 When collections are different sizes, the Tuple attributes are filled with zero value.
 
@@ -1923,7 +1923,7 @@ items := lo.ZipBy2([]string{"a", "b"}, []int{1, 2}, func(a string, b int) string
 
 ### Unzip2 -> Unzip9
 
-Unzip accepts an array of grouped elements and creates an array regrouping the elements to their pre-zip configuration.
+Unzip accepts a slice of grouped elements and creates a slice regrouping the elements to their pre-zip configuration.
 
 ```go
 a, b := lo.Unzip2([]Tuple2[string, int]{{A: "a", B: 1}, {A: "b", B: 2}})
@@ -1935,7 +1935,7 @@ a, b := lo.Unzip2([]Tuple2[string, int]{{A: "a", B: 1}, {A: "b", B: 2}})
 
 ### UnzipBy2 -> UnzipBy9
 
-UnzipBy2 iterates over a collection and creates an array regrouping the elements to their pre-zip configuration.
+UnzipBy2 iterates over a collection and creates a slice regrouping the elements to their pre-zip configuration.
 
 ```go
 a, b := lo.UnzipBy2([]string{"hello", "john", "doe"}, func(str string) (string, int) {
@@ -2526,7 +2526,7 @@ b := lo.ElementsMatchBy(
 
 ### IndexOf
 
-Returns the index at which the first occurrence of a value is found in an array or return -1 if the value cannot be found.
+Returns the index at which the first occurrence of a value is found in a slice or return -1 if the value cannot be found.
 
 ```go
 found := lo.IndexOf([]int{0, 1, 2, 1, 2, 3}, 2)
@@ -2540,7 +2540,7 @@ notFound := lo.IndexOf([]int{0, 1, 2, 1, 2, 3}, 6)
 
 ### LastIndexOf
 
-Returns the index at which the last occurrence of a value is found in an array or return -1 if the value cannot be found.
+Returns the index at which the last occurrence of a value is found in a slice or return -1 if the value cannot be found.
 
 ```go
 found := lo.LastIndexOf([]int{0, 1, 2, 1, 2, 3}, 2)
@@ -2656,7 +2656,7 @@ result2, ok2 := lo.FindKeyBy(map[string]int{"foo": 1, "bar": 2, "baz": 3}, func(
 
 ### FindUniques
 
-Returns a slice with all the unique elements of the collection. The order of result values is determined by the order they occur in the array.
+Returns a slice with all the unique elements of the collection. The order of result values is determined by the order they occur in the slice.
 
 ```go
 uniqueValues := lo.FindUniques([]int{1, 2, 2, 1, 2, 3})
@@ -2665,7 +2665,7 @@ uniqueValues := lo.FindUniques([]int{1, 2, 2, 1, 2, 3})
 
 ### FindUniquesBy
 
-Returns a slice with all the unique elements of the collection. The order of result values is determined by the order they occur in the array. It accepts `iteratee` which is invoked for each element in array to generate the criterion by which uniqueness is computed.
+Returns a slice with all the unique elements of the collection. The order of result values is determined by the order they occur in the slice. It accepts `iteratee` which is invoked for each element in slice to generate the criterion by which uniqueness is computed.
 
 ```go
 uniqueValues := lo.FindUniquesBy([]int{3, 4, 5, 6, 7}, func(i int) int {
@@ -2676,7 +2676,7 @@ uniqueValues := lo.FindUniquesBy([]int{3, 4, 5, 6, 7}, func(i int) int {
 
 ### FindDuplicates
 
-Returns a slice with the first occurrence of each duplicated element in the collection. The order of result values is determined by the order they occur in the array.
+Returns a slice with the first occurrence of each duplicated element in the collection. The order of result values is determined by the order they occur in the slice.
 
 ```go
 duplicatedValues := lo.FindDuplicates([]int{1, 2, 2, 1, 2, 3})
@@ -2685,7 +2685,7 @@ duplicatedValues := lo.FindDuplicates([]int{1, 2, 2, 1, 2, 3})
 
 ### FindDuplicatesBy
 
-Returns a slice with the first occurrence of each duplicated element in the collection. The order of result values is determined by the order they occur in the array. It accepts `iteratee` which is invoked for each element in array to generate the criterion by which uniqueness is computed.
+Returns a slice with the first occurrence of each duplicated element in the collection. The order of result values is determined by the order they occur in the slice. It accepts `iteratee` which is invoked for each element in slice to generate the criterion by which uniqueness is computed.
 
 ```go
 duplicatedValues := lo.FindDuplicatesBy([]int{3, 4, 5, 6, 7}, func(i int) int {

--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ uniqValues := lo.Uniq([]int{1, 2, 2, 1})
 
 ### UniqBy
 
-Returns a duplicate-free version of a slice, in which only the first occurrence of each element is kept. The order of result values is determined by the order they occur in the slice. It accepts `iteratee` which is invoked for each element in slice to generate the criterion by which uniqueness is computed.
+Returns a duplicate-free version of a slice, in which only the first occurrence of each element is kept. The order of result values is determined by the order they occur in the slice. It accepts `iteratee` which is invoked for each element in the slice to generate the criterion by which uniqueness is computed.
 
 ```go
 uniqValues := lo.UniqBy([]int{0, 1, 2, 3, 4, 5}, func(i int) int {
@@ -626,7 +626,7 @@ groups := lo.GroupByMap([]int{0, 1, 2, 3, 4, 5}, func(i int) (int, int) {
 
 ### Chunk
 
-Returns a slice of elements split into groups of length size. If slice can't be split evenly, the final chunk will be the remaining elements.
+Returns a slice of elements split into groups of length size. If the slice can't be split evenly, the final chunk will be the remaining elements.
 
 ```go
 lo.Chunk([]int{0, 1, 2, 3, 4, 5}, 2)
@@ -725,7 +725,7 @@ list
 
 ### Reverse
 
-Reverses slice so that the first element becomes the last, the second element becomes the second to last, and so on.
+Reverses a slice so that the first element becomes the last, the second element becomes the second to last, and so on.
 
 ⚠️ This helper is **mutable**.
 
@@ -743,7 +743,7 @@ list
 
 ### Fill
 
-Fills elements of slice with `initial` value.
+Fills elements of a slice with `initial` value.
 
 ```go
 type foo struct {
@@ -1489,7 +1489,7 @@ out := lo.MapEntries(in, func(k string, v int) (int, string) {
 
 ### MapToSlice
 
-Transforms a map into a slice based on specific iteratee.
+Transforms a map into a slice based on specified iteratee.
 
 ```go
 m := map[int]int64{1: 4, 2: 5, 3: 6}
@@ -1504,7 +1504,7 @@ s := lo.MapToSlice(m, func(k int, v int64) string {
 
 ### FilterMapToSlice
 
-Transforms a map into a slice based on specific iteratee. The iteratee returns a value and a boolean. If the boolean is true, the value is added to the result slice.
+Transforms a map into a slice based on specified iteratee. The iteratee returns a value and a boolean. If the boolean is true, the value is added to the result slice.
 
 If the boolean is false, the value is not added to the result slice. The order of the keys in the input map is not specified and the order of the keys in the output slice is not guaranteed.
 
@@ -1878,7 +1878,7 @@ tuple2 := lo.T2(example())
 
 ### Unpack2 -> Unpack9
 
-Returns values contained in tuple.
+Returns values contained in a tuple.
 
 ```go
 r1, r2 := lo.Unpack2(lo.Tuple2[string, int]{"a", 1})
@@ -1947,7 +1947,7 @@ a, b := lo.UnzipBy2([]string{"hello", "john", "doe"}, func(str string) (string, 
 
 ### CrossJoin2 -> CrossJoin9
 
-Combines every item from one list with every item from others. It is the cartesian product of lists received as arguments. It returns an empty list if a list is empty.
+Combines every item from one list with every item from others. It is the cartesian product of lists received as arguments. Returns an empty list if a list is empty.
 
 ```go
 result := lo.CrossJoin2([]string{"hello", "john", "doe"}, []int{1, 2})
@@ -1961,7 +1961,7 @@ result := lo.CrossJoin2([]string{"hello", "john", "doe"}, []int{1, 2})
 
 ### CrossJoinBy2 -> CrossJoinBy9
 
-Combines every item from one list with every item from others. It is the cartesian product of lists received as arguments. The project function is used to create the output values. It returns an empty list if a list is empty.
+Combines every item from one list with every item from others. It is the cartesian product of lists received as arguments. The project function is used to create the output values. Returns an empty list if a list is empty.
 
 ```go
 result := lo.CrossJoinBy2([]string{"hello", "john", "doe"}, []int{1, 2}, func(a A, b B) string {
@@ -2114,7 +2114,7 @@ for v := range lo.SliceToChannel(2, list) {
 
 ### ChannelToSlice
 
-Returns a slice built from channels items. Blocks until channel closes.
+Returns a slice built from channel items. Blocks until channel closes.
 
 ```go
 list := []int{1, 2, 3, 4, 5}
@@ -2433,7 +2433,7 @@ union := lo.Union([]int{0, 1, 2, 3, 4, 5}, []int{0, 2}, []int{0, 10})
 
 ### Without
 
-Returns slice excluding all given values.
+Returns a slice excluding all given values.
 
 ```go
 subset := lo.Without([]int{0, 2, 10}, 2)
@@ -2447,7 +2447,7 @@ subset := lo.Without([]int{0, 2, 10}, 0, 1, 2, 3, 4, 5)
 
 Filters a slice by excluding elements whose extracted keys match any in the exclude list.
 
-It returns a new slice containing only the elements whose keys are not in the exclude list.
+Returns a new slice containing only the elements whose keys are not in the exclude list.
 
 
 ```go
@@ -2478,7 +2478,7 @@ filteredUsers := lo.WithoutBy(users, getID, excludedIDs...)
 
 ### WithoutEmpty
 
-Returns slice excluding zero values.
+Returns a slice excluding zero values.
 
 ```go
 subset := lo.WithoutEmpty([]int{0, 2, 10})
@@ -2487,7 +2487,7 @@ subset := lo.WithoutEmpty([]int{0, 2, 10})
 
 ### WithoutNth
 
-Returns slice excluding nth value.
+Returns a slice excluding the nth value.
 
 ```go
 subset := lo.WithoutNth([]int{-2, -1, 0, 1, 2}, 3, -42, 1)
@@ -2526,7 +2526,7 @@ b := lo.ElementsMatchBy(
 
 ### IndexOf
 
-Returns the index at which the first occurrence of a value is found in a slice or return -1 if the value cannot be found.
+Returns the index at which the first occurrence of a value is found in a slice or -1 if the value cannot be found.
 
 ```go
 found := lo.IndexOf([]int{0, 1, 2, 1, 2, 3}, 2)
@@ -2540,7 +2540,7 @@ notFound := lo.IndexOf([]int{0, 1, 2, 1, 2, 3}, 6)
 
 ### LastIndexOf
 
-Returns the index at which the last occurrence of a value is found in a slice or return -1 if the value cannot be found.
+Returns the index at which the last occurrence of a value is found in a slice or -1 if the value cannot be found.
 
 ```go
 found := lo.LastIndexOf([]int{0, 1, 2, 1, 2, 3}, 2)
@@ -2552,7 +2552,7 @@ notFound := lo.LastIndexOf([]int{0, 1, 2, 1, 2, 3}, 6)
 
 ### Find
 
-Searches for an element in a slice based on a predicate. It returns element and true if element was found.
+Searches for an element in a slice based on a predicate. Returns element and true if element was found.
 
 ```go
 str, ok := lo.Find([]string{"a", "b", "c", "d"}, func(i string) bool {
@@ -2570,7 +2570,7 @@ str, ok := lo.Find([]string{"foobar"}, func(i string) bool {
 
 ### FindIndexOf
 
-FindIndexOf searches an element in a slice based on a predicate and returns the index and true. It returns -1 and false if the element is not found.
+FindIndexOf searches for an element in a slice based on a predicate and returns the index and true. Returns -1 and false if the element is not found.
 
 ```go
 str, index, ok := lo.FindIndexOf([]string{"a", "b", "a", "b"}, func(i string) bool {
@@ -2588,7 +2588,7 @@ str, index, ok := lo.FindIndexOf([]string{"foobar"}, func(i string) bool {
 
 ### FindLastIndexOf
 
-FindLastIndexOf searches an element in a slice based on a predicate and returns the index and true. It returns -1 and false if the element is not found.
+FindLastIndexOf searches for the last element in a slice based on a predicate and returns the index and true. Returns -1 and false if the element is not found.
 
 ```go
 str, index, ok := lo.FindLastIndexOf([]string{"a", "b", "a", "b"}, func(i string) bool {
@@ -2606,7 +2606,7 @@ str, index, ok := lo.FindLastIndexOf([]string{"foobar"}, func(i string) bool {
 
 ### FindOrElse
 
-Searches for an element in a slice based on a predicate. It returns the element if found or a given fallback value otherwise.
+Searches for an element in a slice based on a predicate. Returns the element if found or a given fallback value otherwise.
 
 ```go
 str := lo.FindOrElse([]string{"a", "b", "c", "d"}, "x", func(i string) bool {
@@ -2656,7 +2656,7 @@ result2, ok2 := lo.FindKeyBy(map[string]int{"foo": 1, "bar": 2, "baz": 3}, func(
 
 ### FindUniques
 
-Returns a slice with all the unique elements of the collection. The order of result values is determined by the order they occur in the slice.
+Returns a slice with all the elements that appear in the collection only once. The order of result values is determined by the order they occur in the slice.
 
 ```go
 uniqueValues := lo.FindUniques([]int{1, 2, 2, 1, 2, 3})
@@ -2665,7 +2665,7 @@ uniqueValues := lo.FindUniques([]int{1, 2, 2, 1, 2, 3})
 
 ### FindUniquesBy
 
-Returns a slice with all the unique elements of the collection. The order of result values is determined by the order they occur in the slice. It accepts `iteratee` which is invoked for each element in slice to generate the criterion by which uniqueness is computed.
+Returns a slice with all the elements that appear in the collection only once. The order of result values is determined by the order they occur in the slice. It accepts `iteratee` which is invoked for each element in the slice to generate the criterion by which uniqueness is computed.
 
 ```go
 uniqueValues := lo.FindUniquesBy([]int{3, 4, 5, 6, 7}, func(i int) int {
@@ -2685,7 +2685,7 @@ duplicatedValues := lo.FindDuplicates([]int{1, 2, 2, 1, 2, 3})
 
 ### FindDuplicatesBy
 
-Returns a slice with the first occurrence of each duplicated element in the collection. The order of result values is determined by the order they occur in the slice. It accepts `iteratee` which is invoked for each element in slice to generate the criterion by which uniqueness is computed.
+Returns a slice with the first occurrence of each duplicated element in the collection. The order of result values is determined by the order they occur in the slice. It accepts `iteratee` which is invoked for each element in the slice to generate the criterion by which uniqueness is computed.
 
 ```go
 duplicatedValues := lo.FindDuplicatesBy([]int{3, 4, 5, 6, 7}, func(i int) int {

--- a/README.md
+++ b/README.md
@@ -935,7 +935,7 @@ l := lo.DropByIndex([]int{0, 1, 2, 3, 4, 5}, 2, 4, -1)
 
 ### Reject
 
-The opposite of Filter, this method returns the elements of collection that predicate does not return truthy for.
+The opposite of Filter, this method returns the elements of collection that predicate does not return true for.
 
 ```go
 odd := lo.Reject([]int{1, 2, 3, 4}, func(x int, _ int) bool {
@@ -964,7 +964,7 @@ items := lo.RejectMap([]int{1, 2, 3, 4}, func(x int, _ int) (int, bool) {
 
 ### FilterReject
 
-Mixes Filter and Reject, this method returns two slices, one for the elements of collection that predicate returns truthy for and one for the elements that predicate does not return truthy for.
+Mixes Filter and Reject, this method returns two slices, one for the elements of collection that predicate returns true for and one for the elements that predicate does not return true for.
 
 ```go
 kept, rejected := lo.FilterReject([]int{1, 2, 3, 4}, func(x int, _ int) bool {
@@ -1519,7 +1519,7 @@ result := lo.FilterMapToSlice(kv, func(k int, v int64) (string, bool) {
 
 ### FilterKeys
 
-Transforms a map into a slice based on predicate returns truthy for specific elements. It is a mix of `lo.Filter()` and `lo.Keys()`.
+Transforms a map into a slice based on predicate returns true for specific elements. It is a mix of `lo.Filter()` and `lo.Keys()`.
 
 ```go
 kv := map[int]string{1: "foo", 2: "bar", 3: "baz"}
@@ -1534,7 +1534,7 @@ result := FilterKeys(kv, func(k int, v string) bool {
 
 ### FilterValues
 
-Transforms a map into a slice based on predicate returns truthy for specific elements. It is a mix of `lo.Filter()` and `lo.Values()`.
+Transforms a map into a slice based on predicate returns true for specific elements. It is a mix of `lo.Filter()` and `lo.Values()`.
 
 ```go
 kv := map[int]string{1: "foo", 2: "bar", 3: "baz"}
@@ -2640,7 +2640,7 @@ result3, ok3 := lo.FindKey(map[string]test{"foo": test{"foo"}, "bar": test{"bar"
 
 ### FindKeyBy
 
-Returns the key of the first element predicate returns truthy for.
+Returns the key of the first element predicate returns true for.
 
 ```go
 result1, ok1 := lo.FindKeyBy(map[string]int{"foo": 1, "bar": 2, "baz": 3}, func(k string, v int) bool {

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ import (
 )
 ```
 
-I take no responsibility on this junk. 😁 💩
+I take no responsibility for this junk. 😁 💩
 
 ## 🤠 Spec
 
@@ -429,7 +429,7 @@ names := lo.UniqMap(users, func(u User, index int) string {
 
 ### FilterMap
 
-Returns a slice which obtained after both filtering and mapping using the given callback function.
+Returns a slice obtained after both filtering and mapping using the given callback function.
 
 The callback function should return two values: the result of the mapping operation and whether the result element should be included or not.
 
@@ -626,7 +626,7 @@ groups := lo.GroupByMap([]int{0, 1, 2, 3, 4, 5}, func(i int) (int, int) {
 
 ### Chunk
 
-Returns an array of elements split into groups the length of size. If array can't be split evenly, the final chunk will be the remaining elements.
+Returns an array of elements split into groups of length size. If array can't be split evenly, the final chunk will be the remaining elements.
 
 ```go
 lo.Chunk([]int{0, 1, 2, 3, 4, 5}, 2)
@@ -826,7 +826,7 @@ result := lo.KeyBy(characters, func(char Character) string {
 ### SliceToMap (alias: Associate)
 
 Returns a map containing key-value pairs provided by transform function applied to elements of the given slice.
-If any of two pairs would have the same key the last one gets added to the map.
+If any of two pairs have the same key the last one gets added to the map.
 
 The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
 
@@ -845,7 +845,7 @@ aMap := lo.SliceToMap(in, func (f *foo) (string, int) {
 
 Returns a map containing key-value pairs provided by transform function applied to elements of the given slice.
 
-If any of two pairs would have the same key the last one gets added to the map.
+If any of two pairs have the same key the last one gets added to the map.
 
 The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
 
@@ -948,7 +948,7 @@ odd := lo.Reject([]int{1, 2, 3, 4}, func(x int, _ int) bool {
 
 ### RejectMap
 
-The opposite of FilterMap, this method returns a slice which obtained after both filtering and mapping using the given callback function.
+The opposite of FilterMap, this method returns a slice obtained after both filtering and mapping using the given callback function.
 
 The callback function should return two values:
 
@@ -976,7 +976,7 @@ kept, rejected := lo.FilterReject([]int{1, 2, 3, 4}, func(x int, _ int) bool {
 
 ### Count
 
-Counts the number of elements in the collection that compare equal to value.
+Counts the number of elements in the collection that equal value.
 
 ```go
 count := lo.Count([]int{1, 5, 1}, 1)
@@ -1023,7 +1023,7 @@ lo.CountValues([]string{"foo", "bar", "bar"})
 
 ### CountValuesBy
 
-Counts the number of each element in the collection. It ss equivalent to chaining lo.Map and lo.CountValues.
+Counts the number of each element in the collection. It is equivalent to chaining lo.Map and lo.CountValues.
 
 ```go
 isEven := func(v int) bool {
@@ -1424,7 +1424,7 @@ mergedMaps := lo.Assign(
 
 ### ChunkEntries
 
-Splits a map into an array of elements in groups of a length equal to its size. If the map cannot be split evenly, the final chunk will contain the remaining elements.
+Splits a map into an array of elements in groups of length equal to its size. If the map cannot be split evenly, the final chunk will contain the remaining elements.
 
 ```go
 maps := lo.ChunkEntries(
@@ -1446,7 +1446,7 @@ maps := lo.ChunkEntries(
 
 ### MapKeys
 
-Manipulates a map keys and transforms it to a map of another type.
+Manipulates map keys and transforms it to a map of another type.
 
 ```go
 m2 := lo.MapKeys(map[int]int{1: 1, 2: 2, 3: 3, 4: 4}, func(_ int, v int) string {
@@ -1459,7 +1459,7 @@ m2 := lo.MapKeys(map[int]int{1: 1, 2: 2, 3: 3, 4: 4}, func(_ int, v int) string 
 
 ### MapValues
 
-Manipulates a map values and transforms it to a map of another type.
+Manipulates map values and transforms it to a map of another type.
 
 ```go
 m1 := map[int]int64{1: 1, 2: 2, 3: 3}
@@ -1474,7 +1474,7 @@ m2 := lo.MapValues(m1, func(x int64, _ int) string {
 
 ### MapEntries
 
-Manipulates a map entries and transforms it to a map of another type.
+Manipulates map entries and transforms it to a map of another type.
 
 ```go
 in := map[string]int{"foo": 1, "bar": 2}
@@ -1695,9 +1695,9 @@ mean := lo.MeanBy([]float64{}, mapper)
 
 ### Mode
 
-Calculates the mode(most frequent value) of a collection of numbers.
+Calculates the mode (most frequent value) of a collection of numbers.
 
-If multiple values ​​have the same highest frequency, then multiple values ​​are returned.
+If multiple values have the same highest frequency, then multiple values are returned.
 
 If the collection is empty, the zero value of `T[]` is returned.
 
@@ -1746,7 +1746,7 @@ sub := lo.Substring("hello", -2, math.MaxUint)
 
 ### ChunkString
 
-Returns an array of strings split into groups the length of size. If array can't be split evenly, the final chunk will be the remaining elements.
+Returns an array of strings split into groups of length size. If the string can't be split evenly, the final chunk will be the remaining characters.
 
 ```go
 lo.ChunkString("123456", 2)
@@ -1899,7 +1899,7 @@ a, b := tuple2.Unpack()
 
 Zip creates a slice of grouped elements, the first of which contains the first elements of the given arrays, the second of which contains the second elements of the given arrays, and so on.
 
-When collections have different size, the Tuple attributes are filled with zero value.
+When collections are different sizes, the Tuple attributes are filled with zero value.
 
 ```go
 tuples := lo.Zip2([]string{"a", "b"}, []int{1, 2})
@@ -1912,7 +1912,7 @@ tuples := lo.Zip2([]string{"a", "b"}, []int{1, 2})
 
 ZipBy creates a slice of transformed elements, the first of which contains the first elements of the given arrays, the second of which contains the second elements of the given arrays, and so on.
 
-When collections have different size, the Tuple attributes are filled with zero value.
+When collections are different sizes, the Tuple attributes are filled with zero value.
 
 ```go
 items := lo.ZipBy2([]string{"a", "b"}, []int{1, 2}, func(a string, b int) string {
@@ -1947,7 +1947,7 @@ a, b := lo.UnzipBy2([]string{"hello", "john", "doe"}, func(str string) (string, 
 
 ### CrossJoin2 -> CrossJoin9
 
-Combines every items from one list with every items from others. It is the cartesian product of lists received as arguments. It returns an empty list if a list is empty.
+Combines every item from one list with every item from others. It is the cartesian product of lists received as arguments. It returns an empty list if a list is empty.
 
 ```go
 result := lo.CrossJoin2([]string{"hello", "john", "doe"}, []int{1, 2})
@@ -1961,7 +1961,7 @@ result := lo.CrossJoin2([]string{"hello", "john", "doe"}, []int{1, 2})
 
 ### CrossJoinBy2 -> CrossJoinBy9
 
-Combines every items from one list with every items from others. It is the cartesian product of lists received as arguments. The project function is used to create the output values. It returns an empty list if a list is empty.
+Combines every item from one list with every item from others. It is the cartesian product of lists received as arguments. The project function is used to create the output values. It returns an empty list if a list is empty.
 
 ```go
 result := lo.CrossJoinBy2([]string{"hello", "john", "doe"}, []int{1, 2}, func(a A, b B) string {
@@ -2099,7 +2099,7 @@ children := lo.ChannelDispatcher(ch, 5, 10, customStrategy)
 
 ### SliceToChannel
 
-Returns a read-only channels of collection elements. Channel is closed after last element. Channel capacity can be customized.
+Returns a read-only channel of collection elements. Channel is closed after last element. Channel capacity can be customized.
 
 ```go
 list := []int{1, 2, 3, 4, 5}
@@ -2267,7 +2267,7 @@ for i := range children {
 
 ### FanIn
 
-Merge messages from multiple input channels into a single buffered channel. Output messages has no priority. When all upstream channels reach EOF, downstream channel closes.
+Merge messages from multiple input channels into a single buffered channel. Output messages have no priority. When all upstream channels reach EOF, downstream channel closes.
 
 ```go
 stream1 := make(chan int, 42)
@@ -2280,7 +2280,7 @@ all := lo.FanIn(100, stream1, stream2, stream3)
 
 ### FanOut
 
-Broadcasts all the upstream messages to multiple downstream channels. When upstream channel reach EOF, downstream channels close. If any downstream channels is full, broadcasting is paused.
+Broadcasts all the upstream messages to multiple downstream channels. When upstream channel reaches EOF, downstream channels close. If any downstream channels is full, broadcasting is paused.
 
 ```go
 stream := make(chan int, 42)
@@ -2313,7 +2313,7 @@ present := lo.ContainsBy([]int{0, 1, 2, 3, 4, 5}, func(x int) bool {
 
 ### Every
 
-Returns true if all elements of a subset are contained into a collection or if the subset is empty.
+Returns true if all elements of a subset are contained in a collection or if the subset is empty.
 
 ```go
 ok := lo.Every([]int{0, 1, 2, 3, 4, 5}, []int{0, 2})
@@ -2338,7 +2338,7 @@ b := EveryBy([]int{1, 2, 3, 4}, func(x int) bool {
 
 ### Some
 
-Returns true if at least 1 element of a subset is contained into a collection.
+Returns true if at least 1 element of a subset is contained in a collection.
 If the subset is empty Some returns false.
 
 ```go
@@ -2366,7 +2366,7 @@ b := SomeBy([]int{1, 2, 3, 4}, func(x int) bool {
 
 ### None
 
-Returns true if no element of a subset are contained into a collection or if the subset is empty.
+Returns true if no element of a subset is contained in a collection or if the subset is empty.
 
 ```go
 b := None([]int{0, 1, 2, 3, 4, 5}, []int{0, 2})
@@ -2409,8 +2409,8 @@ result3 := lo.Intersect([]int{0, 1, 2, 3, 4, 5}, []int{-1, 6})
 
 Returns the difference between two collections.
 
-- The first value is the collection of element absent of list2.
-- The second value is the collection of element absent of list1.
+- The first value is the collection of elements absent from list2.
+- The second value is the collection of elements absent from list1.
 
 ```go
 left, right := lo.Difference([]int{0, 1, 2, 3, 4, 5}, []int{0, 2, 6})
@@ -2498,7 +2498,7 @@ subset := lo.WithoutNth([]int{-2, -1, 0, 1, 2}, 3, -42, 1)
 
 Returns true if lists contain the same set of elements (including empty set).
 
-If there are duplicate elements, the number of appearances of each of them in both lists should match.
+If there are duplicate elements, the number of occurrences in each list should match.
 
 The order of elements is not checked.
 
@@ -2511,7 +2511,7 @@ b := lo.ElementsMatch([]int{1, 1, 2}, []int{2, 1, 1})
 
 Returns true if lists contain the same set of elements' keys (including empty set).
 
-If there are duplicate keys, the number of appearances of each of them in both lists should match.
+If there are duplicate keys, the number of occurrences in each list should match.
 
 The order of elements is not checked.
 
@@ -2552,7 +2552,7 @@ notFound := lo.LastIndexOf([]int{0, 1, 2, 1, 2, 3}, 6)
 
 ### Find
 
-Search an element in a slice based on a predicate. It returns element and true if element was found.
+Searches for an element in a slice based on a predicate. It returns element and true if element was found.
 
 ```go
 str, ok := lo.Find([]string{"a", "b", "c", "d"}, func(i string) bool {
@@ -2606,7 +2606,7 @@ str, index, ok := lo.FindLastIndexOf([]string{"foobar"}, func(i string) bool {
 
 ### FindOrElse
 
-Search an element in a slice based on a predicate. It returns the element if found or a given fallback value otherwise.
+Searches for an element in a slice based on a predicate. It returns the element if found or a given fallback value otherwise.
 
 ```go
 str := lo.FindOrElse([]string{"a", "b", "c", "d"}, "x", func(i string) bool {
@@ -2676,7 +2676,7 @@ uniqueValues := lo.FindUniquesBy([]int{3, 4, 5, 6, 7}, func(i int) int {
 
 ### FindDuplicates
 
-Returns a slice with the first occurrence of each duplicated elements of the collection. The order of result values is determined by the order they occur in the array.
+Returns a slice with the first occurrence of each duplicated element in the collection. The order of result values is determined by the order they occur in the array.
 
 ```go
 duplicatedValues := lo.FindDuplicates([]int{1, 2, 2, 1, 2, 3})
@@ -2685,7 +2685,7 @@ duplicatedValues := lo.FindDuplicates([]int{1, 2, 2, 1, 2, 3})
 
 ### FindDuplicatesBy
 
-Returns a slice with the first occurrence of each duplicated elements of the collection. The order of result values is determined by the order they occur in the array. It accepts `iteratee` which is invoked for each element in array to generate the criterion by which uniqueness is computed.
+Returns a slice with the first occurrence of each duplicated element in the collection. The order of result values is determined by the order they occur in the array. It accepts `iteratee` which is invoked for each element in array to generate the criterion by which uniqueness is computed.
 
 ```go
 duplicatedValues := lo.FindDuplicatesBy([]int{3, 4, 5, 6, 7}, func(i int) int {
@@ -3072,7 +3072,7 @@ lo.SamplesBy([]string{"a", "b", "c"}, 3, r.Intn)
 
 ### Ternary
 
-A 1 line if/else statement.
+A single line if/else statement.
 
 
 ```go
@@ -3089,7 +3089,7 @@ Take care to avoid dereferencing potentially nil pointers in your A/B expression
 
 ### TernaryF
 
-A 1 line if/else statement whose options are functions.
+A single line if/else statement whose options are functions.
 
 ```go
 result := lo.TernaryF(true, func() string { return "a" }, func() string { return "b" })
@@ -3322,7 +3322,7 @@ value := lo.FromPtrOr(nil, "empty")
 
 ### ToSlicePtr
 
-Returns a slice of pointer copy of value.
+Returns a slice of pointers to each value.
 
 ```go
 ptr := lo.ToSlicePtr([]string{"hello", "world"})
@@ -3372,7 +3372,7 @@ elements := lo.ToAnySlice([]int{1, 5, 1})
 
 ### FromAnySlice
 
-Returns an `any` slice with all elements mapped to a type. Returns false in case of type conversion failure.
+Returns a slice with all elements mapped to a type. Returns false in case of type conversion failure.
 
 ```go
 elements, ok := lo.FromAnySlice([]any{"foobar", 42})
@@ -3611,7 +3611,7 @@ iter, err := lo.Attempt(0, func(i int) error {
 // nil
 ```
 
-For more advanced retry strategies (delay, exponential backoff...), please take a look on [cenkalti/backoff](https://github.com/cenkalti/backoff).
+For more advanced retry strategies (delay, exponential backoff...), please take a look at [cenkalti/backoff](https://github.com/cenkalti/backoff).
 
 [[play](https://go.dev/play/p/3ggJZ2ZKcMj)]
 
@@ -3634,7 +3634,7 @@ iter, duration, err := lo.AttemptWithDelay(5, 2*time.Second, func(i int, duratio
 // nil
 ```
 
-For more advanced retry strategies (delay, exponential backoff...), please take a look on [cenkalti/backoff](https://github.com/cenkalti/backoff).
+For more advanced retry strategies (delay, exponential backoff...), please take a look at [cenkalti/backoff](https://github.com/cenkalti/backoff).
 
 [[play](https://go.dev/play/p/tVs6CygC7m1)]
 
@@ -3648,7 +3648,7 @@ When the first argument is less than `1`, the function runs until a successful r
 count1, err1 := lo.AttemptWhile(5, func(i int) (error, bool) {
     err := doMockedHTTPRequest(i)
     if err != nil {
-        if errors.Is(err, ErrBadRequest) { // lets assume ErrBadRequest is a critical error that needs to terminate the invoke
+        if errors.Is(err, ErrBadRequest) { // let's assume ErrBadRequest is a critical error that needs to terminate the invoke
             return err, false // flag the second return value as false to terminate the invoke
         }
 
@@ -3659,7 +3659,7 @@ count1, err1 := lo.AttemptWhile(5, func(i int) (error, bool) {
 })
 ```
 
-For more advanced retry strategies (delay, exponential backoff...), please take a look on [cenkalti/backoff](https://github.com/cenkalti/backoff).
+For more advanced retry strategies (delay, exponential backoff...), please take a look at [cenkalti/backoff](https://github.com/cenkalti/backoff).
 
 [[play](https://go.dev/play/p/1VS7HxlYMOG)]
 
@@ -3673,7 +3673,7 @@ When the first argument is less than `1`, the function runs until a successful r
 count1, time1, err1 := lo.AttemptWhileWithDelay(5, time.Millisecond, func(i int, d time.Duration) (error, bool) {
     err := doMockedHTTPRequest(i)
     if err != nil {
-        if errors.Is(err, ErrBadRequest) { // lets assume ErrBadRequest is a critical error that needs to terminate the invoke
+        if errors.Is(err, ErrBadRequest) { // let's assume ErrBadRequest is a critical error that needs to terminate the invoke
             return err, false // flag the second return value as false to terminate the invoke
         }
 
@@ -3684,7 +3684,7 @@ count1, time1, err1 := lo.AttemptWhileWithDelay(5, time.Millisecond, func(i int,
 })
 ```
 
-For more advanced retry strategies (delay, exponential backoff...), please take a look on [cenkalti/backoff](https://github.com/cenkalti/backoff).
+For more advanced retry strategies (delay, exponential backoff...), please take a look at [cenkalti/backoff](https://github.com/cenkalti/backoff).
 
 [[play](https://go.dev/play/p/mhufUjJfLEF)]
 
@@ -3827,8 +3827,8 @@ ch := lo.Async(func() error { time.Sleep(10 * time.Second); return nil })
 ### Async{0->6}
 
 Executes a function in a goroutine and returns the result in a channel.
-For function with multiple return values, the results will be returned as a tuple inside the channel.
-For function without return, struct{} will be returned in the channel.
+For functions with multiple return values, the results will be returned as a tuple inside the channel.
+For functions without return, struct{} will be returned in the channel.
 
 ```go
 ch := lo.Async0(func() { time.Sleep(10 * time.Second) })
@@ -3995,7 +3995,7 @@ val := lo.Validate(len(slice) == 0, "Slice should be empty but contains %v", sli
 
 ### Must
 
-Wraps a function call to panics if second argument is `error` or `false`, returns the value otherwise.
+Wraps a function call and panics if second argument is `error` or `false`, returns the value otherwise.
 
 ```go
 val := lo.Must(time.Parse("2006-01-02", "2022-01-15"))
@@ -4009,7 +4009,7 @@ val := lo.Must(time.Parse("2006-01-02", "bad-value"))
 
 ### Must{0->6}
 
-Must\* has the same behavior as Must, but returns multiple values.
+Must\* has the same behavior as Must but returns multiple values.
 
 ```go
 func example0() (error)
@@ -4201,7 +4201,7 @@ if ok := errors.As(err, &rateLimitErr); ok {
 }
 ```
 
-1 line `lo` helper:
+single line `lo` helper:
 
 ```go
 err := doSomething()
@@ -4281,7 +4281,7 @@ ok  	github.com/samber/lo	6.657s
 - `lo.Map` is way faster (x7) than `go-funk`, a reflection-based Map implementation.
 - `lo.Map` has the same allocation profile as `for`.
 - `lo.Map` is 4% slower than `for`.
-- `lop.Map` is slower than `lo.Map` because it implies more memory allocation and locks. `lop.Map` will be useful for long-running callbacks, such as i/o bound processing.
+- `lop.Map` is slower than `lo.Map` because it implies more memory allocation and locks. `lop.Map` is useful for long-running callbacks, such as i/o bound processing.
 - `for` beats other implementations for memory and CPU.
 
 ## 🤝 Contributing

--- a/channel.go
+++ b/channel.go
@@ -177,7 +177,7 @@ func SliceToChannel[T any](bufferSize int, collection []T) <-chan T {
 	return ch
 }
 
-// ChannelToSlice returns a slice built from channels items. Blocks until channel closes.
+// ChannelToSlice returns a slice built from channel items. Blocks until channel closes.
 // Play: https://go.dev/play/p/lIbSY3QmiEg
 func ChannelToSlice[T any](ch <-chan T) []T {
 	collection := []T{}

--- a/channel.go
+++ b/channel.go
@@ -161,7 +161,7 @@ func DispatchingStrategyMost[T any](msg T, index uint64, channels []<-chan T) in
 	})
 }
 
-// SliceToChannel returns a read-only channels of collection elements.
+// SliceToChannel returns a read-only channel of collection elements.
 // Play: https://go.dev/play/p/lIbSY3QmiEg
 func SliceToChannel[T any](bufferSize int, collection []T) <-chan T {
 	ch := make(chan T, bufferSize)
@@ -207,7 +207,7 @@ func Generator[T any](bufferSize int, generator func(yield func(T))) <-chan T {
 }
 
 // Buffer creates a slice of n elements from a channel. Returns the slice and the slice length.
-// @TODO: we should probably provide an helper that reuse the same buffer.
+// @TODO: we should probably provide a helper that reuses the same buffer.
 // Play: https://go.dev/play/p/gPQ-6xmcKQI
 func Buffer[T any](ch <-chan T, size int) (collection []T, length int, readTime time.Duration, ok bool) {
 	buffer := make([]T, 0, size)
@@ -234,7 +234,7 @@ func Batch[T any](ch <-chan T, size int) (collection []T, length int, readTime t
 }
 
 // BufferWithContext creates a slice of n elements from a channel, with context. Returns the slice and the slice length.
-// @TODO: we should probably provide an helper that reuse the same buffer.
+// @TODO: we should probably provide a helper that reuses the same buffer.
 // Play: https://go.dev/play/p/oRfOyJWK9YF
 func BufferWithContext[T any](ctx context.Context, ch <-chan T, size int) (collection []T, length int, readTime time.Duration, ok bool) {
 	buffer := make([]T, 0, size)
@@ -273,7 +273,7 @@ func BatchWithTimeout[T any](ch <-chan T, size int, timeout time.Duration) (coll
 }
 
 // FanIn collects messages from multiple input channels into a single buffered channel.
-// Output messages has no priority. When all upstream channels reach EOF, downstream channel closes.
+// Output messages have no priority. When all upstream channels reach EOF, downstream channel closes.
 // Play: https://go.dev/play/p/FH8Wq-T04Jb
 func FanIn[T any](channelBufferCap int, upstreams ...<-chan T) <-chan T {
 	out := make(chan T, channelBufferCap)
@@ -299,7 +299,7 @@ func FanIn[T any](channelBufferCap int, upstreams ...<-chan T) <-chan T {
 }
 
 // ChannelMerge collects messages from multiple input channels into a single buffered channel.
-// Output messages has no priority. When all upstream channels reach EOF, downstream channel closes.
+// Output messages have no priority. When all upstream channels reach EOF, downstream channel closes.
 //
 // Deprecated: Use [FanIn] instead.
 func ChannelMerge[T any](channelBufferCap int, upstreams ...<-chan T) <-chan T {
@@ -307,7 +307,7 @@ func ChannelMerge[T any](channelBufferCap int, upstreams ...<-chan T) <-chan T {
 }
 
 // FanOut broadcasts all the upstream messages to multiple downstream channels.
-// When upstream channel reach EOF, downstream channels close. If any downstream
+// When upstream channel reaches EOF, downstream channels close. If any downstream
 // channels is full, broadcasting is paused.
 // Play: https://go.dev/play/p/2LHxcjKX23L
 func FanOut[T any](count int, channelsBufferCap int, upstream <-chan T) []<-chan T {

--- a/condition.go
+++ b/condition.go
@@ -1,6 +1,6 @@
 package lo
 
-// Ternary is a 1 line if/else statement.
+// Ternary is a single line if/else statement.
 // Take care to avoid dereferencing potentially nil pointers in your A/B expressions, because they are both evaluated. See TernaryF to avoid this problem.
 // Play: https://go.dev/play/p/t-D7WBL44h2
 func Ternary[T any](condition bool, ifOutput T, elseOutput T) T {
@@ -11,7 +11,7 @@ func Ternary[T any](condition bool, ifOutput T, elseOutput T) T {
 	return elseOutput
 }
 
-// TernaryF is a 1 line if/else statement whose options are functions
+// TernaryF is a single line if/else statement whose options are functions
 // Play: https://go.dev/play/p/AO4VW20JoqM
 func TernaryF[T any](condition bool, ifFunc func() T, elseFunc func() T) T {
 	if condition {
@@ -26,7 +26,7 @@ type ifElse[T any] struct {
 	done   bool
 }
 
-// If is a 1 line if/else statement.
+// If is a single line if/else statement.
 // Play: https://go.dev/play/p/WSw3ApMxhyW
 func If[T any](condition bool, result T) *ifElse[T] { //nolint:revive
 	if condition {
@@ -37,7 +37,7 @@ func If[T any](condition bool, result T) *ifElse[T] { //nolint:revive
 	return &ifElse[T]{t, false}
 }
 
-// IfF is a 1 line if/else statement whose options are functions
+// IfF is a single line if/else statement whose options are functions
 // Play: https://go.dev/play/p/WSw3ApMxhyW
 func IfF[T any](condition bool, resultF func() T) *ifElse[T] { //nolint:revive
 	if condition {

--- a/condition.go
+++ b/condition.go
@@ -11,7 +11,7 @@ func Ternary[T any](condition bool, ifOutput T, elseOutput T) T {
 	return elseOutput
 }
 
-// TernaryF is a single line if/else statement whose options are functions
+// TernaryF is a single line if/else statement whose options are functions.
 // Play: https://go.dev/play/p/AO4VW20JoqM
 func TernaryF[T any](condition bool, ifFunc func() T, elseFunc func() T) T {
 	if condition {
@@ -37,7 +37,7 @@ func If[T any](condition bool, result T) *ifElse[T] { //nolint:revive
 	return &ifElse[T]{t, false}
 }
 
-// IfF is a single line if/else statement whose options are functions
+// IfF is a single line if/else statement whose options are functions.
 // Play: https://go.dev/play/p/WSw3ApMxhyW
 func IfF[T any](condition bool, resultF func() T) *ifElse[T] { //nolint:revive
 	if condition {

--- a/errors.go
+++ b/errors.go
@@ -73,7 +73,7 @@ func Must0(err any, messageArgs ...any) {
 	must(err, messageArgs...)
 }
 
-// Must1 is an alias to Must
+// Must1 is an alias to Must.
 // Play: https://go.dev/play/p/TMoWrRp3DyC
 func Must1[T any](val T, err any, messageArgs ...any) T {
 	return Must(val, err, messageArgs...)

--- a/find.go
+++ b/find.go
@@ -36,7 +36,7 @@ func LastIndexOf[T comparable](collection []T, element T) int {
 	return -1
 }
 
-// Find search an element in a slice based on a predicate. It returns element and true if element was found.
+// Find searches for an element in a slice based on a predicate. It returns element and true if element was found.
 // Play: https://go.dev/play/p/Eo7W0lvKTky
 func Find[T any](collection []T, predicate func(item T) bool) (T, bool) {
 	for i := range collection {
@@ -79,7 +79,7 @@ func FindLastIndexOf[T any](collection []T, predicate func(item T) bool) (T, int
 	return result, -1, false
 }
 
-// FindOrElse search an element in a slice based on a predicate. It returns the element if found or a given fallback value otherwise.
+// FindOrElse searches for an element in a slice based on a predicate. It returns the element if found or a given fallback value otherwise.
 // Play: https://go.dev/play/p/Eo7W0lvKTky
 func FindOrElse[T any](collection []T, fallback T, predicate func(item T) bool) T {
 	for i := range collection {
@@ -170,7 +170,7 @@ func FindUniquesBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee f
 	return result
 }
 
-// FindDuplicates returns a slice with the first occurrence of each duplicated elements of the collection.
+// FindDuplicates returns a slice with the first occurrence of each duplicated element in the collection.
 // The order of result values is determined by the order they occur in the collection.
 func FindDuplicates[T comparable, Slice ~[]T](collection Slice) Slice {
 	isDupl := make(map[T]bool, len(collection))
@@ -196,7 +196,7 @@ func FindDuplicates[T comparable, Slice ~[]T](collection Slice) Slice {
 	return result
 }
 
-// FindDuplicatesBy returns a slice with the first occurrence of each duplicated elements of the collection.
+// FindDuplicatesBy returns a slice with the first occurrence of each duplicated element in the collection.
 // The order of result values is determined by the order they occur in the array. It accepts `iteratee` which is
 // invoked for each element in array to generate the criterion by which uniqueness is computed.
 func FindDuplicatesBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee func(item T) U) Slice {

--- a/find.go
+++ b/find.go
@@ -8,7 +8,7 @@ import (
 	"github.com/samber/lo/internal/rand"
 )
 
-// IndexOf returns the index at which the first occurrence of a value is found in a slice or return -1
+// IndexOf returns the index at which the first occurrence of a value is found in a slice or -1
 // if the value cannot be found.
 // Play: https://go.dev/play/p/Eo7W0lvKTky
 func IndexOf[T comparable](collection []T, element T) int {
@@ -21,7 +21,7 @@ func IndexOf[T comparable](collection []T, element T) int {
 	return -1
 }
 
-// LastIndexOf returns the index at which the last occurrence of a value is found in a slice or return -1
+// LastIndexOf returns the index at which the last occurrence of a value is found in a slice or -1
 // if the value cannot be found.
 // Play: https://go.dev/play/p/Eo7W0lvKTky
 func LastIndexOf[T comparable](collection []T, element T) int {
@@ -36,7 +36,7 @@ func LastIndexOf[T comparable](collection []T, element T) int {
 	return -1
 }
 
-// Find searches for an element in a slice based on a predicate. It returns element and true if element was found.
+// Find searches for an element in a slice based on a predicate. Returns element and true if element was found.
 // Play: https://go.dev/play/p/Eo7W0lvKTky
 func Find[T any](collection []T, predicate func(item T) bool) (T, bool) {
 	for i := range collection {
@@ -49,8 +49,8 @@ func Find[T any](collection []T, predicate func(item T) bool) (T, bool) {
 	return result, false
 }
 
-// FindIndexOf searches an element in a slice based on a predicate and returns the index and true.
-// It returns -1 and false if the element is not found.
+// FindIndexOf searches for an element in a slice based on a predicate and returns the index and true.
+// Returns -1 and false if the element is not found.
 // Play: https://go.dev/play/p/XWSEM4Ic_t0
 func FindIndexOf[T any](collection []T, predicate func(item T) bool) (T, int, bool) {
 	for i := range collection {
@@ -63,8 +63,8 @@ func FindIndexOf[T any](collection []T, predicate func(item T) bool) (T, int, bo
 	return result, -1, false
 }
 
-// FindLastIndexOf searches last element in a slice based on a predicate and returns the index and true.
-// It returns -1 and false if the element is not found.
+// FindLastIndexOf searches for the last element in a slice based on a predicate and returns the index and true.
+// Returns -1 and false if the element is not found.
 // Play: https://go.dev/play/p/dPiMRtJ6cUx
 func FindLastIndexOf[T any](collection []T, predicate func(item T) bool) (T, int, bool) {
 	length := len(collection)
@@ -79,7 +79,7 @@ func FindLastIndexOf[T any](collection []T, predicate func(item T) bool) (T, int
 	return result, -1, false
 }
 
-// FindOrElse searches for an element in a slice based on a predicate. It returns the element if found or a given fallback value otherwise.
+// FindOrElse searches for an element in a slice based on a predicate. Returns the element if found or a given fallback value otherwise.
 // Play: https://go.dev/play/p/Eo7W0lvKTky
 func FindOrElse[T any](collection []T, fallback T, predicate func(item T) bool) T {
 	for i := range collection {
@@ -115,7 +115,7 @@ func FindKeyBy[K comparable, V any](object map[K]V, predicate func(key K, value 
 	return Empty[K](), false
 }
 
-// FindUniques returns a slice with all the unique elements of the collection.
+// FindUniques returns a slice with all the elements that appear in the collection only once.
 // The order of result values is determined by the order they occur in the collection.
 func FindUniques[T comparable, Slice ~[]T](collection Slice) Slice {
 	isDupl := make(map[T]bool, len(collection))
@@ -140,9 +140,9 @@ func FindUniques[T comparable, Slice ~[]T](collection Slice) Slice {
 	return result
 }
 
-// FindUniquesBy returns a slice with all the unique elements of the collection.
+// FindUniquesBy returns a slice with all the elements that appear in the collection only once.
 // The order of result values is determined by the order they occur in the slice. It accepts `iteratee` which is
-// invoked for each element in slice to generate the criterion by which uniqueness is computed.
+// invoked for each element in the slice to generate the criterion by which uniqueness is computed.
 func FindUniquesBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee func(item T) U) Slice {
 	isDupl := make(map[U]bool, len(collection))
 
@@ -198,7 +198,7 @@ func FindDuplicates[T comparable, Slice ~[]T](collection Slice) Slice {
 
 // FindDuplicatesBy returns a slice with the first occurrence of each duplicated element in the collection.
 // The order of result values is determined by the order they occur in the slice. It accepts `iteratee` which is
-// invoked for each element in slice to generate the criterion by which uniqueness is computed.
+// invoked for each element in the slice to generate the criterion by which uniqueness is computed.
 func FindDuplicatesBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee func(item T) U) Slice {
 	isDupl := make(map[U]bool, len(collection))
 
@@ -622,7 +622,7 @@ func NthOrEmpty[T any, N constraints.Integer](collection []T, nth N) T {
 }
 
 // randomIntGenerator is a function that should return a random integer in the range [0, n)
-// where n is the parameter passed to the randomIntGenerator.
+// where n is the argument passed to the randomIntGenerator.
 type randomIntGenerator func(n int) int
 
 // Sample returns a random item from collection.

--- a/find.go
+++ b/find.go
@@ -8,7 +8,7 @@ import (
 	"github.com/samber/lo/internal/rand"
 )
 
-// IndexOf returns the index at which the first occurrence of a value is found in an array or return -1
+// IndexOf returns the index at which the first occurrence of a value is found in a slice or return -1
 // if the value cannot be found.
 // Play: https://go.dev/play/p/Eo7W0lvKTky
 func IndexOf[T comparable](collection []T, element T) int {
@@ -21,7 +21,7 @@ func IndexOf[T comparable](collection []T, element T) int {
 	return -1
 }
 
-// LastIndexOf returns the index at which the last occurrence of a value is found in an array or return -1
+// LastIndexOf returns the index at which the last occurrence of a value is found in a slice or return -1
 // if the value cannot be found.
 // Play: https://go.dev/play/p/Eo7W0lvKTky
 func LastIndexOf[T comparable](collection []T, element T) int {
@@ -141,8 +141,8 @@ func FindUniques[T comparable, Slice ~[]T](collection Slice) Slice {
 }
 
 // FindUniquesBy returns a slice with all the unique elements of the collection.
-// The order of result values is determined by the order they occur in the array. It accepts `iteratee` which is
-// invoked for each element in array to generate the criterion by which uniqueness is computed.
+// The order of result values is determined by the order they occur in the slice. It accepts `iteratee` which is
+// invoked for each element in slice to generate the criterion by which uniqueness is computed.
 func FindUniquesBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee func(item T) U) Slice {
 	isDupl := make(map[U]bool, len(collection))
 
@@ -197,8 +197,8 @@ func FindDuplicates[T comparable, Slice ~[]T](collection Slice) Slice {
 }
 
 // FindDuplicatesBy returns a slice with the first occurrence of each duplicated element in the collection.
-// The order of result values is determined by the order they occur in the array. It accepts `iteratee` which is
-// invoked for each element in array to generate the criterion by which uniqueness is computed.
+// The order of result values is determined by the order they occur in the slice. It accepts `iteratee` which is
+// invoked for each element in slice to generate the criterion by which uniqueness is computed.
 func FindDuplicatesBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee func(item T) U) Slice {
 	isDupl := make(map[U]bool, len(collection))
 

--- a/find.go
+++ b/find.go
@@ -103,7 +103,7 @@ func FindKey[K comparable, V comparable](object map[K]V, value V) (K, bool) {
 	return Empty[K](), false
 }
 
-// FindKeyBy returns the key of the first element predicate returns truthy for.
+// FindKeyBy returns the key of the first element predicate returns true for.
 // Play: https://go.dev/play/p/9IbiPElcyo8
 func FindKeyBy[K comparable, V any](object map[K]V, predicate func(key K, value V) bool) (K, bool) {
 	for k := range object {

--- a/func.go
+++ b/func.go
@@ -38,7 +38,7 @@ func Partial4[T1, T2, T3, T4, T5, R any](f func(T1, T2, T3, T4, T5) R, arg1 T1) 
 	}
 }
 
-// Partial5 returns new function that, when called, has its first argument set to the provided value
+// Partial5 returns new function that, when called, has its first argument set to the provided value.
 // Play: https://go.dev/play/p/7Is7K2y_VC3
 func Partial5[T1, T2, T3, T4, T5, T6, R any](f func(T1, T2, T3, T4, T5, T6) R, arg1 T1) func(T2, T3, T4, T5, T6) R {
 	return func(t2 T2, t3 T3, t4 T4, t5 T5, t6 T6) R {

--- a/img/README.md
+++ b/img/README.md
@@ -1,2 +1,2 @@
 
-Credits goes to https://gopherize.me/
+Credit goes to https://gopherize.me/

--- a/internal/rand/ordered_go118.go
+++ b/internal/rand/ordered_go118.go
@@ -6,7 +6,7 @@ package rand
 
 import "math/rand"
 
-// Shuffle returns an array of shuffled values. Uses the Fisher-Yates shuffle algorithm.
+// Shuffle returns a slice of shuffled values. Uses the Fisher-Yates shuffle algorithm.
 func Shuffle(n int, swap func(i, j int)) {
 	rand.Shuffle(n, swap)
 }

--- a/internal/rand/ordered_go122.go
+++ b/internal/rand/ordered_go122.go
@@ -4,7 +4,7 @@ package rand
 
 import "math/rand/v2"
 
-// Shuffle returns an array of shuffled values. Uses the Fisher-Yates shuffle algorithm.
+// Shuffle returns a slice of shuffled values. Uses the Fisher-Yates shuffle algorithm.
 func Shuffle(n int, swap func(i, j int)) {
 	rand.Shuffle(n, swap)
 }

--- a/intersect.go
+++ b/intersect.go
@@ -176,7 +176,7 @@ func Union[T comparable, Slice ~[]T](lists ...Slice) Slice {
 	return result
 }
 
-// Without returns slice excluding all given values.
+// Without returns a slice excluding all given values.
 // Play: https://go.dev/play/p/5j30Ux8TaD0
 func Without[T comparable, Slice ~[]T](collection Slice, exclude ...T) Slice {
 	excludeMap := make(map[T]struct{}, len(exclude))
@@ -194,7 +194,7 @@ func Without[T comparable, Slice ~[]T](collection Slice, exclude ...T) Slice {
 }
 
 // WithoutBy filters a slice by excluding elements whose extracted keys match any in the exclude list.
-// It returns a new slice containing only the elements whose keys are not in the exclude list.
+// Returns a new slice containing only the elements whose keys are not in the exclude list.
 // Play: https://go.dev/play/p/VgWJOF01NbJ
 func WithoutBy[T any, K comparable](collection []T, iteratee func(item T) K, exclude ...K) []T {
 	excludeMap := make(map[K]struct{}, len(exclude))
@@ -211,14 +211,14 @@ func WithoutBy[T any, K comparable](collection []T, iteratee func(item T) K, exc
 	return result
 }
 
-// WithoutEmpty returns slice excluding zero values.
+// WithoutEmpty returns a slice excluding zero values.
 //
 // Deprecated: Use lo.Compact instead.
 func WithoutEmpty[T comparable, Slice ~[]T](collection Slice) Slice {
 	return Compact(collection)
 }
 
-// WithoutNth returns slice excluding nth value.
+// WithoutNth returns a slice excluding the nth value.
 // Play: https://go.dev/play/p/5g3F9R2H1xL
 func WithoutNth[T comparable, Slice ~[]T](collection Slice, nths ...int) Slice {
 	length := len(collection)

--- a/intersect.go
+++ b/intersect.go
@@ -24,7 +24,7 @@ func ContainsBy[T any](collection []T, predicate func(item T) bool) bool {
 	return false
 }
 
-// Every returns true if all elements of a subset are contained into a collection or if the subset is empty.
+// Every returns true if all elements of a subset are contained in a collection or if the subset is empty.
 // Play: https://go.dev/play/p/W1EvyqY6t9j
 func Every[T comparable](collection []T, subset []T) bool {
 	for i := range subset {
@@ -48,7 +48,7 @@ func EveryBy[T any](collection []T, predicate func(item T) bool) bool {
 	return true
 }
 
-// Some returns true if at least 1 element of a subset is contained into a collection.
+// Some returns true if at least 1 element of a subset is contained in a collection.
 // If the subset is empty Some returns false.
 // Play: https://go.dev/play/p/Lj4ceFkeT9V
 func Some[T comparable](collection []T, subset []T) bool {
@@ -74,7 +74,7 @@ func SomeBy[T any](collection []T, predicate func(item T) bool) bool {
 	return false
 }
 
-// None returns true if no element of a subset are contained into a collection or if the subset is empty.
+// None returns true if no element of a subset is contained in a collection or if the subset is empty.
 // Play: https://go.dev/play/p/fye7JsmxzPV
 func None[T comparable](collection []T, subset []T) bool {
 	for i := range subset {
@@ -118,8 +118,8 @@ func Intersect[T comparable, Slice ~[]T](list1 Slice, list2 Slice) Slice {
 }
 
 // Difference returns the difference between two collections.
-// The first value is the collection of element absent of list2.
-// The second value is the collection of element absent of list1.
+// The first value is the collection of elements absent from list2.
+// The second value is the collection of elements absent from list1.
 // Play: https://go.dev/play/p/pKE-JgzqRpz
 func Difference[T comparable, Slice ~[]T](list1 Slice, list2 Slice) (Slice, Slice) {
 	left := Slice{}
@@ -241,7 +241,7 @@ func WithoutNth[T comparable, Slice ~[]T](collection Slice, nths ...int) Slice {
 }
 
 // ElementsMatch returns true if lists contain the same set of elements (including empty set).
-// If there are duplicate elements, the number of appearances of each of them in both lists should match.
+// If there are duplicate elements, the number of occurrences in each list should match.
 // The order of elements is not checked.
 // Play: https://go.dev/play/p/XWSEM4Ic_t0
 func ElementsMatch[T comparable, Slice ~[]T](list1 Slice, list2 Slice) bool {
@@ -249,7 +249,7 @@ func ElementsMatch[T comparable, Slice ~[]T](list1 Slice, list2 Slice) bool {
 }
 
 // ElementsMatchBy returns true if lists contain the same set of elements' keys (including empty set).
-// If there are duplicate keys, the number of appearances of each of them in both lists should match.
+// If there are duplicate keys, the number of occurrences in each list should match.
 // The order of elements is not checked.
 // Play: https://go.dev/play/p/XWSEM4Ic_t0
 func ElementsMatchBy[T any, K comparable](list1 []T, list2 []T, iteratee func(item T) K) bool {

--- a/map.go
+++ b/map.go
@@ -315,7 +315,7 @@ func MapEntries[K1 comparable, V1 any, K2 comparable, V2 any](in map[K1]V1, iter
 	return result
 }
 
-// MapToSlice transforms a map into a slice based on specific iteratee
+// MapToSlice transforms a map into a slice based on specified iteratee.
 // Play: https://go.dev/play/p/ZuiCZpDt6LD
 func MapToSlice[K comparable, V any, R any](in map[K]V, iteratee func(key K, value V) R) []R {
 	result := make([]R, 0, len(in))
@@ -327,7 +327,7 @@ func MapToSlice[K comparable, V any, R any](in map[K]V, iteratee func(key K, val
 	return result
 }
 
-// FilterMapToSlice transforms a map into a slice based on specific iteratee.
+// FilterMapToSlice transforms a map into a slice based on specified iteratee.
 // The iteratee returns a value and a boolean. If the boolean is true, the value is added to the result slice.
 // If the boolean is false, the value is not added to the result slice.
 // The order of the keys in the input map is not specified and the order of the keys in the output slice is not guaranteed.

--- a/map.go
+++ b/map.go
@@ -344,7 +344,7 @@ func FilterMapToSlice[K comparable, V any, R any](in map[K]V, iteratee func(key 
 	return result
 }
 
-// FilterKeys transforms a map into a slice based on predicate returns truthy for specific elements.
+// FilterKeys transforms a map into a slice based on predicate returns true for specific elements.
 // It is a mix of lo.Filter() and lo.Keys().
 // Play: https://go.dev/play/p/OFlKXlPrBAe
 func FilterKeys[K comparable, V any](in map[K]V, predicate func(key K, value V) bool) []K {
@@ -359,7 +359,7 @@ func FilterKeys[K comparable, V any](in map[K]V, predicate func(key K, value V) 
 	return result
 }
 
-// FilterValues transforms a map into a slice based on predicate returns truthy for specific elements.
+// FilterValues transforms a map into a slice based on predicate returns true for specific elements.
 // It is a mix of lo.Filter() and lo.Values().
 // Play: https://go.dev/play/p/YVD5r_h-LX-
 func FilterValues[K comparable, V any](in map[K]V, predicate func(key K, value V) bool) []V {

--- a/map.go
+++ b/map.go
@@ -247,7 +247,7 @@ func Assign[K comparable, V any, Map ~map[K]V](maps ...Map) Map {
 	return out
 }
 
-// ChunkEntries splits a map into an array of elements in groups of a length equal to its size. If the map cannot be split evenly,
+// ChunkEntries splits a map into an array of elements in groups of length equal to its size. If the map cannot be split evenly,
 // the final chunk will contain the remaining elements.
 // Play: https://go.dev/play/p/X_YQL6mmoD-
 func ChunkEntries[K comparable, V any](m map[K]V, size int) []map[K]V {
@@ -278,7 +278,7 @@ func ChunkEntries[K comparable, V any](m map[K]V, size int) []map[K]V {
 	return result
 }
 
-// MapKeys manipulates a map keys and transforms it to a map of another type.
+// MapKeys manipulates map keys and transforms it to a map of another type.
 // Play: https://go.dev/play/p/9_4WPIqOetJ
 func MapKeys[K comparable, V any, R comparable](in map[K]V, iteratee func(value V, key K) R) map[R]V {
 	result := make(map[R]V, len(in))
@@ -290,7 +290,7 @@ func MapKeys[K comparable, V any, R comparable](in map[K]V, iteratee func(value 
 	return result
 }
 
-// MapValues manipulates a map values and transforms it to a map of another type.
+// MapValues manipulates map values and transforms it to a map of another type.
 // Play: https://go.dev/play/p/T_8xAfvcf0W
 func MapValues[K comparable, V any, R any](in map[K]V, iteratee func(value V, key K) R) map[K]R {
 	result := make(map[K]R, len(in))
@@ -302,7 +302,7 @@ func MapValues[K comparable, V any, R any](in map[K]V, iteratee func(value V, ke
 	return result
 }
 
-// MapEntries manipulates a map entries and transforms it to a map of another type.
+// MapEntries manipulates map entries and transforms it to a map of another type.
 // Play: https://go.dev/play/p/VuvNQzxKimT
 func MapEntries[K1 comparable, V1 any, K2 comparable, V2 any](in map[K1]V1, iteratee func(key K1, value V1) (K2, V2)) map[K2]V2 {
 	result := make(map[K2]V2, len(in))

--- a/map.go
+++ b/map.go
@@ -1,6 +1,6 @@
 package lo
 
-// Keys creates an array of the map keys.
+// Keys creates a slice of the map keys.
 // Play: https://go.dev/play/p/Uu11fHASqrU
 func Keys[K comparable, V any](in ...map[K]V) []K {
 	size := 0
@@ -18,7 +18,7 @@ func Keys[K comparable, V any](in ...map[K]V) []K {
 	return result
 }
 
-// UniqKeys creates an array of unique keys in the map.
+// UniqKeys creates a slice of unique keys in the map.
 // Play: https://go.dev/play/p/TPKAb6ILdHk
 func UniqKeys[K comparable, V any](in ...map[K]V) []K {
 	size := 0
@@ -49,7 +49,7 @@ func HasKey[K comparable, V any](in map[K]V, key K) bool {
 	return ok
 }
 
-// Values creates an array of the map values.
+// Values creates a slice of the map values.
 // Play: https://go.dev/play/p/nnRTQkzQfF6
 func Values[K comparable, V any](in ...map[K]V) []V {
 	size := 0
@@ -67,7 +67,7 @@ func Values[K comparable, V any](in ...map[K]V) []V {
 	return result
 }
 
-// UniqValues creates an array of unique values in the map.
+// UniqValues creates a slice of unique values in the map.
 // Play: https://go.dev/play/p/nf6bXMh7rM3
 func UniqValues[K comparable, V comparable](in ...map[K]V) []V {
 	size := 0
@@ -174,7 +174,7 @@ func OmitByValues[K comparable, V comparable, Map ~map[K]V](in Map, values []V) 
 	return r
 }
 
-// Entries transforms a map into array of key/value pairs.
+// Entries transforms a map into a slice of key/value pairs.
 // Play: https://go.dev/play/p/_t4Xe34-Nl5
 func Entries[K comparable, V any](in map[K]V) []Entry[K, V] {
 	entries := make([]Entry[K, V], 0, len(in))
@@ -189,14 +189,14 @@ func Entries[K comparable, V any](in map[K]V) []Entry[K, V] {
 	return entries
 }
 
-// ToPairs transforms a map into array of key/value pairs.
+// ToPairs transforms a map into a slice of key/value pairs.
 // Alias of Entries().
 // Play: https://go.dev/play/p/3Dhgx46gawJ
 func ToPairs[K comparable, V any](in map[K]V) []Entry[K, V] {
 	return Entries(in)
 }
 
-// FromEntries transforms an array of key/value pairs into a map.
+// FromEntries transforms a slice of key/value pairs into a map.
 // Play: https://go.dev/play/p/oIr5KHFGCEN
 func FromEntries[K comparable, V any](entries []Entry[K, V]) map[K]V {
 	out := make(map[K]V, len(entries))
@@ -208,7 +208,7 @@ func FromEntries[K comparable, V any](entries []Entry[K, V]) map[K]V {
 	return out
 }
 
-// FromPairs transforms an array of key/value pairs into a map.
+// FromPairs transforms a slice of key/value pairs into a map.
 // Alias of FromEntries().
 // Play: https://go.dev/play/p/oIr5KHFGCEN
 func FromPairs[K comparable, V any](entries []Entry[K, V]) map[K]V {
@@ -247,7 +247,7 @@ func Assign[K comparable, V any, Map ~map[K]V](maps ...Map) Map {
 	return out
 }
 
-// ChunkEntries splits a map into an array of elements in groups of length equal to its size. If the map cannot be split evenly,
+// ChunkEntries splits a map into a slice of elements in groups of length equal to its size. If the map cannot be split evenly,
 // the final chunk will contain the remaining elements.
 // Play: https://go.dev/play/p/X_YQL6mmoD-
 func ChunkEntries[K comparable, V any](m map[K]V, size int) []map[K]V {

--- a/math.go
+++ b/math.go
@@ -4,7 +4,7 @@ import (
 	"github.com/samber/lo/internal/constraints"
 )
 
-// Range creates an array of numbers (positive and/or negative) with given length.
+// Range creates a slice of numbers (positive and/or negative) with given length.
 // Play: https://go.dev/play/p/0r6VimXAi9H
 func Range(elementNum int) []int {
 	length := If(elementNum < 0, -elementNum).Else(elementNum)
@@ -16,7 +16,7 @@ func Range(elementNum int) []int {
 	return result
 }
 
-// RangeFrom creates an array of numbers from start with specified length.
+// RangeFrom creates a slice of numbers from start with specified length.
 // Play: https://go.dev/play/p/0r6VimXAi9H
 func RangeFrom[T constraints.Integer | constraints.Float](start T, elementNum int) []T {
 	length := If(elementNum < 0, -elementNum).Else(elementNum)
@@ -28,8 +28,8 @@ func RangeFrom[T constraints.Integer | constraints.Float](start T, elementNum in
 	return result
 }
 
-// RangeWithSteps creates an array of numbers (positive and/or negative) progressing from start up to, but not including end.
-// step set to zero will return an empty array.
+// RangeWithSteps creates a slice of numbers (positive and/or negative) progressing from start up to, but not including end.
+// step set to zero will return an empty slice.
 // Play: https://go.dev/play/p/0r6VimXAi9H
 func RangeWithSteps[T constraints.Integer | constraints.Float](start, end, step T) []T {
 	result := []T{}

--- a/math.go
+++ b/math.go
@@ -29,7 +29,7 @@ func RangeFrom[T constraints.Integer | constraints.Float](start T, elementNum in
 }
 
 // RangeWithSteps creates an array of numbers (positive and/or negative) progressing from start up to, but not including end.
-// step set to zero will return empty array.
+// step set to zero will return an empty array.
 // Play: https://go.dev/play/p/0r6VimXAi9H
 func RangeWithSteps[T constraints.Integer | constraints.Float](start, end, step T) []T {
 	result := []T{}
@@ -144,7 +144,7 @@ func MeanBy[T any, R constraints.Float | constraints.Integer](collection []T, it
 }
 
 // Mode returns the mode (most frequent value) of a collection.
-// If multiple values ​​have the same highest frequency, then multiple values ​​are returned.
+// If multiple values have the same highest frequency, then multiple values are returned.
 // If the collection is empty, then the zero value of T is returned.
 func Mode[T constraints.Integer | constraints.Float](collection []T) []T {
 	length := T(len(collection))

--- a/mutable/slice.go
+++ b/mutable/slice.go
@@ -60,7 +60,7 @@ func Shuffle[T any, Slice ~[]T](collection Slice) {
 	})
 }
 
-// Reverse reverses slice so that the first element becomes the last, the second element becomes the second to last, and so on.
+// Reverse reverses a slice so that the first element becomes the last, the second element becomes the second to last, and so on.
 // Play: https://go.dev/play/p/O-M5pmCRgzV
 func Reverse[T any, Slice ~[]T](collection Slice) {
 	length := len(collection)

--- a/mutable/slice.go
+++ b/mutable/slice.go
@@ -52,7 +52,7 @@ func MapI[T any, Slice ~[]T](collection Slice, fn func(item T, index int) T) {
 	}
 }
 
-// Shuffle returns an array of shuffled values. Uses the Fisher-Yates shuffle algorithm.
+// Shuffle returns a slice of shuffled values. Uses the Fisher-Yates shuffle algorithm.
 // Play: https://go.dev/play/p/2xb3WdLjeSJ
 func Shuffle[T any, Slice ~[]T](collection Slice) {
 	rand.Shuffle(len(collection), func(i, j int) {
@@ -60,7 +60,7 @@ func Shuffle[T any, Slice ~[]T](collection Slice) {
 	})
 }
 
-// Reverse reverses array so that the first element becomes the last, the second element becomes the second to last, and so on.
+// Reverse reverses slice so that the first element becomes the last, the second element becomes the second to last, and so on.
 // Play: https://go.dev/play/p/O-M5pmCRgzV
 func Reverse[T any, Slice ~[]T](collection Slice) {
 	length := len(collection)

--- a/mutable/slice_example_test.go
+++ b/mutable/slice_example_test.go
@@ -67,7 +67,7 @@ func ExampleReverse() {
 	// Output: [5 4 3 2 1 0]
 }
 
-// Fill fills elements of array with `initial` value.
+// Fill fills elements of slice with `initial` value.
 // Play: https://go.dev/play/p/VwR34GzqEub
 func Fill[T any, Slice ~[]T](collection Slice, initial T) {
 	for i := range collection {

--- a/mutable/slice_example_test.go
+++ b/mutable/slice_example_test.go
@@ -67,7 +67,7 @@ func ExampleReverse() {
 	// Output: [5 4 3 2 1 0]
 }
 
-// Fill fills elements of slice with `initial` value.
+// Fill fills elements of a slice with `initial` value.
 // Play: https://go.dev/play/p/VwR34GzqEub
 func Fill[T any, Slice ~[]T](collection Slice, initial T) {
 	for i := range collection {

--- a/parallel/slice.go
+++ b/parallel/slice.go
@@ -3,7 +3,7 @@ package parallel
 import "sync"
 
 // Map manipulates a slice and transforms it to a slice of another type.
-// `iteratee` is call in parallel. Result keep the same order.
+// `iteratee` is called in parallel. Result keep the same order.
 // Play: https://go.dev/play/p/sCJaB3quRMC
 func Map[T any, R any](collection []T, iteratee func(item T, index int) R) []R {
 	result := make([]R, len(collection))
@@ -27,7 +27,7 @@ func Map[T any, R any](collection []T, iteratee func(item T, index int) R) []R {
 }
 
 // ForEach iterates over elements of collection and invokes iteratee for each element.
-// `iteratee` is call in parallel.
+// `iteratee` is called in parallel.
 // Play: https://go.dev/play/p/sCJaB3quRMC
 func ForEach[T any](collection []T, iteratee func(item T, index int)) {
 	var wg sync.WaitGroup
@@ -45,7 +45,7 @@ func ForEach[T any](collection []T, iteratee func(item T, index int)) {
 
 // Times invokes the iteratee n times, returning an array of the results of each invocation.
 // The iteratee is invoked with index as argument.
-// `iteratee` is call in parallel.
+// `iteratee` is called in parallel.
 func Times[T any](count int, iteratee func(index int) T) []T {
 	result := make([]T, count)
 
@@ -69,7 +69,7 @@ func Times[T any](count int, iteratee func(index int) T) []T {
 
 // GroupBy returns an object composed of keys generated from the results of running each element of collection through iteratee.
 // The order of grouped values is determined by the order they occur in the collection.
-// `iteratee` is call in parallel.
+// `iteratee` is called in parallel.
 func GroupBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee func(item T) U) map[U]Slice {
 	result := map[U]Slice{}
 
@@ -88,7 +88,7 @@ func GroupBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee func(it
 // determined by the order they occur in collection. The grouping is generated from the results
 // of running each element of collection through iteratee.
 // The order of groups is determined by their first appearance in the collection.
-// `iteratee` is call in parallel.
+// `iteratee` is called in parallel.
 func PartitionBy[T any, K comparable, Slice ~[]T](collection Slice, iteratee func(item T) K) []Slice {
 	result := []Slice{}
 	seen := map[K]int{}

--- a/parallel/slice.go
+++ b/parallel/slice.go
@@ -43,7 +43,7 @@ func ForEach[T any](collection []T, iteratee func(item T, index int)) {
 	wg.Wait()
 }
 
-// Times invokes the iteratee n times, returning an array of the results of each invocation.
+// Times invokes the iteratee n times, returning a slice of the results of each invocation.
 // The iteratee is invoked with index as argument.
 // `iteratee` is called in parallel.
 func Times[T any](count int, iteratee func(index int) T) []T {
@@ -84,7 +84,7 @@ func GroupBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee func(it
 	return result
 }
 
-// PartitionBy returns an array of elements split into groups. The order of grouped values is
+// PartitionBy returns a slice of elements split into groups. The order of grouped values is
 // determined by the order they occur in collection. The grouping is generated from the results
 // of running each element of collection through iteratee.
 // The order of groups is determined by their first appearance in the collection.

--- a/retry.go
+++ b/retry.go
@@ -261,7 +261,7 @@ type Transaction[T any] struct {
 	steps []transactionStep[T]
 }
 
-// Then adds a step to the chain of callbacks. It returns the same Transaction.
+// Then adds a step to the chain of callbacks. Returns the same Transaction.
 // Play: https://go.dev/play/p/Qxrd7MGQGh1 https://go.dev/play/p/xrHb2_kMvTY
 func (t *Transaction[T]) Then(exec func(T) (T, error), onRollback func(T) T) *Transaction[T] {
 	t.steps = append(t.steps, transactionStep[T]{
@@ -345,7 +345,7 @@ func (th *throttleBy[T]) reset() {
 }
 
 // NewThrottle creates a throttled instance that invokes given functions only once in every interval.
-// This returns 2 functions, First one is throttled function and Second one is a function to reset interval
+// This returns 2 functions, First one is throttled function and Second one is a function to reset interval.
 // Play: https://go.dev/play/p/qQn3fm8Z7jS
 func NewThrottle(interval time.Duration, f ...func()) (throttle func(), reset func()) {
 	return NewThrottleWithCount(interval, 1, f...)
@@ -367,7 +367,7 @@ func NewThrottleWithCount(interval time.Duration, count int, f ...func()) (throt
 }
 
 // NewThrottleBy creates a throttled instance that invokes given functions only once in every interval.
-// This returns 2 functions, First one is throttled function and Second one is a function to reset interval
+// This returns 2 functions, First one is throttled function and Second one is a function to reset interval.
 // Play: https://go.dev/play/p/0Wv6oX7dHdC
 func NewThrottleBy[T comparable](interval time.Duration, f ...func(key T)) (throttle func(key T), reset func()) {
 	return NewThrottleByWithCount[T](interval, 1, f...)

--- a/slice.go
+++ b/slice.go
@@ -155,7 +155,7 @@ func Uniq[T comparable, Slice ~[]T](collection Slice) Slice {
 
 // UniqBy returns a duplicate-free version of a slice, in which only the first occurrence of each element is kept.
 // The order of result values is determined by the order they occur in the slice. It accepts `iteratee` which is
-// invoked for each element in slice to generate the criterion by which uniqueness is computed.
+// invoked for each element in the slice to generate the criterion by which uniqueness is computed.
 // Play: https://go.dev/play/p/g42Z3QSb53u
 func UniqBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee func(item T) U) Slice {
 	result := make(Slice, 0, len(collection))
@@ -203,7 +203,7 @@ func GroupByMap[T any, K comparable, V any](collection []T, iteratee func(item T
 	return result
 }
 
-// Chunk returns a slice of elements split into groups of length size. If slice can't be split evenly,
+// Chunk returns a slice of elements split into groups of length size. If the slice can't be split evenly,
 // the final chunk will be the remaining elements.
 // Play: https://go.dev/play/p/kEMkFbdu85g
 func Chunk[T any, Slice ~[]T](collection Slice, size int) []Slice {
@@ -277,7 +277,7 @@ func Flatten[T any, Slice ~[]T](collection []Slice) Slice {
 	return result
 }
 
-// Interleave round-robin alternating input slices and sequentially appending value at index into result
+// Interleave round-robin alternating input slices and sequentially appending value at index into result.
 // Play: https://go.dev/play/p/-RJkTLQEDVt
 func Interleave[T any, Slice ~[]T](collections ...Slice) Slice {
 	if len(collections) == 0 {
@@ -324,7 +324,7 @@ func Shuffle[T any, Slice ~[]T](collection Slice) Slice {
 	return collection
 }
 
-// Reverse reverses slice so that the first element becomes the last, the second element becomes the second to last, and so on.
+// Reverse reverses a slice so that the first element becomes the last, the second element becomes the second to last, and so on.
 // Play: https://go.dev/play/p/iv2e9jslfBM
 //
 // Deprecated: use mutable.Reverse() instead.
@@ -333,7 +333,7 @@ func Reverse[T any, Slice ~[]T](collection Slice) Slice {
 	return collection
 }
 
-// Fill fills elements of slice with `initial` value.
+// Fill fills elements of a slice with `initial` value.
 // Play: https://go.dev/play/p/VwR34GzqEub
 func Fill[T Clonable[T], Slice ~[]T](collection Slice, initial T) Slice {
 	result := make(Slice, 0, len(collection))

--- a/slice.go
+++ b/slice.go
@@ -7,7 +7,7 @@ import (
 	"github.com/samber/lo/mutable"
 )
 
-// Filter iterates over elements of collection, returning an array of all elements predicate returns true for.
+// Filter iterates over elements of collection, returning a slice of all elements predicate returns true for.
 // Play: https://go.dev/play/p/Apjg3WeSi7K
 func Filter[T any, Slice ~[]T](collection Slice, predicate func(item T, index int) bool) Slice {
 	result := make(Slice, 0, len(collection))
@@ -121,7 +121,7 @@ func ForEachWhile[T any](collection []T, iteratee func(item T, index int) (goon 
 	}
 }
 
-// Times invokes the iteratee n times, returning an array of the results of each invocation.
+// Times invokes the iteratee n times, returning a slice of the results of each invocation.
 // The iteratee is invoked with index as argument.
 // Play: https://go.dev/play/p/vgQj3Glr6lT
 func Times[T any](count int, iteratee func(index int) T) []T {
@@ -134,8 +134,8 @@ func Times[T any](count int, iteratee func(index int) T) []T {
 	return result
 }
 
-// Uniq returns a duplicate-free version of an array, in which only the first occurrence of each element is kept.
-// The order of result values is determined by the order they occur in the array.
+// Uniq returns a duplicate-free version of a slice, in which only the first occurrence of each element is kept.
+// The order of result values is determined by the order they occur in the slice.
 // Play: https://go.dev/play/p/DTzbeXZ6iEN
 func Uniq[T comparable, Slice ~[]T](collection Slice) Slice {
 	result := make(Slice, 0, len(collection))
@@ -153,9 +153,9 @@ func Uniq[T comparable, Slice ~[]T](collection Slice) Slice {
 	return result
 }
 
-// UniqBy returns a duplicate-free version of an array, in which only the first occurrence of each element is kept.
-// The order of result values is determined by the order they occur in the array. It accepts `iteratee` which is
-// invoked for each element in array to generate the criterion by which uniqueness is computed.
+// UniqBy returns a duplicate-free version of a slice, in which only the first occurrence of each element is kept.
+// The order of result values is determined by the order they occur in the slice. It accepts `iteratee` which is
+// invoked for each element in slice to generate the criterion by which uniqueness is computed.
 // Play: https://go.dev/play/p/g42Z3QSb53u
 func UniqBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee func(item T) U) Slice {
 	result := make(Slice, 0, len(collection))
@@ -203,7 +203,7 @@ func GroupByMap[T any, K comparable, V any](collection []T, iteratee func(item T
 	return result
 }
 
-// Chunk returns an array of elements split into groups of length size. If array can't be split evenly,
+// Chunk returns a slice of elements split into groups of length size. If slice can't be split evenly,
 // the final chunk will be the remaining elements.
 // Play: https://go.dev/play/p/kEMkFbdu85g
 func Chunk[T any, Slice ~[]T](collection Slice, size int) []Slice {
@@ -233,7 +233,7 @@ func Chunk[T any, Slice ~[]T](collection Slice, size int) []Slice {
 	return result
 }
 
-// PartitionBy returns an array of elements split into groups. The order of grouped values is
+// PartitionBy returns a slice of elements split into groups. The order of grouped values is
 // determined by the order they occur in collection. The grouping is generated from the results
 // of running each element of collection through iteratee.
 // Play: https://go.dev/play/p/NfQ_nGjkgXW
@@ -261,7 +261,7 @@ func PartitionBy[T any, K comparable, Slice ~[]T](collection Slice, iteratee fun
 	// return Values[K, []T](groups)
 }
 
-// Flatten returns an array a single level deep.
+// Flatten returns a slice a single level deep.
 // Play: https://go.dev/play/p/rbp9ORaMpjw
 func Flatten[T any, Slice ~[]T](collection []Slice) Slice {
 	totalLen := 0
@@ -315,7 +315,7 @@ func Interleave[T any, Slice ~[]T](collections ...Slice) Slice {
 	return result
 }
 
-// Shuffle returns an array of shuffled values. Uses the Fisher-Yates shuffle algorithm.
+// Shuffle returns a slice of shuffled values. Uses the Fisher-Yates shuffle algorithm.
 // Play: https://go.dev/play/p/ZTGG7OUCdnp
 //
 // Deprecated: use mutable.Shuffle() instead.
@@ -324,7 +324,7 @@ func Shuffle[T any, Slice ~[]T](collection Slice) Slice {
 	return collection
 }
 
-// Reverse reverses array so that the first element becomes the last, the second element becomes the second to last, and so on.
+// Reverse reverses slice so that the first element becomes the last, the second element becomes the second to last, and so on.
 // Play: https://go.dev/play/p/iv2e9jslfBM
 //
 // Deprecated: use mutable.Reverse() instead.
@@ -333,7 +333,7 @@ func Reverse[T any, Slice ~[]T](collection Slice) Slice {
 	return collection
 }
 
-// Fill fills elements of array with `initial` value.
+// Fill fills elements of slice with `initial` value.
 // Play: https://go.dev/play/p/VwR34GzqEub
 func Fill[T Clonable[T], Slice ~[]T](collection Slice, initial T) Slice {
 	result := make(Slice, 0, len(collection))
@@ -369,7 +369,7 @@ func RepeatBy[T any](count int, predicate func(index int) T) []T {
 	return result
 }
 
-// KeyBy transforms a slice or an array of structs to a map based on a pivot callback.
+// KeyBy transforms a slice or a slice of structs to a map based on a pivot callback.
 // Play: https://go.dev/play/p/ccUiUL_Lnel
 func KeyBy[K comparable, V any](collection []V, iteratee func(item V) K) map[K]V {
 	result := make(map[K]V, len(collection))
@@ -384,7 +384,7 @@ func KeyBy[K comparable, V any](collection []V, iteratee func(item V) K) map[K]V
 
 // Associate returns a map containing key-value pairs provided by transform function applied to elements of the given slice.
 // If any of two pairs have the same key the last one gets added to the map.
-// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original slice.
 // Play: https://go.dev/play/p/WHa2CfMO3Lr
 func Associate[T any, K comparable, V any](collection []T, transform func(item T) (K, V)) map[K]V {
 	result := make(map[K]V, len(collection))
@@ -399,7 +399,7 @@ func Associate[T any, K comparable, V any](collection []T, transform func(item T
 
 // SliceToMap returns a map containing key-value pairs provided by transform function applied to elements of the given slice.
 // If any of two pairs have the same key the last one gets added to the map.
-// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original slice.
 // Alias of Associate().
 // Play: https://go.dev/play/p/WHa2CfMO3Lr
 func SliceToMap[T any, K comparable, V any](collection []T, transform func(item T) (K, V)) map[K]V {
@@ -408,7 +408,7 @@ func SliceToMap[T any, K comparable, V any](collection []T, transform func(item 
 
 // FilterSliceToMap returns a map containing key-value pairs provided by transform function applied to elements of the given slice.
 // If any of two pairs have the same key the last one gets added to the map.
-// The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original slice.
 // The third return value of the transform function is a boolean that indicates whether the key-value pair should be included in the map.
 // Play: https://go.dev/play/p/2z0rDz2ZSGU
 func FilterSliceToMap[T any, K comparable, V any](collection []T, transform func(item T) (K, V, bool)) map[K]V {
@@ -436,7 +436,7 @@ func Keyify[T comparable, Slice ~[]T](collection Slice) map[T]struct{} {
 	return result
 }
 
-// Drop drops n elements from the beginning of a slice or array.
+// Drop drops n elements from the beginning of a slice.
 // Play: https://go.dev/play/p/JswS7vXRJP2
 func Drop[T any, Slice ~[]T](collection Slice, n int) Slice {
 	if len(collection) <= n {
@@ -448,7 +448,7 @@ func Drop[T any, Slice ~[]T](collection Slice, n int) Slice {
 	return append(result, collection[n:]...)
 }
 
-// DropRight drops n elements from the end of a slice or array.
+// DropRight drops n elements from the end of a slice.
 // Play: https://go.dev/play/p/GG0nXkSJJa3
 func DropRight[T any, Slice ~[]T](collection Slice, n int) Slice {
 	if len(collection) <= n {
@@ -459,7 +459,7 @@ func DropRight[T any, Slice ~[]T](collection Slice, n int) Slice {
 	return append(result, collection[:len(collection)-n]...)
 }
 
-// DropWhile drops elements from the beginning of a slice or array while the predicate returns true.
+// DropWhile drops elements from the beginning of a slice while the predicate returns true.
 // Play: https://go.dev/play/p/7gBPYw2IK16
 func DropWhile[T any, Slice ~[]T](collection Slice, predicate func(item T) bool) Slice {
 	i := 0
@@ -473,7 +473,7 @@ func DropWhile[T any, Slice ~[]T](collection Slice, predicate func(item T) bool)
 	return append(result, collection[i:]...)
 }
 
-// DropRightWhile drops elements from the end of a slice or array while the predicate returns true.
+// DropRightWhile drops elements from the end of a slice while the predicate returns true.
 // Play: https://go.dev/play/p/3-n71oEC0Hz
 func DropRightWhile[T any, Slice ~[]T](collection Slice, predicate func(item T) bool) Slice {
 	i := len(collection) - 1
@@ -487,7 +487,7 @@ func DropRightWhile[T any, Slice ~[]T](collection Slice, predicate func(item T) 
 	return append(result, collection[:i+1]...)
 }
 
-// DropByIndex drops elements from a slice or array by the index.
+// DropByIndex drops elements from a slice by the index.
 // A negative index will drop elements from the end of the slice.
 // Play: https://go.dev/play/p/bPIH4npZRxS
 func DropByIndex[T any](collection []T, indexes ...int) []T {

--- a/slice.go
+++ b/slice.go
@@ -49,7 +49,7 @@ func UniqMap[T any, R comparable](collection []T, iteratee func(item T, index in
 	return result
 }
 
-// FilterMap returns a slice which obtained after both filtering and mapping using the given callback function.
+// FilterMap returns a slice obtained after both filtering and mapping using the given callback function.
 // The callback function should return two values:
 //   - the result of the mapping operation and
 //   - whether the result element should be included or not.
@@ -92,7 +92,7 @@ func Reduce[T any, R any](collection []T, accumulator func(agg R, item T, index 
 	return initial
 }
 
-// ReduceRight helper is like Reduce except that it iterates over elements of collection from right to left.
+// ReduceRight is like Reduce except that it iterates over elements of collection from right to left.
 // Play: https://go.dev/play/p/Fq3W70l7wXF
 func ReduceRight[T any, R any](collection []T, accumulator func(agg R, item T, index int) R, initial R) R {
 	for i := len(collection) - 1; i >= 0; i-- {
@@ -203,7 +203,7 @@ func GroupByMap[T any, K comparable, V any](collection []T, iteratee func(item T
 	return result
 }
 
-// Chunk returns an array of elements split into groups the length of size. If array can't be split evenly,
+// Chunk returns an array of elements split into groups of length size. If array can't be split evenly,
 // the final chunk will be the remaining elements.
 // Play: https://go.dev/play/p/kEMkFbdu85g
 func Chunk[T any, Slice ~[]T](collection Slice, size int) []Slice {
@@ -383,7 +383,7 @@ func KeyBy[K comparable, V any](collection []V, iteratee func(item V) K) map[K]V
 }
 
 // Associate returns a map containing key-value pairs provided by transform function applied to elements of the given slice.
-// If any of two pairs would have the same key the last one gets added to the map.
+// If any of two pairs have the same key the last one gets added to the map.
 // The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
 // Play: https://go.dev/play/p/WHa2CfMO3Lr
 func Associate[T any, K comparable, V any](collection []T, transform func(item T) (K, V)) map[K]V {
@@ -398,7 +398,7 @@ func Associate[T any, K comparable, V any](collection []T, transform func(item T
 }
 
 // SliceToMap returns a map containing key-value pairs provided by transform function applied to elements of the given slice.
-// If any of two pairs would have the same key the last one gets added to the map.
+// If any of two pairs have the same key the last one gets added to the map.
 // The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
 // Alias of Associate().
 // Play: https://go.dev/play/p/WHa2CfMO3Lr
@@ -407,7 +407,7 @@ func SliceToMap[T any, K comparable, V any](collection []T, transform func(item 
 }
 
 // FilterSliceToMap returns a map containing key-value pairs provided by transform function applied to elements of the given slice.
-// If any of two pairs would have the same key the last one gets added to the map.
+// If any of two pairs have the same key the last one gets added to the map.
 // The order of keys in returned map is not specified and is not guaranteed to be the same from the original array.
 // The third return value of the transform function is a boolean that indicates whether the key-value pair should be included in the map.
 // Play: https://go.dev/play/p/2z0rDz2ZSGU
@@ -533,7 +533,7 @@ func Reject[T any, Slice ~[]T](collection Slice, predicate func(item T, index in
 	return result
 }
 
-// RejectMap is the opposite of FilterMap, this method returns a slice which obtained after both filtering and mapping using the given callback function.
+// RejectMap is the opposite of FilterMap, this method returns a slice obtained after both filtering and mapping using the given callback function.
 // The callback function should return two values:
 //   - the result of the mapping operation and
 //   - whether the result element should be included or not.
@@ -569,7 +569,7 @@ func FilterReject[T any, Slice ~[]T](collection Slice, predicate func(T, int) bo
 	return kept, rejected
 }
 
-// Count counts the number of elements in the collection that compare equal to value.
+// Count counts the number of elements in the collection that equal value.
 // Play: https://go.dev/play/p/Y3FlK54yveC
 func Count[T comparable](collection []T, value T) (count int) {
 	for i := range collection {
@@ -605,7 +605,7 @@ func CountValues[T comparable](collection []T) map[T]int {
 	return result
 }
 
-// CountValuesBy counts the number of each element return from mapper function.
+// CountValuesBy counts the number of each element returned from mapper function.
 // Is equivalent to chaining lo.Map and lo.CountValues.
 // Play: https://go.dev/play/p/2U0dG1SnOmS
 func CountValuesBy[T any, U comparable](collection []T, mapper func(item T) U) map[U]int {

--- a/slice.go
+++ b/slice.go
@@ -7,7 +7,7 @@ import (
 	"github.com/samber/lo/mutable"
 )
 
-// Filter iterates over elements of collection, returning an array of all elements predicate returns truthy for.
+// Filter iterates over elements of collection, returning an array of all elements predicate returns true for.
 // Play: https://go.dev/play/p/Apjg3WeSi7K
 func Filter[T any, Slice ~[]T](collection Slice, predicate func(item T, index int) bool) Slice {
 	result := make(Slice, 0, len(collection))
@@ -519,7 +519,7 @@ func DropByIndex[T any](collection []T, indexes ...int) []T {
 	return result
 }
 
-// Reject is the opposite of Filter, this method returns the elements of collection that predicate does not return truthy for.
+// Reject is the opposite of Filter, this method returns the elements of collection that predicate does not return true for.
 // Play: https://go.dev/play/p/pFCF5WVB225
 func Reject[T any, Slice ~[]T](collection Slice, predicate func(item T, index int) bool) Slice {
 	result := Slice{}
@@ -552,7 +552,7 @@ func RejectMap[T any, R any](collection []T, callback func(item T, index int) (R
 }
 
 // FilterReject mixes Filter and Reject, this method returns two slices, one for the elements of collection that
-// predicate returns truthy for and one for the elements that predicate does not return truthy for.
+// predicate returns true for and one for the elements that predicate does not return true for.
 // Play: https://go.dev/play/p/lHSEGSznJjB
 func FilterReject[T any, Slice ~[]T](collection Slice, predicate func(T, int) bool) (kept Slice, rejected Slice) {
 	kept = make(Slice, 0, len(collection))

--- a/slice_test.go
+++ b/slice_test.go
@@ -327,11 +327,11 @@ func TestChunk(t *testing.T) {
 	nonempty := Chunk(allStrings, 2)
 	is.IsType(nonempty[0], allStrings, "type preserved")
 
-	// appending to a chunk should not affect original array
-	originalArray := []int{0, 1, 2, 3, 4, 5}
-	result5 := Chunk(originalArray, 2)
+	// appending to a chunk should not affect original slice
+	original := []int{0, 1, 2, 3, 4, 5}
+	result5 := Chunk(original, 2)
 	result5[0] = append(result5[0], 6)
-	is.Equal([]int{0, 1, 2, 3, 4, 5}, originalArray)
+	is.Equal([]int{0, 1, 2, 3, 4, 5}, original)
 }
 
 func TestPartitionBy(t *testing.T) {

--- a/string.go
+++ b/string.go
@@ -113,7 +113,7 @@ func Substring[T ~string](str T, offset int, length uint) T {
 	return T(strings.ReplaceAll(string(rs[offset:offset+int(length)]), "\x00", ""))
 }
 
-// ChunkString returns an array of strings split into groups of length size. If the string can't be split evenly,
+// ChunkString returns a slice of strings split into groups of length size. If the string can't be split evenly,
 // the final chunk will be the remaining characters.
 // Play: https://go.dev/play/p/__FLTuJVz54
 func ChunkString[T ~string](str T, size int) []T {
@@ -194,7 +194,7 @@ func SnakeCase(str string) string {
 	return strings.Join(items, "_")
 }
 
-// Words splits string into an array of its words.
+// Words splits string into a slice of its words.
 // Play: https://go.dev/play/p/-f3VIQqiaVw
 func Words(str string) []string {
 	str = splitWordReg.ReplaceAllString(str, `$1$3$5$7 $2$4$6$8$9`)

--- a/string.go
+++ b/string.go
@@ -113,8 +113,8 @@ func Substring[T ~string](str T, offset int, length uint) T {
 	return T(strings.ReplaceAll(string(rs[offset:offset+int(length)]), "\x00", ""))
 }
 
-// ChunkString returns an array of strings split into groups the length of size. If array can't be split evenly,
-// the final chunk will be the remaining elements.
+// ChunkString returns an array of strings split into groups of length size. If the string can't be split evenly,
+// the final chunk will be the remaining characters.
 // Play: https://go.dev/play/p/__FLTuJVz54
 func ChunkString[T ~string](str T, size int) []T {
 	if size <= 0 {

--- a/tuples.go
+++ b/tuples.go
@@ -48,49 +48,49 @@ func T9[A, B, C, D, E, F, G, H, I any](a A, b B, c C, d D, e E, f F, g G, h H, i
 	return Tuple9[A, B, C, D, E, F, G, H, I]{A: a, B: b, C: c, D: d, E: e, F: f, G: g, H: h, I: i}
 }
 
-// Unpack2 returns values contained in tuple.
+// Unpack2 returns values contained in a tuple.
 // Play: https://go.dev/play/p/xVP_k0kJ96W
 func Unpack2[A, B any](tuple Tuple2[A, B]) (A, B) {
 	return tuple.A, tuple.B
 }
 
-// Unpack3 returns values contained in tuple.
+// Unpack3 returns values contained in a tuple.
 // Play: https://go.dev/play/p/xVP_k0kJ96W
 func Unpack3[A, B, C any](tuple Tuple3[A, B, C]) (A, B, C) {
 	return tuple.A, tuple.B, tuple.C
 }
 
-// Unpack4 returns values contained in tuple.
+// Unpack4 returns values contained in a tuple.
 // Play: https://go.dev/play/p/xVP_k0kJ96W
 func Unpack4[A, B, C, D any](tuple Tuple4[A, B, C, D]) (A, B, C, D) {
 	return tuple.A, tuple.B, tuple.C, tuple.D
 }
 
-// Unpack5 returns values contained in tuple.
+// Unpack5 returns values contained in a tuple.
 // Play: https://go.dev/play/p/xVP_k0kJ96W
 func Unpack5[A, B, C, D, E any](tuple Tuple5[A, B, C, D, E]) (A, B, C, D, E) {
 	return tuple.A, tuple.B, tuple.C, tuple.D, tuple.E
 }
 
-// Unpack6 returns values contained in tuple.
+// Unpack6 returns values contained in a tuple.
 // Play: https://go.dev/play/p/xVP_k0kJ96W
 func Unpack6[A, B, C, D, E, F any](tuple Tuple6[A, B, C, D, E, F]) (A, B, C, D, E, F) {
 	return tuple.A, tuple.B, tuple.C, tuple.D, tuple.E, tuple.F
 }
 
-// Unpack7 returns values contained in tuple.
+// Unpack7 returns values contained in a tuple.
 // Play: https://go.dev/play/p/xVP_k0kJ96W
 func Unpack7[A, B, C, D, E, F, G any](tuple Tuple7[A, B, C, D, E, F, G]) (A, B, C, D, E, F, G) {
 	return tuple.A, tuple.B, tuple.C, tuple.D, tuple.E, tuple.F, tuple.G
 }
 
-// Unpack8 returns values contained in tuple.
+// Unpack8 returns values contained in a tuple.
 // Play: https://go.dev/play/p/xVP_k0kJ96W
 func Unpack8[A, B, C, D, E, F, G, H any](tuple Tuple8[A, B, C, D, E, F, G, H]) (A, B, C, D, E, F, G, H) {
 	return tuple.A, tuple.B, tuple.C, tuple.D, tuple.E, tuple.F, tuple.G, tuple.H
 }
 
-// Unpack9 returns values contained in tuple.
+// Unpack9 returns values contained in a tuple.
 // Play: https://go.dev/play/p/xVP_k0kJ96W
 func Unpack9[A, B, C, D, E, F, G, H, I any](tuple Tuple9[A, B, C, D, E, F, G, H, I]) (A, B, C, D, E, F, G, H, I) {
 	return tuple.A, tuple.B, tuple.C, tuple.D, tuple.E, tuple.F, tuple.G, tuple.H, tuple.I
@@ -886,7 +886,7 @@ func UnzipBy9[In any, A any, B any, C any, D any, E any, F any, G any, H any, I 
 
 // CrossJoin2 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments.
-// It returns an empty list if a list is empty.
+// Returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/3VFppyL9FDU
 func CrossJoin2[A, B any](listA []A, listB []B) []Tuple2[A, B] {
 	return CrossJoinBy2(listA, listB, T2[A, B])
@@ -894,7 +894,7 @@ func CrossJoin2[A, B any](listA []A, listB []B) []Tuple2[A, B] {
 
 // CrossJoin3 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments.
-// It returns an empty list if a list is empty.
+// Returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/2WGeHyJj4fK
 func CrossJoin3[A, B, C any](listA []A, listB []B, listC []C) []Tuple3[A, B, C] {
 	return CrossJoinBy3(listA, listB, listC, T3[A, B, C])
@@ -902,7 +902,7 @@ func CrossJoin3[A, B, C any](listA []A, listB []B, listC []C) []Tuple3[A, B, C] 
 
 // CrossJoin4 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments.
-// It returns an empty list if a list is empty.
+// Returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/6XhKjLmMnNp
 func CrossJoin4[A, B, C, D any](listA []A, listB []B, listC []C, listD []D) []Tuple4[A, B, C, D] {
 	return CrossJoinBy4(listA, listB, listC, listD, T4[A, B, C, D])
@@ -910,7 +910,7 @@ func CrossJoin4[A, B, C, D any](listA []A, listB []B, listC []C, listD []D) []Tu
 
 // CrossJoin5 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments.
-// It returns an empty list if a list is empty.
+// Returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/7oPqRsTuVwX
 func CrossJoin5[A, B, C, D, E any](listA []A, listB []B, listC []C, listD []D, listE []E) []Tuple5[A, B, C, D, E] {
 	return CrossJoinBy5(listA, listB, listC, listD, listE, T5[A, B, C, D, E])
@@ -918,7 +918,7 @@ func CrossJoin5[A, B, C, D, E any](listA []A, listB []B, listC []C, listD []D, l
 
 // CrossJoin6 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments.
-// It returns an empty list if a list is empty.
+// Returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/8yZ1aB2cD3e
 func CrossJoin6[A, B, C, D, E, F any](listA []A, listB []B, listC []C, listD []D, listE []E, listF []F) []Tuple6[A, B, C, D, E, F] {
 	return CrossJoinBy6(listA, listB, listC, listD, listE, listF, T6[A, B, C, D, E, F])
@@ -926,7 +926,7 @@ func CrossJoin6[A, B, C, D, E, F any](listA []A, listB []B, listC []C, listD []D
 
 // CrossJoin7 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments.
-// It returns an empty list if a list is empty.
+// Returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/9f4g5h6i7j8
 func CrossJoin7[A, B, C, D, E, F, G any](listA []A, listB []B, listC []C, listD []D, listE []E, listF []F, listG []G) []Tuple7[A, B, C, D, E, F, G] {
 	return CrossJoinBy7(listA, listB, listC, listD, listE, listF, listG, T7[A, B, C, D, E, F, G])
@@ -934,7 +934,7 @@ func CrossJoin7[A, B, C, D, E, F, G any](listA []A, listB []B, listC []C, listD 
 
 // CrossJoin8 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments.
-// It returns an empty list if a list is empty.
+// Returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/0k1l2m3n4o5
 func CrossJoin8[A, B, C, D, E, F, G, H any](listA []A, listB []B, listC []C, listD []D, listE []E, listF []F, listG []G, listH []H) []Tuple8[A, B, C, D, E, F, G, H] {
 	return CrossJoinBy8(listA, listB, listC, listD, listE, listF, listG, listH, T8[A, B, C, D, E, F, G, H])
@@ -942,7 +942,7 @@ func CrossJoin8[A, B, C, D, E, F, G, H any](listA []A, listB []B, listC []C, lis
 
 // CrossJoin9 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments.
-// It returns an empty list if a list is empty.
+// Returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/6p7q8r9s0t1
 func CrossJoin9[A, B, C, D, E, F, G, H, I any](listA []A, listB []B, listC []C, listD []D, listE []E, listF []F, listG []G, listH []H, listI []I) []Tuple9[A, B, C, D, E, F, G, H, I] {
 	return CrossJoinBy9(listA, listB, listC, listD, listE, listF, listG, listH, listI, T9[A, B, C, D, E, F, G, H, I])
@@ -951,7 +951,7 @@ func CrossJoin9[A, B, C, D, E, F, G, H, I any](listA []A, listB []B, listC []C, 
 // CrossJoinBy2 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments. The project function
 // is used to create the output values.
-// It returns an empty list if a list is empty.
+// Returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/8Y7btpvuA-C
 func CrossJoinBy2[A, B, Out any](listA []A, listB []B, project func(a A, b B) Out) []Out {
 	size := len(listA) * len(listB)
@@ -973,7 +973,7 @@ func CrossJoinBy2[A, B, Out any](listA []A, listB []B, project func(a A, b B) Ou
 // CrossJoinBy3 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments. The project function
 // is used to create the output values.
-// It returns an empty list if a list is empty.
+// Returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/3z4y5x6w7v8
 func CrossJoinBy3[A, B, C, Out any](listA []A, listB []B, listC []C, project func(a A, b B, c C) Out) []Out {
 	size := len(listA) * len(listB) * len(listC)
@@ -997,7 +997,7 @@ func CrossJoinBy3[A, B, C, Out any](listA []A, listB []B, listC []C, project fun
 // CrossJoinBy4 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments. The project function
 // is used to create the output values.
-// It returns an empty list if a list is empty.
+// Returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/8b9c0d1e2f3
 func CrossJoinBy4[A, B, C, D, Out any](listA []A, listB []B, listC []C, listD []D, project func(a A, b B, c C, d D) Out) []Out {
 	size := len(listA) * len(listB) * len(listC) * len(listD)
@@ -1023,7 +1023,7 @@ func CrossJoinBy4[A, B, C, D, Out any](listA []A, listB []B, listC []C, listD []
 // CrossJoinBy5 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments. The project function
 // is used to create the output values.
-// It returns an empty list if a list is empty.
+// Returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/4g5h6i7j8k9
 func CrossJoinBy5[A, B, C, D, E, Out any](listA []A, listB []B, listC []C, listD []D, listE []E, project func(a A, b B, c C, d D, e E) Out) []Out {
 	size := len(listA) * len(listB) * len(listC) * len(listD) * len(listE)
@@ -1051,7 +1051,7 @@ func CrossJoinBy5[A, B, C, D, E, Out any](listA []A, listB []B, listC []C, listD
 // CrossJoinBy6 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments. The project function
 // is used to create the output values.
-// It returns an empty list if a list is empty.
+// Returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/1l2m3n4o5p6
 func CrossJoinBy6[A, B, C, D, E, F, Out any](listA []A, listB []B, listC []C, listD []D, listE []E, listF []F, project func(a A, b B, c C, d D, e E, f F) Out) []Out {
 	size := len(listA) * len(listB) * len(listC) * len(listD) * len(listE) * len(listF)
@@ -1081,7 +1081,7 @@ func CrossJoinBy6[A, B, C, D, E, F, Out any](listA []A, listB []B, listC []C, li
 // CrossJoinBy7 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments. The project function
 // is used to create the output values.
-// It returns an empty list if a list is empty.
+// Returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/7q8r9s0t1u2
 func CrossJoinBy7[A, B, C, D, E, F, G, Out any](listA []A, listB []B, listC []C, listD []D, listE []E, listF []F, listG []G, project func(a A, b B, c C, d D, e E, f F, g G) Out) []Out {
 	size := len(listA) * len(listB) * len(listC) * len(listD) * len(listE) * len(listF) * len(listG)
@@ -1113,7 +1113,7 @@ func CrossJoinBy7[A, B, C, D, E, F, G, Out any](listA []A, listB []B, listC []C,
 // CrossJoinBy8 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments. The project function
 // is used to create the output values.
-// It returns an empty list if a list is empty.
+// Returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/3v4w5x6y7z8
 func CrossJoinBy8[A, B, C, D, E, F, G, H, Out any](listA []A, listB []B, listC []C, listD []D, listE []E, listF []F, listG []G, listH []H, project func(a A, b B, c C, d D, e E, f F, g G, h H) Out) []Out {
 	size := len(listA) * len(listB) * len(listC) * len(listD) * len(listE) * len(listF) * len(listG) * len(listH)
@@ -1147,7 +1147,7 @@ func CrossJoinBy8[A, B, C, D, E, F, G, H, Out any](listA []A, listB []B, listC [
 // CrossJoinBy9 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments. The project function
 // is used to create the output values.
-// It returns an empty list if a list is empty.
+// Returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/9a0b1c2d3e4
 func CrossJoinBy9[A, B, C, D, E, F, G, H, I, Out any](listA []A, listB []B, listC []C, listD []D, listE []E, listF []F, listG []G, listH []H, listI []I, project func(a A, b B, c C, d D, e E, f F, g G, h H, i I) Out) []Out {
 	size := len(listA) * len(listB) * len(listC) * len(listD) * len(listE) * len(listF) * len(listG) * len(listH) * len(listI)

--- a/tuples.go
+++ b/tuples.go
@@ -97,7 +97,7 @@ func Unpack9[A, B, C, D, E, F, G, H, I any](tuple Tuple9[A, B, C, D, E, F, G, H,
 }
 
 // Zip2 creates a slice of grouped elements, the first of which contains the first elements
-// of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+// of the given slices, the second of which contains the second elements of the given slices, and so on.
 // When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
 func Zip2[A, B any](a []A, b []B) []Tuple2[A, B] {
@@ -119,7 +119,7 @@ func Zip2[A, B any](a []A, b []B) []Tuple2[A, B] {
 }
 
 // Zip3 creates a slice of grouped elements, the first of which contains the first elements
-// of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+// of the given slices, the second of which contains the second elements of the given slices, and so on.
 // When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
 func Zip3[A, B, C any](a []A, b []B, c []C) []Tuple3[A, B, C] {
@@ -143,7 +143,7 @@ func Zip3[A, B, C any](a []A, b []B, c []C) []Tuple3[A, B, C] {
 }
 
 // Zip4 creates a slice of grouped elements, the first of which contains the first elements
-// of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+// of the given slices, the second of which contains the second elements of the given slices, and so on.
 // When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
 func Zip4[A, B, C, D any](a []A, b []B, c []C, d []D) []Tuple4[A, B, C, D] {
@@ -169,7 +169,7 @@ func Zip4[A, B, C, D any](a []A, b []B, c []C, d []D) []Tuple4[A, B, C, D] {
 }
 
 // Zip5 creates a slice of grouped elements, the first of which contains the first elements
-// of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+// of the given slices, the second of which contains the second elements of the given slices, and so on.
 // When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
 func Zip5[A, B, C, D, E any](a []A, b []B, c []C, d []D, e []E) []Tuple5[A, B, C, D, E] {
@@ -197,7 +197,7 @@ func Zip5[A, B, C, D, E any](a []A, b []B, c []C, d []D, e []E) []Tuple5[A, B, C
 }
 
 // Zip6 creates a slice of grouped elements, the first of which contains the first elements
-// of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+// of the given slices, the second of which contains the second elements of the given slices, and so on.
 // When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
 func Zip6[A, B, C, D, E, F any](a []A, b []B, c []C, d []D, e []E, f []F) []Tuple6[A, B, C, D, E, F] {
@@ -227,7 +227,7 @@ func Zip6[A, B, C, D, E, F any](a []A, b []B, c []C, d []D, e []E, f []F) []Tupl
 }
 
 // Zip7 creates a slice of grouped elements, the first of which contains the first elements
-// of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+// of the given slices, the second of which contains the second elements of the given slices, and so on.
 // When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
 func Zip7[A, B, C, D, E, F, G any](a []A, b []B, c []C, d []D, e []E, f []F, g []G) []Tuple7[A, B, C, D, E, F, G] {
@@ -259,7 +259,7 @@ func Zip7[A, B, C, D, E, F, G any](a []A, b []B, c []C, d []D, e []E, f []F, g [
 }
 
 // Zip8 creates a slice of grouped elements, the first of which contains the first elements
-// of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+// of the given slices, the second of which contains the second elements of the given slices, and so on.
 // When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
 func Zip8[A, B, C, D, E, F, G, H any](a []A, b []B, c []C, d []D, e []E, f []F, g []G, h []H) []Tuple8[A, B, C, D, E, F, G, H] {
@@ -293,7 +293,7 @@ func Zip8[A, B, C, D, E, F, G, H any](a []A, b []B, c []C, d []D, e []E, f []F, 
 }
 
 // Zip9 creates a slice of grouped elements, the first of which contains the first elements
-// of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+// of the given slices, the second of which contains the second elements of the given slices, and so on.
 // When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
 func Zip9[A, B, C, D, E, F, G, H, I any](a []A, b []B, c []C, d []D, e []E, f []F, g []G, h []H, i []I) []Tuple9[A, B, C, D, E, F, G, H, I] {
@@ -329,7 +329,7 @@ func Zip9[A, B, C, D, E, F, G, H, I any](a []A, b []B, c []C, d []D, e []E, f []
 }
 
 // ZipBy2 creates a slice of transformed elements, the first of which contains the first elements
-// of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+// of the given slices, the second of which contains the second elements of the given slices, and so on.
 // When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/wlHur6yO8rR
 func ZipBy2[A any, B any, Out any](a []A, b []B, iteratee func(a A, b B) Out) []Out {
@@ -348,7 +348,7 @@ func ZipBy2[A any, B any, Out any](a []A, b []B, iteratee func(a A, b B) Out) []
 }
 
 // ZipBy3 creates a slice of transformed elements, the first of which contains the first elements
-// of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+// of the given slices, the second of which contains the second elements of the given slices, and so on.
 // When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/j9maveOnSQX
 func ZipBy3[A any, B any, C any, Out any](a []A, b []B, c []C, iteratee func(a A, b B, c C) Out) []Out {
@@ -368,7 +368,7 @@ func ZipBy3[A any, B any, C any, Out any](a []A, b []B, c []C, iteratee func(a A
 }
 
 // ZipBy4 creates a slice of transformed elements, the first of which contains the first elements
-// of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+// of the given slices, the second of which contains the second elements of the given slices, and so on.
 // When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/Y1eF2Ke0Ayz
 func ZipBy4[A any, B any, C any, D any, Out any](a []A, b []B, c []C, d []D, iteratee func(a A, b B, c C, d D) Out) []Out {
@@ -389,7 +389,7 @@ func ZipBy4[A any, B any, C any, D any, Out any](a []A, b []B, c []C, d []D, ite
 }
 
 // ZipBy5 creates a slice of transformed elements, the first of which contains the first elements
-// of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+// of the given slices, the second of which contains the second elements of the given slices, and so on.
 // When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/SLynyalh5Oa
 func ZipBy5[A any, B any, C any, D any, E any, Out any](a []A, b []B, c []C, d []D, e []E, iteratee func(a A, b B, c C, d D, e E) Out) []Out {
@@ -411,7 +411,7 @@ func ZipBy5[A any, B any, C any, D any, E any, Out any](a []A, b []B, c []C, d [
 }
 
 // ZipBy6 creates a slice of transformed elements, the first of which contains the first elements
-// of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+// of the given slices, the second of which contains the second elements of the given slices, and so on.
 // When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/IK6KVgw9e-S
 func ZipBy6[A any, B any, C any, D any, E any, F any, Out any](a []A, b []B, c []C, d []D, e []E, f []F, iteratee func(a A, b B, c C, d D, e E, f F) Out) []Out {
@@ -434,7 +434,7 @@ func ZipBy6[A any, B any, C any, D any, E any, F any, Out any](a []A, b []B, c [
 }
 
 // ZipBy7 creates a slice of transformed elements, the first of which contains the first elements
-// of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+// of the given slices, the second of which contains the second elements of the given slices, and so on.
 // When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/4uW6a2vXh8w
 func ZipBy7[A any, B any, C any, D any, E any, F any, G any, Out any](a []A, b []B, c []C, d []D, e []E, f []F, g []G, iteratee func(a A, b B, c C, d D, e E, f F, g G) Out) []Out {
@@ -458,7 +458,7 @@ func ZipBy7[A any, B any, C any, D any, E any, F any, G any, Out any](a []A, b [
 }
 
 // ZipBy8 creates a slice of transformed elements, the first of which contains the first elements
-// of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+// of the given slices, the second of which contains the second elements of the given slices, and so on.
 // When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/tk8xW7XzY4v
 func ZipBy8[A any, B any, C any, D any, E any, F any, G any, H any, Out any](a []A, b []B, c []C, d []D, e []E, f []F, g []G, h []H, iteratee func(a A, b B, c C, d D, e E, f F, g G, h H) Out) []Out {
@@ -483,7 +483,7 @@ func ZipBy8[A any, B any, C any, D any, E any, F any, G any, H any, Out any](a [
 }
 
 // ZipBy9 creates a slice of transformed elements, the first of which contains the first elements
-// of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+// of the given slices, the second of which contains the second elements of the given slices, and so on.
 // When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/VGqjDmQ9YqX
 func ZipBy9[A any, B any, C any, D any, E any, F any, G any, H any, I any, Out any](a []A, b []B, c []C, d []D, e []E, f []F, g []G, h []H, i []I, iteratee func(a A, b B, c C, d D, e E, f F, g G, h H, i I) Out) []Out {
@@ -508,7 +508,7 @@ func ZipBy9[A any, B any, C any, D any, E any, F any, G any, H any, I any, Out a
 	return result
 }
 
-// Unzip2 accepts an array of grouped elements and creates an array regrouping the elements
+// Unzip2 accepts a slice of grouped elements and creates a slice regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/ciHugugvaAW
 func Unzip2[A, B any](tuples []Tuple2[A, B]) ([]A, []B) {
@@ -524,7 +524,7 @@ func Unzip2[A, B any](tuples []Tuple2[A, B]) ([]A, []B) {
 	return r1, r2
 }
 
-// Unzip3 accepts an array of grouped elements and creates an array regrouping the elements
+// Unzip3 accepts a slice of grouped elements and creates a slice regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/ciHugugvaAW
 func Unzip3[A, B, C any](tuples []Tuple3[A, B, C]) ([]A, []B, []C) {
@@ -542,7 +542,7 @@ func Unzip3[A, B, C any](tuples []Tuple3[A, B, C]) ([]A, []B, []C) {
 	return r1, r2, r3
 }
 
-// Unzip4 accepts an array of grouped elements and creates an array regrouping the elements
+// Unzip4 accepts a slice of grouped elements and creates a slice regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/ciHugugvaAW
 func Unzip4[A, B, C, D any](tuples []Tuple4[A, B, C, D]) ([]A, []B, []C, []D) {
@@ -562,7 +562,7 @@ func Unzip4[A, B, C, D any](tuples []Tuple4[A, B, C, D]) ([]A, []B, []C, []D) {
 	return r1, r2, r3, r4
 }
 
-// Unzip5 accepts an array of grouped elements and creates an array regrouping the elements
+// Unzip5 accepts a slice of grouped elements and creates a slice regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/ciHugugvaAW
 func Unzip5[A, B, C, D, E any](tuples []Tuple5[A, B, C, D, E]) ([]A, []B, []C, []D, []E) {
@@ -584,7 +584,7 @@ func Unzip5[A, B, C, D, E any](tuples []Tuple5[A, B, C, D, E]) ([]A, []B, []C, [
 	return r1, r2, r3, r4, r5
 }
 
-// Unzip6 accepts an array of grouped elements and creates an array regrouping the elements
+// Unzip6 accepts a slice of grouped elements and creates a slice regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/ciHugugvaAW
 func Unzip6[A, B, C, D, E, F any](tuples []Tuple6[A, B, C, D, E, F]) ([]A, []B, []C, []D, []E, []F) {
@@ -608,7 +608,7 @@ func Unzip6[A, B, C, D, E, F any](tuples []Tuple6[A, B, C, D, E, F]) ([]A, []B, 
 	return r1, r2, r3, r4, r5, r6
 }
 
-// Unzip7 accepts an array of grouped elements and creates an array regrouping the elements
+// Unzip7 accepts a slice of grouped elements and creates a slice regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/ciHugugvaAW
 func Unzip7[A, B, C, D, E, F, G any](tuples []Tuple7[A, B, C, D, E, F, G]) ([]A, []B, []C, []D, []E, []F, []G) {
@@ -634,7 +634,7 @@ func Unzip7[A, B, C, D, E, F, G any](tuples []Tuple7[A, B, C, D, E, F, G]) ([]A,
 	return r1, r2, r3, r4, r5, r6, r7
 }
 
-// Unzip8 accepts an array of grouped elements and creates an array regrouping the elements
+// Unzip8 accepts a slice of grouped elements and creates a slice regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/ciHugugvaAW
 func Unzip8[A, B, C, D, E, F, G, H any](tuples []Tuple8[A, B, C, D, E, F, G, H]) ([]A, []B, []C, []D, []E, []F, []G, []H) {
@@ -662,7 +662,7 @@ func Unzip8[A, B, C, D, E, F, G, H any](tuples []Tuple8[A, B, C, D, E, F, G, H])
 	return r1, r2, r3, r4, r5, r6, r7, r8
 }
 
-// Unzip9 accepts an array of grouped elements and creates an array regrouping the elements
+// Unzip9 accepts a slice of grouped elements and creates a slice regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/ciHugugvaAW
 func Unzip9[A, B, C, D, E, F, G, H, I any](tuples []Tuple9[A, B, C, D, E, F, G, H, I]) ([]A, []B, []C, []D, []E, []F, []G, []H, []I) {
@@ -692,7 +692,7 @@ func Unzip9[A, B, C, D, E, F, G, H, I any](tuples []Tuple9[A, B, C, D, E, F, G, 
 	return r1, r2, r3, r4, r5, r6, r7, r8, r9
 }
 
-// UnzipBy2 iterates over a collection and creates an array regrouping the elements
+// UnzipBy2 iterates over a collection and creates a slice regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/tN8yqaRZz0r
 func UnzipBy2[In any, A any, B any](items []In, iteratee func(In) (a A, b B)) ([]A, []B) {
@@ -709,7 +709,7 @@ func UnzipBy2[In any, A any, B any](items []In, iteratee func(In) (a A, b B)) ([
 	return r1, r2
 }
 
-// UnzipBy3 iterates over a collection and creates an array regrouping the elements
+// UnzipBy3 iterates over a collection and creates a slice regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/36ITO2DlQq1
 func UnzipBy3[In any, A any, B any, C any](items []In, iteratee func(In) (a A, b B, c C)) ([]A, []B, []C) {
@@ -728,7 +728,7 @@ func UnzipBy3[In any, A any, B any, C any](items []In, iteratee func(In) (a A, b
 	return r1, r2, r3
 }
 
-// UnzipBy4 iterates over a collection and creates an array regrouping the elements
+// UnzipBy4 iterates over a collection and creates a slice regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/zJ6qY1dD1rL
 func UnzipBy4[In any, A any, B any, C any, D any](items []In, iteratee func(In) (a A, b B, c C, d D)) ([]A, []B, []C, []D) {
@@ -749,7 +749,7 @@ func UnzipBy4[In any, A any, B any, C any, D any](items []In, iteratee func(In) 
 	return r1, r2, r3, r4
 }
 
-// UnzipBy5 iterates over a collection and creates an array regrouping the elements
+// UnzipBy5 iterates over a collection and creates a slice regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/3f7jKkV9xZt
 func UnzipBy5[In any, A any, B any, C any, D any, E any](items []In, iteratee func(In) (a A, b B, c C, d D, e E)) ([]A, []B, []C, []D, []E) {
@@ -772,7 +772,7 @@ func UnzipBy5[In any, A any, B any, C any, D any, E any](items []In, iteratee fu
 	return r1, r2, r3, r4, r5
 }
 
-// UnzipBy6 iterates over a collection and creates an array regrouping the elements
+// UnzipBy6 iterates over a collection and creates a slice regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/8Y1b7tKu2pL
 func UnzipBy6[In any, A any, B any, C any, D any, E any, F any](items []In, iteratee func(In) (a A, b B, c C, d D, e E, f F)) ([]A, []B, []C, []D, []E, []F) {
@@ -797,7 +797,7 @@ func UnzipBy6[In any, A any, B any, C any, D any, E any, F any](items []In, iter
 	return r1, r2, r3, r4, r5, r6
 }
 
-// UnzipBy7 iterates over a collection and creates an array regrouping the elements
+// UnzipBy7 iterates over a collection and creates a slice regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/7j1kLmVn3pM
 func UnzipBy7[In any, A any, B any, C any, D any, E any, F any, G any](items []In, iteratee func(In) (a A, b B, c C, d D, e E, f F, g G)) ([]A, []B, []C, []D, []E, []F, []G) {
@@ -824,7 +824,7 @@ func UnzipBy7[In any, A any, B any, C any, D any, E any, F any, G any](items []I
 	return r1, r2, r3, r4, r5, r6, r7
 }
 
-// UnzipBy8 iterates over a collection and creates an array regrouping the elements
+// UnzipBy8 iterates over a collection and creates a slice regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/1n2k3L4m5N6
 func UnzipBy8[In any, A any, B any, C any, D any, E any, F any, G any, H any](items []In, iteratee func(In) (a A, b B, c C, d D, e E, f F, g G, h H)) ([]A, []B, []C, []D, []E, []F, []G, []H) {
@@ -853,7 +853,7 @@ func UnzipBy8[In any, A any, B any, C any, D any, E any, F any, G any, H any](it
 	return r1, r2, r3, r4, r5, r6, r7, r8
 }
 
-// UnzipBy9 iterates over a collection and creates an array regrouping the elements
+// UnzipBy9 iterates over a collection and creates a slice regrouping the elements
 // to their pre-zip configuration.
 // Play: https://go.dev/play/p/7o8p9q0r1s2
 func UnzipBy9[In any, A any, B any, C any, D any, E any, F any, G any, H any, I any](items []In, iteratee func(In) (a A, b B, c C, d D, e E, f F, g G, h H, i I)) ([]A, []B, []C, []D, []E, []F, []G, []H, []I) {

--- a/tuples.go
+++ b/tuples.go
@@ -98,7 +98,7 @@ func Unpack9[A, B, C, D, E, F, G, H, I any](tuple Tuple9[A, B, C, D, E, F, G, H,
 
 // Zip2 creates a slice of grouped elements, the first of which contains the first elements
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
-// When collections have different size, the Tuple attributes are filled with zero value.
+// When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
 func Zip2[A, B any](a []A, b []B) []Tuple2[A, B] {
 	size := Max([]int{len(a), len(b)})
@@ -120,7 +120,7 @@ func Zip2[A, B any](a []A, b []B) []Tuple2[A, B] {
 
 // Zip3 creates a slice of grouped elements, the first of which contains the first elements
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
-// When collections have different size, the Tuple attributes are filled with zero value.
+// When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
 func Zip3[A, B, C any](a []A, b []B, c []C) []Tuple3[A, B, C] {
 	size := Max([]int{len(a), len(b), len(c)})
@@ -144,7 +144,7 @@ func Zip3[A, B, C any](a []A, b []B, c []C) []Tuple3[A, B, C] {
 
 // Zip4 creates a slice of grouped elements, the first of which contains the first elements
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
-// When collections have different size, the Tuple attributes are filled with zero value.
+// When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
 func Zip4[A, B, C, D any](a []A, b []B, c []C, d []D) []Tuple4[A, B, C, D] {
 	size := Max([]int{len(a), len(b), len(c), len(d)})
@@ -170,7 +170,7 @@ func Zip4[A, B, C, D any](a []A, b []B, c []C, d []D) []Tuple4[A, B, C, D] {
 
 // Zip5 creates a slice of grouped elements, the first of which contains the first elements
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
-// When collections have different size, the Tuple attributes are filled with zero value.
+// When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
 func Zip5[A, B, C, D, E any](a []A, b []B, c []C, d []D, e []E) []Tuple5[A, B, C, D, E] {
 	size := Max([]int{len(a), len(b), len(c), len(d), len(e)})
@@ -198,7 +198,7 @@ func Zip5[A, B, C, D, E any](a []A, b []B, c []C, d []D, e []E) []Tuple5[A, B, C
 
 // Zip6 creates a slice of grouped elements, the first of which contains the first elements
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
-// When collections have different size, the Tuple attributes are filled with zero value.
+// When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
 func Zip6[A, B, C, D, E, F any](a []A, b []B, c []C, d []D, e []E, f []F) []Tuple6[A, B, C, D, E, F] {
 	size := Max([]int{len(a), len(b), len(c), len(d), len(e), len(f)})
@@ -228,7 +228,7 @@ func Zip6[A, B, C, D, E, F any](a []A, b []B, c []C, d []D, e []E, f []F) []Tupl
 
 // Zip7 creates a slice of grouped elements, the first of which contains the first elements
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
-// When collections have different size, the Tuple attributes are filled with zero value.
+// When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
 func Zip7[A, B, C, D, E, F, G any](a []A, b []B, c []C, d []D, e []E, f []F, g []G) []Tuple7[A, B, C, D, E, F, G] {
 	size := Max([]int{len(a), len(b), len(c), len(d), len(e), len(f), len(g)})
@@ -260,7 +260,7 @@ func Zip7[A, B, C, D, E, F, G any](a []A, b []B, c []C, d []D, e []E, f []F, g [
 
 // Zip8 creates a slice of grouped elements, the first of which contains the first elements
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
-// When collections have different size, the Tuple attributes are filled with zero value.
+// When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
 func Zip8[A, B, C, D, E, F, G, H any](a []A, b []B, c []C, d []D, e []E, f []F, g []G, h []H) []Tuple8[A, B, C, D, E, F, G, H] {
 	size := Max([]int{len(a), len(b), len(c), len(d), len(e), len(f), len(g), len(h)})
@@ -294,7 +294,7 @@ func Zip8[A, B, C, D, E, F, G, H any](a []A, b []B, c []C, d []D, e []E, f []F, 
 
 // Zip9 creates a slice of grouped elements, the first of which contains the first elements
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
-// When collections have different size, the Tuple attributes are filled with zero value.
+// When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/jujaA6GaJTp
 func Zip9[A, B, C, D, E, F, G, H, I any](a []A, b []B, c []C, d []D, e []E, f []F, g []G, h []H, i []I) []Tuple9[A, B, C, D, E, F, G, H, I] {
 	size := Max([]int{len(a), len(b), len(c), len(d), len(e), len(f), len(g), len(h), len(i)})
@@ -330,7 +330,7 @@ func Zip9[A, B, C, D, E, F, G, H, I any](a []A, b []B, c []C, d []D, e []E, f []
 
 // ZipBy2 creates a slice of transformed elements, the first of which contains the first elements
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
-// When collections have different size, the Tuple attributes are filled with zero value.
+// When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/wlHur6yO8rR
 func ZipBy2[A any, B any, Out any](a []A, b []B, iteratee func(a A, b B) Out) []Out {
 	size := Max([]int{len(a), len(b)})
@@ -349,7 +349,7 @@ func ZipBy2[A any, B any, Out any](a []A, b []B, iteratee func(a A, b B) Out) []
 
 // ZipBy3 creates a slice of transformed elements, the first of which contains the first elements
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
-// When collections have different size, the Tuple attributes are filled with zero value.
+// When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/j9maveOnSQX
 func ZipBy3[A any, B any, C any, Out any](a []A, b []B, c []C, iteratee func(a A, b B, c C) Out) []Out {
 	size := Max([]int{len(a), len(b), len(c)})
@@ -369,7 +369,7 @@ func ZipBy3[A any, B any, C any, Out any](a []A, b []B, c []C, iteratee func(a A
 
 // ZipBy4 creates a slice of transformed elements, the first of which contains the first elements
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
-// When collections have different size, the Tuple attributes are filled with zero value.
+// When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/Y1eF2Ke0Ayz
 func ZipBy4[A any, B any, C any, D any, Out any](a []A, b []B, c []C, d []D, iteratee func(a A, b B, c C, d D) Out) []Out {
 	size := Max([]int{len(a), len(b), len(c), len(d)})
@@ -390,7 +390,7 @@ func ZipBy4[A any, B any, C any, D any, Out any](a []A, b []B, c []C, d []D, ite
 
 // ZipBy5 creates a slice of transformed elements, the first of which contains the first elements
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
-// When collections have different size, the Tuple attributes are filled with zero value.
+// When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/SLynyalh5Oa
 func ZipBy5[A any, B any, C any, D any, E any, Out any](a []A, b []B, c []C, d []D, e []E, iteratee func(a A, b B, c C, d D, e E) Out) []Out {
 	size := Max([]int{len(a), len(b), len(c), len(d), len(e)})
@@ -412,7 +412,7 @@ func ZipBy5[A any, B any, C any, D any, E any, Out any](a []A, b []B, c []C, d [
 
 // ZipBy6 creates a slice of transformed elements, the first of which contains the first elements
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
-// When collections have different size, the Tuple attributes are filled with zero value.
+// When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/IK6KVgw9e-S
 func ZipBy6[A any, B any, C any, D any, E any, F any, Out any](a []A, b []B, c []C, d []D, e []E, f []F, iteratee func(a A, b B, c C, d D, e E, f F) Out) []Out {
 	size := Max([]int{len(a), len(b), len(c), len(d), len(e), len(f)})
@@ -435,7 +435,7 @@ func ZipBy6[A any, B any, C any, D any, E any, F any, Out any](a []A, b []B, c [
 
 // ZipBy7 creates a slice of transformed elements, the first of which contains the first elements
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
-// When collections have different size, the Tuple attributes are filled with zero value.
+// When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/4uW6a2vXh8w
 func ZipBy7[A any, B any, C any, D any, E any, F any, G any, Out any](a []A, b []B, c []C, d []D, e []E, f []F, g []G, iteratee func(a A, b B, c C, d D, e E, f F, g G) Out) []Out {
 	size := Max([]int{len(a), len(b), len(c), len(d), len(e), len(f), len(g)})
@@ -459,7 +459,7 @@ func ZipBy7[A any, B any, C any, D any, E any, F any, G any, Out any](a []A, b [
 
 // ZipBy8 creates a slice of transformed elements, the first of which contains the first elements
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
-// When collections have different size, the Tuple attributes are filled with zero value.
+// When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/tk8xW7XzY4v
 func ZipBy8[A any, B any, C any, D any, E any, F any, G any, H any, Out any](a []A, b []B, c []C, d []D, e []E, f []F, g []G, h []H, iteratee func(a A, b B, c C, d D, e E, f F, g G, h H) Out) []Out {
 	size := Max([]int{len(a), len(b), len(c), len(d), len(e), len(f), len(g), len(h)})
@@ -484,7 +484,7 @@ func ZipBy8[A any, B any, C any, D any, E any, F any, G any, H any, Out any](a [
 
 // ZipBy9 creates a slice of transformed elements, the first of which contains the first elements
 // of the given arrays, the second of which contains the second elements of the given arrays, and so on.
-// When collections have different size, the Tuple attributes are filled with zero value.
+// When collections are different sizes, the Tuple attributes are filled with zero value.
 // Play: https://go.dev/play/p/VGqjDmQ9YqX
 func ZipBy9[A any, B any, C any, D any, E any, F any, G any, H any, I any, Out any](a []A, b []B, c []C, d []D, e []E, f []F, g []G, h []H, i []I, iteratee func(a A, b B, c C, d D, e E, f F, g G, h H, i I) Out) []Out {
 	size := Max([]int{len(a), len(b), len(c), len(d), len(e), len(f), len(g), len(h), len(i)})
@@ -884,7 +884,7 @@ func UnzipBy9[In any, A any, B any, C any, D any, E any, F any, G any, H any, I 
 	return r1, r2, r3, r4, r5, r6, r7, r8, r9
 }
 
-// CrossJoin2 combines every items from one list with every items from others.
+// CrossJoin2 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments.
 // It returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/3VFppyL9FDU
@@ -892,7 +892,7 @@ func CrossJoin2[A, B any](listA []A, listB []B) []Tuple2[A, B] {
 	return CrossJoinBy2(listA, listB, T2[A, B])
 }
 
-// CrossJoin3 combines every items from one list with every items from others.
+// CrossJoin3 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments.
 // It returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/2WGeHyJj4fK
@@ -900,7 +900,7 @@ func CrossJoin3[A, B, C any](listA []A, listB []B, listC []C) []Tuple3[A, B, C] 
 	return CrossJoinBy3(listA, listB, listC, T3[A, B, C])
 }
 
-// CrossJoin4 combines every items from one list with every items from others.
+// CrossJoin4 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments.
 // It returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/6XhKjLmMnNp
@@ -908,7 +908,7 @@ func CrossJoin4[A, B, C, D any](listA []A, listB []B, listC []C, listD []D) []Tu
 	return CrossJoinBy4(listA, listB, listC, listD, T4[A, B, C, D])
 }
 
-// CrossJoin5 combines every items from one list with every items from others.
+// CrossJoin5 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments.
 // It returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/7oPqRsTuVwX
@@ -916,7 +916,7 @@ func CrossJoin5[A, B, C, D, E any](listA []A, listB []B, listC []C, listD []D, l
 	return CrossJoinBy5(listA, listB, listC, listD, listE, T5[A, B, C, D, E])
 }
 
-// CrossJoin6 combines every items from one list with every items from others.
+// CrossJoin6 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments.
 // It returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/8yZ1aB2cD3e
@@ -924,7 +924,7 @@ func CrossJoin6[A, B, C, D, E, F any](listA []A, listB []B, listC []C, listD []D
 	return CrossJoinBy6(listA, listB, listC, listD, listE, listF, T6[A, B, C, D, E, F])
 }
 
-// CrossJoin7 combines every items from one list with every items from others.
+// CrossJoin7 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments.
 // It returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/9f4g5h6i7j8
@@ -932,7 +932,7 @@ func CrossJoin7[A, B, C, D, E, F, G any](listA []A, listB []B, listC []C, listD 
 	return CrossJoinBy7(listA, listB, listC, listD, listE, listF, listG, T7[A, B, C, D, E, F, G])
 }
 
-// CrossJoin8 combines every items from one list with every items from others.
+// CrossJoin8 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments.
 // It returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/0k1l2m3n4o5
@@ -940,7 +940,7 @@ func CrossJoin8[A, B, C, D, E, F, G, H any](listA []A, listB []B, listC []C, lis
 	return CrossJoinBy8(listA, listB, listC, listD, listE, listF, listG, listH, T8[A, B, C, D, E, F, G, H])
 }
 
-// CrossJoin9 combines every items from one list with every items from others.
+// CrossJoin9 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments.
 // It returns an empty list if a list is empty.
 // Play: https://go.dev/play/p/6p7q8r9s0t1
@@ -948,7 +948,7 @@ func CrossJoin9[A, B, C, D, E, F, G, H, I any](listA []A, listB []B, listC []C, 
 	return CrossJoinBy9(listA, listB, listC, listD, listE, listF, listG, listH, listI, T9[A, B, C, D, E, F, G, H, I])
 }
 
-// CrossJoinBy2 combines every items from one list with every items from others.
+// CrossJoinBy2 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments. The project function
 // is used to create the output values.
 // It returns an empty list if a list is empty.
@@ -970,7 +970,7 @@ func CrossJoinBy2[A, B, Out any](listA []A, listB []B, project func(a A, b B) Ou
 	return result
 }
 
-// CrossJoinBy3 combines every items from one list with every items from others.
+// CrossJoinBy3 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments. The project function
 // is used to create the output values.
 // It returns an empty list if a list is empty.
@@ -994,7 +994,7 @@ func CrossJoinBy3[A, B, C, Out any](listA []A, listB []B, listC []C, project fun
 	return result
 }
 
-// CrossJoinBy4 combines every items from one list with every items from others.
+// CrossJoinBy4 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments. The project function
 // is used to create the output values.
 // It returns an empty list if a list is empty.
@@ -1020,7 +1020,7 @@ func CrossJoinBy4[A, B, C, D, Out any](listA []A, listB []B, listC []C, listD []
 	return result
 }
 
-// CrossJoinBy5 combines every items from one list with every items from others.
+// CrossJoinBy5 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments. The project function
 // is used to create the output values.
 // It returns an empty list if a list is empty.
@@ -1048,7 +1048,7 @@ func CrossJoinBy5[A, B, C, D, E, Out any](listA []A, listB []B, listC []C, listD
 	return result
 }
 
-// CrossJoinBy6 combines every items from one list with every items from others.
+// CrossJoinBy6 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments. The project function
 // is used to create the output values.
 // It returns an empty list if a list is empty.
@@ -1078,7 +1078,7 @@ func CrossJoinBy6[A, B, C, D, E, F, Out any](listA []A, listB []B, listC []C, li
 	return result
 }
 
-// CrossJoinBy7 combines every items from one list with every items from others.
+// CrossJoinBy7 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments. The project function
 // is used to create the output values.
 // It returns an empty list if a list is empty.
@@ -1110,7 +1110,7 @@ func CrossJoinBy7[A, B, C, D, E, F, G, Out any](listA []A, listB []B, listC []C,
 	return result
 }
 
-// CrossJoinBy8 combines every items from one list with every items from others.
+// CrossJoinBy8 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments. The project function
 // is used to create the output values.
 // It returns an empty list if a list is empty.
@@ -1144,7 +1144,7 @@ func CrossJoinBy8[A, B, C, D, E, F, G, H, Out any](listA []A, listB []B, listC [
 	return result
 }
 
-// CrossJoinBy9 combines every items from one list with every items from others.
+// CrossJoinBy9 combines every item from one list with every item from others.
 // It is the cartesian product of lists received as arguments. The project function
 // is used to create the output values.
 // It returns an empty list if a list is empty.

--- a/type_manipulation.go
+++ b/type_manipulation.go
@@ -60,7 +60,7 @@ func FromPtrOr[T any](x *T, fallback T) T {
 	return *x
 }
 
-// ToSlicePtr returns a slice of pointer copy of value.
+// ToSlicePtr returns a slice of pointers to each value.
 // Play: https://go.dev/play/p/P2sD0PMXw4F
 func ToSlicePtr[T any](collection []T) []*T {
 	result := make([]*T, len(collection))
@@ -104,7 +104,7 @@ func ToAnySlice[T any](collection []T) []any {
 	return result
 }
 
-// FromAnySlice returns an `any` slice with all elements mapped to a type.
+// FromAnySlice returns a slice with all elements mapped to a type.
 // Returns false in case of type conversion failure.
 // Play: https://go.dev/play/p/P2sD0PMXw4F
 func FromAnySlice[T any](in []any) (out []T, ok bool) {

--- a/type_manipulation.go
+++ b/type_manipulation.go
@@ -94,7 +94,7 @@ func FromSlicePtrOr[T any](collection []*T, fallback T) []T {
 	})
 }
 
-// ToAnySlice returns a slice with all elements mapped to `any` type
+// ToAnySlice returns a slice with all elements mapped to `any` type.
 // Play: https://go.dev/play/p/P2sD0PMXw4F
 func ToAnySlice[T any](collection []T) []any {
 	result := make([]any, len(collection))

--- a/types.go
+++ b/types.go
@@ -12,7 +12,7 @@ type Tuple2[A, B any] struct {
 	B B
 }
 
-// Unpack returns values contained in tuple.
+// Unpack returns values contained in a tuple.
 // Play: https://go.dev/play/p/yrtn7QJTmL_E
 func (t Tuple2[A, B]) Unpack() (A, B) {
 	return t.A, t.B
@@ -25,7 +25,7 @@ type Tuple3[A, B, C any] struct {
 	C C
 }
 
-// Unpack returns values contained in tuple.
+// Unpack returns values contained in a tuple.
 // Play: https://go.dev/play/p/yrtn7QJTmL_E
 func (t Tuple3[A, B, C]) Unpack() (A, B, C) {
 	return t.A, t.B, t.C
@@ -39,7 +39,7 @@ type Tuple4[A, B, C, D any] struct {
 	D D
 }
 
-// Unpack returns values contained in tuple.
+// Unpack returns values contained in a tuple.
 // Play: https://go.dev/play/p/yrtn7QJTmL_E
 func (t Tuple4[A, B, C, D]) Unpack() (A, B, C, D) {
 	return t.A, t.B, t.C, t.D
@@ -54,7 +54,7 @@ type Tuple5[A, B, C, D, E any] struct {
 	E E
 }
 
-// Unpack returns values contained in tuple.
+// Unpack returns values contained in a tuple.
 // Play: https://go.dev/play/p/7J4KrtgtK3M
 func (t Tuple5[A, B, C, D, E]) Unpack() (A, B, C, D, E) {
 	return t.A, t.B, t.C, t.D, t.E
@@ -70,7 +70,7 @@ type Tuple6[A, B, C, D, E, F any] struct {
 	F F
 }
 
-// Unpack returns values contained in tuple.
+// Unpack returns values contained in a tuple.
 // Play: https://go.dev/play/p/7J4KrtgtK3M
 func (t Tuple6[A, B, C, D, E, F]) Unpack() (A, B, C, D, E, F) {
 	return t.A, t.B, t.C, t.D, t.E, t.F
@@ -87,7 +87,7 @@ type Tuple7[A, B, C, D, E, F, G any] struct {
 	G G
 }
 
-// Unpack returns values contained in tuple.
+// Unpack returns values contained in a tuple.
 // Play: https://go.dev/play/p/Ow9Zgf_zeiA
 func (t Tuple7[A, B, C, D, E, F, G]) Unpack() (A, B, C, D, E, F, G) {
 	return t.A, t.B, t.C, t.D, t.E, t.F, t.G
@@ -105,7 +105,7 @@ type Tuple8[A, B, C, D, E, F, G, H any] struct {
 	H H
 }
 
-// Unpack returns values contained in tuple.
+// Unpack returns values contained in a tuple.
 // Play: https://go.dev/play/p/Ow9Zgf_zeiA
 func (t Tuple8[A, B, C, D, E, F, G, H]) Unpack() (A, B, C, D, E, F, G, H) {
 	return t.A, t.B, t.C, t.D, t.E, t.F, t.G, t.H
@@ -124,7 +124,7 @@ type Tuple9[A, B, C, D, E, F, G, H, I any] struct {
 	I I
 }
 
-// Unpack returns values contained in tuple.
+// Unpack returns values contained in a tuple.
 // Play: https://go.dev/play/p/Ow9Zgf_zeiA
 func (t Tuple9[A, B, C, D, E, F, G, H, I]) Unpack() (A, B, C, D, E, F, G, H, I) {
 	return t.A, t.B, t.C, t.D, t.E, t.F, t.G, t.H, t.I


### PR DESCRIPTION
Improved the documentation to use more standard English, discovered during my work on #672. In addition to grammar fixes, I've removed the "truthy" and "array" terminology since they're not relevant here.