### PR TITLE
feat: from slice/iterator to map with index passed

### DIFF
--- a/it/seq.go
+++ b/it/seq.go
@@ -414,11 +414,21 @@ func KeyBy[K comparable, V any](collection iter.Seq[V], transform func(item V) K
 // The order of keys in returned map is not specified and is not guaranteed to be the same from the original sequence.
 // Will iterate through the entire sequence.
 func Associate[T any, K comparable, V any](collection iter.Seq[T], transform func(item T) (K, V)) map[K]V {
+	return AssociateI(collection, func(item T, _ int) (K, V) { return transform(item) })
+}
+
+// AssociateI returns a map containing key-value pairs provided by transform function applied to elements of the given sequence.
+// If any of two pairs have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original sequence.
+// Will iterate through the entire sequence.
+func AssociateI[T any, K comparable, V any](collection iter.Seq[T], transform func(item T, index int) (K, V)) map[K]V {
 	result := make(map[K]V)
 
+	var i int
 	for item := range collection {
-		k, v := transform(item)
+		k, v := transform(item, i)
 		result[k] = v
+		i++
 	}
 
 	return result
@@ -433,18 +443,40 @@ func SeqToMap[T any, K comparable, V any](collection iter.Seq[T], transform func
 	return Associate(collection, transform)
 }
 
+// SeqToMapI returns a map containing key-value pairs provided by transform function applied to elements of the given sequence.
+// If any of two pairs have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original sequence.
+// Alias of AssociateI().
+// Will iterate through the entire sequence.
+func SeqToMapI[T any, K comparable, V any](collection iter.Seq[T], transform func(item T, index int) (K, V)) map[K]V {
+	return AssociateI(collection, transform)
+}
+
 // FilterSeqToMap returns a map containing key-value pairs provided by transform function applied to elements of the given sequence.
 // If any of two pairs have the same key the last one gets added to the map.
 // The order of keys in returned map is not specified and is not guaranteed to be the same from the original sequence.
 // The third return value of the transform function is a boolean that indicates whether the key-value pair should be included in the map.
 // Will iterate through the entire sequence.
 func FilterSeqToMap[T any, K comparable, V any](collection iter.Seq[T], transform func(item T) (K, V, bool)) map[K]V {
+	return FilterSeqToMapI(collection, func(item T, _ int) (K, V, bool) {
+		return transform(item)
+	})
+}
+
+// FilterSeqToMapI returns a map containing key-value pairs provided by transform function applied to elements of the given sequence.
+// If any of two pairs have the same key the last one gets added to the map.
+// The order of keys in returned map is not specified and is not guaranteed to be the same from the original sequence.
+// The third return value of the transform function is a boolean that indicates whether the key-value pair should be included in the map.
+// Will iterate through the entire sequence.
+func FilterSeqToMapI[T any, K comparable, V any](collection iter.Seq[T], transform func(item T, index int) (K, V, bool)) map[K]V {
 	result := make(map[K]V)
 
+	var i int
 	for item := range collection {
-		if k, v, ok := transform(item); ok {
+		if k, v, ok := transform(item, i); ok {
 			result[k] = v
 		}
+		i++
 	}
 
 	return result

--- a/it/seq_test.go
+++ b/it/seq_test.go
@@ -651,6 +651,38 @@ func TestAssociate(t *testing.T) {
 	}
 }
 
+func TestAssociateI(t *testing.T) {
+	t.Parallel()
+
+	transform := func(s string, i int) (int, string) {
+		return i % 2, s
+	}
+	testCases := []struct {
+		in   []string
+		want map[int]string
+	}{
+		{
+			in:   []string{"zero"},
+			want: map[int]string{0: "zero"},
+		},
+		{
+			in:   []string{"zero", "one"},
+			want: map[int]string{0: "zero", 1: "one"},
+		},
+		{
+			in:   []string{"two", "one", "zero"},
+			want: map[int]string{0: "zero", 1: "one"},
+		},
+	}
+	for i, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, AssociateI(slices.Values(tc.in), transform))
+		})
+	}
+}
+
 func TestSeqToMap(t *testing.T) {
 	t.Parallel()
 
@@ -687,6 +719,38 @@ func TestSeqToMap(t *testing.T) {
 	}
 }
 
