### PR TITLE
fix: omit duplicates in second Intersect list

### DIFF
--- a/intersect.go
+++ b/intersect.go
@@ -111,6 +111,7 @@ func Intersect[T comparable, Slice ~[]T](list1, list2 Slice) Slice {
 	for i := range list2 {
 		if _, ok := seen[list2[i]]; ok {
 			result = append(result, list2[i])
+			delete(seen, list2[i])
 		}
 	}
 

--- a/intersect_test.go
+++ b/intersect_test.go
@@ -181,12 +181,14 @@ func TestIntersect(t *testing.T) {
 	result3 := Intersect([]int{0, 1, 2, 3, 4, 5}, []int{-1, 6})
 	result4 := Intersect([]int{0, 6}, []int{0, 1, 2, 3, 4, 5})
 	result5 := Intersect([]int{0, 6, 0}, []int{0, 1, 2, 3, 4, 5})
+	result6 := Intersect([]int{0, 1, 2, 3, 4, 5}, []int{0, 6, 0})
 
 	is.Equal([]int{0, 2}, result1)
 	is.Equal([]int{0}, result2)
 	is.Empty(result3)
 	is.Equal([]int{0}, result4)
 	is.Equal([]int{0}, result5)
+	is.Equal([]int{0}, result6)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}


### PR DESCRIPTION
Duplicates passed to `Intersect` in `list1` are omitted and retained in `list2`. I believe this should be a symmetric function, producing identical results when the two input lists are swapped.