### PR TITLE
Fix references to "lo" instead of "ro"

### DIFF
--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -681,6 +681,7 @@ BenchmarkManualUniq-8       5000000     240 ns/op     0 B/op   0 allocs/op  (whe
 ### Related Projects
 Lo is part of a growing ecosystem of Go libraries that enhance developer productivity:
 
+- **[samber/ro](https://github.com/samber/ro)**: Reactive Programming library for Go
 - **[samber/do](https://github.com/samber/do)**: A dependency injection toolkit based on Go 1.18+ Generics
 - **[samber/mo](https://github.com/samber/mo)**: Monads based on Go 1.18+ Generics (Option, Result, Either...)
 


### PR DESCRIPTION
I noticed the docs site referenced `samber/ro` instead of `samber/lo` in a few places, so I updated the links. However, I wasn't sure about the `llms.txt` change. Is there a different project we should be linked to?