### PR TITLE
Refactor Fill function to accept count parameter

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -334,10 +334,10 @@ func Reverse[T any, Slice ~[]T](collection Slice) Slice {
 
 // Fill fills elements of a slice with `initial` value.
 // Play: https://go.dev/play/p/VwR34GzqEub
-func Fill[T Clonable[T], Slice ~[]T](collection Slice, initial T) Slice {
-	result := make(Slice, 0, len(collection))
+func Fill[T Clonable[T]](count int, initial T) Slice {
+	result := make(Slice, 0, count)
 
-	for range collection {
+	for i := 0; i < count; i++ {
 		result = append(result, initial.Clone())
 	}
 


### PR DESCRIPTION
Make it more concise by removing unnecessary slice assignments.

Replace the old function Fill(slice, initial) with the new function Fill(len(slice), initial), which is completely equivalent
