### PR TITLE
feat: preserve type alias in DropByIndex and WithoutBy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
+          version: 'v2.4'
           args: --timeout 120s --max-same-issues 50
 
       - name: Bearer

--- a/intersect.go
+++ b/intersect.go
@@ -196,13 +196,13 @@ func Without[T comparable, Slice ~[]T](collection Slice, exclude ...T) Slice {
 // WithoutBy filters a slice by excluding elements whose extracted keys match any in the exclude list.
 // It returns a new slice containing only the elements whose keys are not in the exclude list.
 // Play: https://go.dev/play/p/VgWJOF01NbJ
-func WithoutBy[T any, K comparable](collection []T, iteratee func(item T) K, exclude ...K) []T {
+func WithoutBy[T any, K comparable, Slice ~[]T](collection Slice, iteratee func(item T) K, exclude ...K) Slice {
 	excludeMap := make(map[K]struct{}, len(exclude))
 	for _, e := range exclude {
 		excludeMap[e] = struct{}{}
 	}
 
-	result := make([]T, 0, len(collection))
+	result := make(Slice, 0, len(collection))
 	for _, item := range collection {
 		if _, ok := excludeMap[iteratee(item)]; !ok {
 			result = append(result, item)

--- a/intersect_test.go
+++ b/intersect_test.go
@@ -290,6 +290,13 @@ func TestWithoutBy(t *testing.T) {
 	is.Equal([]User{{Name: "peter"}}, result1)
 	is.Equal([]User{}, result2)
 	is.Equal([]User{}, result3)
+
+	type myStrings []string
+	allStrings := myStrings{"", "foo", "bar"}
+	nonempty := WithoutBy(allStrings, func(s string) string {
+		return s
+	})
+	is.IsType(nonempty, allStrings, "type preserved")
 }
 
 func TestWithoutEmpty(t *testing.T) {

--- a/slice.go
+++ b/slice.go
@@ -490,10 +490,10 @@ func DropRightWhile[T any, Slice ~[]T](collection Slice, predicate func(item T) 
 // DropByIndex drops elements from a slice or array by the index.
 // A negative index will drop elements from the end of the slice.
 // Play: https://go.dev/play/p/bPIH4npZRxS
-func DropByIndex[T any](collection []T, indexes ...int) []T {
+func DropByIndex[T any, Slice ~[]T](collection Slice, indexes ...int) Slice {
 	initialSize := len(collection)
 	if initialSize == 0 {
-		return make([]T, 0)
+		return make(Slice, 0)
 	}
 
 	for i := range indexes {
@@ -505,7 +505,7 @@ func DropByIndex[T any](collection []T, indexes ...int) []T {
 	indexes = Uniq(indexes)
 	sort.Ints(indexes)
 
-	result := make([]T, 0, initialSize)
+	result := make(Slice, 0, initialSize)
 	result = append(result, collection...)
 
 	for i := range indexes {

--- a/slice_test.go
+++ b/slice_test.go
@@ -734,6 +734,11 @@ func TestDropByIndex(t *testing.T) {
 	is.Equal([]int{}, DropByIndex([]int{42}, 1, 0))
 	is.Equal([]int{}, DropByIndex([]int{}, 1))
 	is.Equal([]int{}, DropByIndex([]int{1}, 0))
+
+	type myStrings []string
+	allStrings := myStrings{"", "foo", "bar"}
+	nonempty := DropByIndex(allStrings, 0)
+	is.IsType(nonempty, allStrings, "type preserved")
 }
 
 func TestReject(t *testing.T) {


### PR DESCRIPTION
I noticed that unlike the other functions that receive and return `[]T`, `WithoutBy` and `DropByIndex` don't use the `Slice ~[]T` pattern to preserve aliased slice types.