### PR TITLE
perf: avoid Keyify twice in Trim

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -839,7 +839,13 @@ func CutSuffix[T comparable, Slice ~[]T](collection Slice, separator Slice) (bef
 // Trim removes all the leading and trailing cutset from the collection.
 // Play: https://go.dev/play/p/1an9mxLdRG5
 func Trim[T comparable, Slice ~[]T](collection Slice, cutset Slice) Slice {
-	return TrimLeft(TrimRight(collection, cutset), cutset)
+	set := Keyify(cutset)
+
+	predicate := func(item T) bool {
+		_, ok := set[item]
+		return ok
+	}
+	return DropRightWhile(DropWhile(collection, predicate), predicate)
 }
 
 // TrimLeft removes all the leading cutset from the collection.

--- a/slice.go
+++ b/slice.go
@@ -841,11 +841,26 @@ func CutSuffix[T comparable, Slice ~[]T](collection Slice, separator Slice) (bef
 func Trim[T comparable, Slice ~[]T](collection Slice, cutset Slice) Slice {
 	set := Keyify(cutset)
 
-	predicate := func(item T) bool {
-		_, ok := set[item]
-		return ok
+	i := 0
+	for ; i < len(collection); i++ {
+		if _, ok := set[collection[i]]; !ok {
+			break
+		}
 	}
-	return DropRightWhile(DropWhile(collection, predicate), predicate)
+
+	if i >= len(collection) {
+		return Slice{}
+	}
+
+	j := len(collection) - 1
+	for ; j >= 0; j-- {
+		if _, ok := set[collection[j]]; !ok {
+			break
+		}
+	}
+
+	result := make(Slice, 0, j+1-i)
+	return append(result, collection[i:j+1]...)
 }
 
 // TrimLeft removes all the leading cutset from the collection.


### PR DESCRIPTION
Chaining `TrimLeft` and `TrimRight` means the input collection will be unnecessarily "Keyified" twice.

Speaking of trim helpers, I was surprised to see that `TrimPrefix` trims all instances of the leading slice, not just the first. This is different from the stdlib `strings.TrimPrefix` and should probably be documented. Same with the suffix version.