### PR TITLE
fix: switch 2 parameters from uint to int for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1077,7 +1077,7 @@ sub := lo.Subset(in, 2, 3)
 sub := lo.Subset(in, -4, 3)
 // []int{1, 2, 3}
 
-sub := lo.Subset(in, -2, math.MaxUint)
+sub := lo.Subset(in, -2, math.MaxInt)
 // []int{3, 4}
 ```
 
@@ -1881,7 +1881,7 @@ sub := lo.Substring("hello", 2, 3)
 sub := lo.Substring("hello", -4, 3)
 // "ell"
 
-sub := lo.Substring("hello", -2, math.MaxUint)
+sub := lo.Substring("hello", -2, math.MaxInt)
 // "lo"
 ```
 

--- a/slice.go
+++ b/slice.go
@@ -632,7 +632,11 @@ func CountValuesBy[T any, U comparable](collection []T, mapper func(item T) U) m
 
 // Subset returns a copy of a slice from `offset` up to `length` elements. Like `slice[start:start+length]`, but does not panic on overflow.
 // Play: https://go.dev/play/p/tOQu1GhFcog
-func Subset[T any, Slice ~[]T](collection Slice, offset int, length uint) Slice {
+func Subset[T any, Slice ~[]T](collection Slice, offset, length int) Slice {
+	if length < 0 {
+		panic("lo.Subset: length must not be negative")
+	}
+
 	size := len(collection)
 
 	if offset < 0 {
@@ -646,11 +650,11 @@ func Subset[T any, Slice ~[]T](collection Slice, offset int, length uint) Slice 
 		return Slice{}
 	}
 
-	if length > uint(size)-uint(offset) {
-		length = uint(size - offset)
+	if length > size-offset {
+		length = size - offset
 	}
 
-	return collection[offset : offset+int(length)]
+	return collection[offset : offset+length]
 }
 
 // Slice returns a copy of a slice from `start` up to, but not including `end`. Like `slice[start:end]`, but does not panic on overflow.

--- a/slice_test.go
+++ b/slice_test.go
@@ -893,7 +893,7 @@ func TestSubset(t *testing.T) {
 	out9 := Subset(in, 2, 4)
 	out10 := Subset(in, -2, 4)
 	out11 := Subset(in, -4, 1)
-	out12 := Subset(in, -4, math.MaxUint)
+	out12 := Subset(in, -4, math.MaxInt)
 
 	is.Empty(out1)
 	is.Empty(out2)
@@ -907,6 +907,10 @@ func TestSubset(t *testing.T) {
 	is.Equal([]int{3, 4}, out10)
 	is.Equal([]int{1}, out11)
 	is.Equal([]int{1, 2, 3, 4}, out12)
+
+	is.PanicsWithValue("lo.Subset: length must not be negative", func() {
+		Subset(in, 0, -1)
+	})
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}

--- a/string.go
+++ b/string.go
@@ -100,9 +100,13 @@ func nearestPowerOfTwo(capacity int) int {
 	return n + 1
 }
 
-// Substring return part of a string.
+// Substring returns part of a string.
 // Play: https://go.dev/play/p/TQlxQi82Lu1
-func Substring[T ~string](str T, offset int, length uint) T {
+func Substring[T ~string](str T, offset, length int) T {
+	if length < 0 {
+		panic("lo.Substring: length must not be negative")
+	}
+
 	rs := []rune(str)
 	size := len(rs)
 
@@ -117,11 +121,11 @@ func Substring[T ~string](str T, offset int, length uint) T {
 		return Empty[T]()
 	}
 
-	if length > uint(size)-uint(offset) {
-		length = uint(size - offset)
+	if length > size-offset {
+		length = size - offset
 	}
 
-	return T(strings.ReplaceAll(string(rs[offset:offset+int(length)]), "\x00", ""))
+	return T(strings.ReplaceAll(string(rs[offset:offset+length]), "\x00", ""))
 }
 
 // ChunkString returns a slice of strings split into groups of length size. If the string can't be split evenly,

--- a/string_example_test.go
+++ b/string_example_test.go
@@ -8,7 +8,7 @@ import (
 func ExampleSubstring() {
 	result1 := Substring("hello", 2, 3)
 	result2 := Substring("hello", -4, 3)
-	result3 := Substring("hello", -2, math.MaxUint)
+	result3 := Substring("hello", -2, math.MaxInt)
 	result4 := Substring("🏠🐶🐱", 0, 2)
 	result5 := Substring("你好，世界", 0, 3)
 

--- a/string_test.go
+++ b/string_test.go
@@ -73,7 +73,7 @@ func TestSubstring(t *testing.T) {
 	str9 := Substring("hello", 2, 4)
 	str10 := Substring("hello", -2, 4)
 	str11 := Substring("hello", -4, 1)
-	str12 := Substring("hello", -4, math.MaxUint)
+	str12 := Substring("hello", -4, math.MaxInt)
 	str13 := Substring("🏠🐶🐱", 0, 2)
 	str14 := Substring("你好，世界", 0, 3)
 	str15 := Substring("hello", 5, 1)
@@ -93,6 +93,10 @@ func TestSubstring(t *testing.T) {
 	is.Equal("🏠🐶", str13)
 	is.Equal("你好，", str14)
 	is.Empty(str15)
+
+	is.PanicsWithValue("lo.Substring: length must not be negative", func() {
+		Substring("hello", 0, -1)
+	})
 }
 
 func TestRuneLength(t *testing.T) {


### PR DESCRIPTION
Per item 22 on #672, the `length` parameter on `Subset` and `Substring` has been changed to `int`.
In theory a breaking API change, but seems pretty unlikely anyone would be passing a length value >= 2^31.