+func TestSeqToMapI(t *testing.T) {
+	t.Parallel()
+
+	transform := func(s string, i int) (int, string) {
+		return i % 2, s
+	}
+	testCases := []struct {
+		in   []string
+		want map[int]string
+	}{
+		{
+			in:   []string{"zero"},
+			want: map[int]string{0: "zero"},
+		},
+		{
+			in:   []string{"zero", "one"},
+			want: map[int]string{0: "zero", 1: "one"},
+		},
+		{
+			in:   []string{"two", "one", "zero"},
+			want: map[int]string{0: "zero", 1: "one"},
+		},
+	}
+	for i, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, SeqToMapI(slices.Values(tc.in), transform))
+		})
+	}
+}
+
 func TestFilterSeqToMap(t *testing.T) {
 	t.Parallel()
 
@@ -719,6 +783,38 @@ func TestFilterSeqToMap(t *testing.T) {
 		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tc.want, FilterSeqToMap(slices.Values(tc.in), transform))
+		})
+	}
+}
+
+func TestFilterSeqToMapI(t *testing.T) {
+	t.Parallel()
+
+	transform := func(s string, i int) (int, string, bool) {
+		return i % 5, s, i%2 == 0
+	}
+	testCases := []struct {
+		in   []string
+		want map[int]string
+	}{
+		{
+			in:   []string{"zero"},
+			want: map[int]string{0: "zero"},
+		},
+		{
+			in:   []string{"zero", "one", "two", "three", "four"},
+			want: map[int]string{0: "zero", 2: "two", 4: "four"},
+		},
+		{
+			in:   []string{"zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"},
+			want: map[int]string{0: "ten", 1: "six", 2: "two", 3: "eight", 4: "four"},
+		},
+	}
+	for i, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, FilterSeqToMapI(slices.Values(tc.in), transform))
 		})
 	}
 }

--- a/slice.go
+++ b/slice.go
@@ -387,14 +387,9 @@ func KeyBy[K comparable, V any](collection []V, iteratee func(item V) K) map[K]V
 // The order of keys in returned map is not specified and is not guaranteed to be the same from the original slice.
 // Play: https://go.dev/play/p/WHa2CfMO3Lr
 func Associate[T any, K comparable, V any](collection []T, transform func(item T) (K, V)) map[K]V {
-	result := make(map[K]V, len(collection))
-
-	for i := range collection {
-		k, v := transform(collection[i])
-		result[k] = v
-	}
-
-	return result
+	return AssociateI(collection, func(item T, _ int) (K, V) {
+		return transform(item)
+	})
 }
 
 // AssociateI returns a map containing key-value pairs provided by transform function applied to elements of the given slice.
@@ -436,16 +431,9 @@ func SliceToMapI[T any, K comparable, V any](collection []T, transform func(item
 // The third return value of the transform function is a boolean that indicates whether the key-value pair should be included in the map.
 // Play: https://go.dev/play/p/2z0rDz2ZSGU
 func FilterSliceToMap[T any, K comparable, V any](collection []T, transform func(item T) (K, V, bool)) map[K]V {
-	result := make(map[K]V, len(collection))
-
-	for i := range collection {
-		k, v, ok := transform(collection[i])
-		if ok {
-			result[k] = v
-		}
-	}
-
-	return result
+	return FilterSliceToMapI(collection, func(item T, _ int) (K, V, bool) {
+		return transform(item)
+	})
 }
 
 // FilterSliceToMapI returns a map containing key-value pairs provided by transform function applied to elements of the given slice.


### PR DESCRIPTION
* Implementation of conversion from slice to map without index passed to transformation function through the similar conversion but with index passed to transformation function (refer to https://github.com/samber/lo/pull/697/files#r2400392214).
* Implementation of conversion from iterator to map without index passed to transformation function through the similar conversion but with index passed to transformation function (refer to https://github.com/samber/lo/pull/672/files#r2400411494).