### PR TITLE
lint: use consistent short slice creation syntax

### DIFF
--- a/benchmark/map_benchmark_test.go
+++ b/benchmark/map_benchmark_test.go
@@ -86,7 +86,7 @@ func BenchmarkUniqKeys(b *testing.B) {
 	b.Run("lo.UniqKeys.jit-alloc", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			seen := make(map[int64]struct{})
-			result := make([]int64, 0)
+			var result []int64
 
 			for i := range m {
 				for k := range m[i] {

--- a/channel.go
+++ b/channel.go
@@ -105,7 +105,7 @@ func DispatchingStrategyRandom[T any](msg T, index uint64, channels []<-chan T) 
 // If the channel capacity is exceeded, another random channel will be selected and so on.
 // Play: https://go.dev/play/p/v0eMh8NZG2L
 func DispatchingStrategyWeightedRandom[T any](weights []int) DispatchingStrategy[T] {
-	seq := []int{}
+	var seq []int
 
 	for i := 0; i < len(weights); i++ {
 		for j := 0; j < weights[i]; j++ {
@@ -180,7 +180,7 @@ func SliceToChannel[T any](bufferSize int, collection []T) <-chan T {
 // ChannelToSlice returns a slice built from channel items. Blocks until channel closes.
 // Play: https://go.dev/play/p/lIbSY3QmiEg
 func ChannelToSlice[T any](ch <-chan T) []T {
-	collection := []T{}
+	var collection []T //nolint:prealloc
 
 	for item := range ch {
 		collection = append(collection, item)

--- a/it/math.go
+++ b/it/math.go
@@ -132,7 +132,7 @@ func MeanBy[T any, R constraints.Float | constraints.Integer](collection iter.Se
 // Long heterogeneous input sequences can cause excessive memory usage.
 // Play: https://go.dev/play/p/c_cmMMA5EhH
 func Mode[T constraints.Integer | constraints.Float](collection iter.Seq[T]) []T {
-	mode := make([]T, 0)
+	var mode []T
 	maxFreq := 0
 	frequency := make(map[T]int)
 

--- a/it/seq_test.go
+++ b/it/seq_test.go
@@ -310,8 +310,8 @@ func TestForEachI(t *testing.T) {
 
 	// check of callback is called for every element and in proper order
 
-	callParams1 := []string{}
-	callParams2 := []int{}
+	var callParams1 []string
+	var callParams2 []int
 
 	ForEachI(values("a", "b", "c"), func(item string, i int) {
 		callParams1 = append(callParams1, item)

--- a/map.go
+++ b/map.go
@@ -27,7 +27,7 @@ func UniqKeys[K comparable, V any](in ...map[K]V) []K {
 	}
 
 	seen := make(map[K]struct{}, size)
-	result := make([]K, 0)
+	var result []K
 
 	for i := range in {
 		for k := range in[i] {
@@ -76,7 +76,7 @@ func UniqValues[K, V comparable](in ...map[K]V) []V {
 	}
 
 	seen := make(map[V]struct{}, size)
-	result := make([]V, 0)
+	var result []V
 
 	for i := range in {
 		for _, v := range in[i] {
@@ -352,7 +352,7 @@ func FilterMapToSlice[K comparable, V, R any](in map[K]V, iteratee func(key K, v
 // It is a mix of lo.Filter() and lo.Keys().
 // Play: https://go.dev/play/p/OFlKXlPrBAe
 func FilterKeys[K comparable, V any](in map[K]V, predicate func(key K, value V) bool) []K {
-	result := make([]K, 0)
+	var result []K
 
 	for k, v := range in {
 		if predicate(k, v) {
@@ -367,7 +367,7 @@ func FilterKeys[K comparable, V any](in map[K]V, predicate func(key K, value V) 
 // It is a mix of lo.Filter() and lo.Values().
 // Play: https://go.dev/play/p/YVD5r_h-LX-
 func FilterValues[K comparable, V any](in map[K]V, predicate func(key K, value V) bool) []V {
-	result := make([]V, 0)
+	var result []V
 
 	for k, v := range in {
 		if predicate(k, v) {

--- a/map_test.go
+++ b/map_test.go
@@ -566,7 +566,7 @@ func BenchmarkAssign(b *testing.B) {
 	allDifferentMap := func(b *testing.B, n int) []map[string]int {
 		b.Helper()
 		defer b.ResetTimer()
-		m := make([]map[string]int, 0)
+		m := make([]map[string]int, 0, n)
 		for i := 0; i < n; i++ {
 			m = append(m, map[string]int{
 				strconv.Itoa(i): i,
@@ -584,7 +584,7 @@ func BenchmarkAssign(b *testing.B) {
 	allTheSameMap := func(b *testing.B, n int) []map[string]int {
 		b.Helper()
 		defer b.ResetTimer()
-		m := make([]map[string]int, 0)
+		m := make([]map[string]int, 0, n)
 		for i := 0; i < n; i++ {
 			m = append(m, map[string]int{
 				"a": 1,

--- a/math.go
+++ b/math.go
@@ -32,7 +32,7 @@ func RangeFrom[T constraints.Integer | constraints.Float](start T, elementNum in
 // step set to zero will return an empty slice.
 // Play: https://go.dev/play/p/0r6VimXAi9H
 func RangeWithSteps[T constraints.Integer | constraints.Float](start, end, step T) []T {
-	result := []T{}
+	var result []T
 	if start == end || step == 0 {
 		return result
 	}
@@ -152,7 +152,7 @@ func Mode[T constraints.Integer | constraints.Float](collection []T) []T {
 		return []T{}
 	}
 
-	mode := make([]T, 0)
+	var mode []T
 	maxFreq := 0
 	frequency := make(map[T]int)
 

--- a/mutable/slice_test.go
+++ b/mutable/slice_test.go
@@ -114,11 +114,11 @@ func TestFill(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	list1 := []string{"a", "0"}
-	Fill(list1, "b")
-	is.Equal([]string{"b", "b"}, list1)
+	list := []string{"a", "0"}
+	Fill(list, "b")
+	is.Equal([]string{"b", "b"}, list)
 
-	list2 := []string{}
-	Fill(list2, "b")
-	is.Empty(list2)
+	list = []string{}
+	Fill(list, "b")
+	is.Empty(list)
 }

--- a/parallel/slice.go
+++ b/parallel/slice.go
@@ -90,7 +90,7 @@ func GroupBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee func(it
 // The order of groups is determined by their first appearance in the collection.
 // `iteratee` is called in parallel.
 func PartitionBy[T any, K comparable, Slice ~[]T](collection Slice, iteratee func(item T) K) []Slice {
-	result := []Slice{}
+	var result []Slice
 	seen := map[K]int{}
 
 	keys := Map(collection, func(item T, _ int) K {

--- a/retry_example_test.go
+++ b/retry_example_test.go
@@ -12,7 +12,7 @@ import (
 
 func ExampleNewDebounce() {
 	i := int32(0)
-	calls := []int32{}
+	var calls []int32
 	mu := sync.Mutex{}
 
 	debounce, cancel := NewDebounce(time.Millisecond, func() {

--- a/slice.go
+++ b/slice.go
@@ -237,7 +237,7 @@ func Chunk[T any, Slice ~[]T](collection Slice, size int) []Slice {
 // of running each element of collection through iteratee.
 // Play: https://go.dev/play/p/NfQ_nGjkgXW
 func PartitionBy[T any, K comparable, Slice ~[]T](collection Slice, iteratee func(item T) K) []Slice {
-	result := []Slice{}
+	var result []Slice
 	seen := map[K]int{}
 
 	for i := range collection {
@@ -480,7 +480,7 @@ func Drop[T any, Slice ~[]T](collection Slice, n int) Slice {
 	}
 
 	if len(collection) <= n {
-		return make(Slice, 0)
+		return Slice{}
 	}
 
 	result := make(Slice, 0, len(collection)-n)
@@ -537,7 +537,7 @@ func DropRightWhile[T any, Slice ~[]T](collection Slice, predicate func(item T) 
 func DropByIndex[T any, Slice ~[]T](collection Slice, indexes ...int) Slice {
 	initialSize := len(collection)
 	if initialSize == 0 {
-		return make(Slice, 0)
+		return Slice{}
 	}
 
 	for i := range indexes {
@@ -584,7 +584,7 @@ func Reject[T any, Slice ~[]T](collection Slice, predicate func(item T, index in
 //
 // Play: https://go.dev/play/p/W9Ug9r0QFkL
 func RejectMap[T, R any](collection []T, callback func(item T, index int) (R, bool)) []R {
-	result := []R{}
+	var result []R
 
 	for i := range collection {
 		if r, ok := callback(collection[i], i); !ok {
@@ -821,7 +821,7 @@ func Splice[T any, Slice ~[]T](collection Slice, i int, elements ...T) Slice {
 // Play: https://go.dev/play/p/GiL3qhpIP3f
 func Cut[T comparable, Slice ~[]T](collection, separator Slice) (before, after Slice, found bool) {
 	if len(separator) == 0 {
-		return make(Slice, 0), collection, true
+		return Slice{}, collection, true
 	}
 
 	for i := 0; i+len(separator) <= len(collection); i++ {
@@ -837,7 +837,7 @@ func Cut[T comparable, Slice ~[]T](collection, separator Slice) (before, after S
 		}
 	}
 
-	return collection, make(Slice, 0), false
+	return collection, Slice{}, false
 }
 
 // CutPrefix returns collection without the provided leading prefix []T

--- a/slice_test.go
+++ b/slice_test.go
@@ -155,8 +155,8 @@ func TestForEach(t *testing.T) {
 
 	// check of callback is called for every element and in proper order
 
-	callParams1 := []string{}
-	callParams2 := []int{}
+	var callParams1 []string
+	var callParams2 []int
 
 	ForEach([]string{"a", "b", "c"}, func(item string, i int) {
 		callParams1 = append(callParams1, item)

--- a/type_manipulation_test.go
+++ b/type_manipulation_test.go
@@ -171,10 +171,8 @@ func TestToAnySlice(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	in1 := []int{0, 1, 2, 3}
-	in2 := []int{}
-	out1 := ToAnySlice(in1)
-	out2 := ToAnySlice(in2)
+	out1 := ToAnySlice([]int{0, 1, 2, 3})
+	out2 := ToAnySlice([]int{})
 
 	is.Equal([]any{0, 1, 2, 3}, out1)
 	is.Empty(out2)


### PR DESCRIPTION
There are a few different patterns used to create slices. This PR makes them all consistent.
This is something I noticed whilst building the `it` subpackage.