### PR TITLE
perf: optimization of map access

### DIFF
--- a/map.go
+++ b/map.go
@@ -283,8 +283,8 @@ func ChunkEntries[K comparable, V any](m map[K]V, size int) []map[K]V {
 func MapKeys[K comparable, V any, R comparable](in map[K]V, iteratee func(value V, key K) R) map[R]V {
 	result := make(map[R]V, len(in))
 
-	for k := range in {
-		result[iteratee(in[k], k)] = in[k]
+	for k, v := range in {
+		result[iteratee(v, k)] = v
 	}
 
 	return result


### PR DESCRIPTION
**Changes**

Optimization of map access.

**Notes**

Probably, more optimizations can be done. This PR covers just author's recent experience.

**Details**

The way original code (loop only) can look like in terms of Go assembler - refer to https://godbolt.org/z/j8eYrT9jh (x86-64, gc 1.24.2):

```asm
        LEAQ    main..autotmp_8+56(SP), DI
        PCDATA  $0, $-2
        LEAQ    -32(DI), DI
        NOP
        DUFFZERO        $331
        PCDATA  $0, $-1
        MOVQ    main..dict+168(SP), DX
        MOVQ    (DX), AX
        MOVQ    main.in+176(SP), BX
        LEAQ    main..autotmp_8+56(SP), CX
        PCDATA  $1, $1
        CALL    runtime.mapIterStart(SB)
        JMP     main_MapKeys[go_shape_int,go_shape_int,go_shape_int]_pc293
main_MapKeys[go_shape_int,go_shape_int,go_shape_int]_pc149:
        MOVQ    (DX), CX
        MOVQ    CX, main.k+24(SP)
        MOVQ    main..dict+168(SP), DX
        MOVQ    (DX), AX
        MOVQ    main.in+176(SP), BX
        CALL    runtime.mapaccess1_fast64(SB)
        MOVQ    main.iteratee+184(SP), DX
        MOVQ    (DX), SI
        MOVQ    (AX), AX
        MOVQ    main.k+24(SP), BX
        CALL    SI
        MOVQ    AX, main..autotmp_18+40(SP)
        MOVQ    main..dict+168(SP), DX
        MOVQ    (DX), AX
        MOVQ    main.in+176(SP), BX
        MOVQ    main.k+24(SP), CX
        CALL    runtime.mapaccess1_fast64(SB)
        MOVQ    main..dict+168(SP), DX
        MOVQ    24(DX), DX
        MOVQ    (AX), SI
        MOVQ    SI, main..autotmp_19+32(SP)
        MOVQ    DX, AX
        MOVQ    main.result+48(SP), BX
        MOVQ    main..autotmp_18+40(SP), CX
        CALL    runtime.mapassign_fast64(SB)
        MOVQ    main..autotmp_19+32(SP), DX
        MOVQ    DX, (AX)
        LEAQ    main..autotmp_8+56(SP), AX
        NOP
        CALL    runtime.mapIterNext(SB)
main_MapKeys[go_shape_int,go_shape_int,go_shape_int]_pc293:
        MOVQ    main..autotmp_8+56(SP), DX
        TESTQ   DX, DX
        JNE     main_MapKeys[go_shape_int,go_shape_int,go_shape_int]_pc149
```

The way new code (loop only) can look like in terms of Go assembler - refer to https://godbolt.org/z/r83o1E6as (x86-64, gc 1.24.2):

```asm
        LEAQ    main..autotmp_12+40(SP), DI
        PCDATA  $0, $-2
        LEAQ    -32(DI), DI
        DUFFZERO        $331
        PCDATA  $0, $-1
        LEAQ    type:map[int]int(SB), AX
        MOVQ    main.in+152(SP), BX
        LEAQ    main..autotmp_12+40(SP), CX
        PCDATA  $1, $1
        CALL    runtime.mapIterStart(SB)
        JMP     main_MapKeys[int,int,int]_pc219
main_MapKeys[int,int,int]_pc146:
        MOVQ    (CX), BX
        MOVQ    main..autotmp_12+48(SP), CX
        MOVQ    (CX), AX
        MOVQ    AX, main.v+24(SP)
        MOVQ    main.iteratee+160(SP), DX
        MOVQ    (DX), CX
        CALL    CX
        LEAQ    type:map[int]int(SB), CX
        MOVQ    main.result+32(SP), BX
        MOVQ    AX, DX
        MOVQ    CX, AX
        MOVQ    DX, CX
        CALL    runtime.mapassign_fast64(SB)
        MOVQ    main.v+24(SP), CX
        MOVQ    CX, (AX)
        LEAQ    main..autotmp_12+40(SP), AX
        CALL    runtime.mapIterNext(SB)
main_MapKeys[int,int,int]_pc219:
        MOVQ    main..autotmp_12+40(SP), CX
        TESTQ   CX, CX
        JNE     main_MapKeys[int,int,int]_pc146
```

The new code doesn't have 2 calls of `runtime.mapaccess1_fast64` (`CALL runtime.mapaccess1_fast64`) comparing to old code. I guess, it means that the new code is more optimal.