### PR TITLE
fix: improve Clone function to preserve nilness and avoid liveness issues

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -739,7 +739,16 @@ func ReplaceAll[T comparable, Slice ~[]T](collection Slice, old, nEw T) Slice {
 
 // Clone returns a shallow copy of the collection.
 func Clone[T any, Slice ~[]T](collection Slice) Slice {
-	return append(collection[:0:0], collection...)
+	// backporting from slices.Clone in Go 1.21
+	// when we drop support for Go 1.20, this can be replaced with: return slices.Clone(collection)
+
+	// Preserve nilness in case it matters.
+	if collection == nil {
+		return nil
+	}
+	// Avoid s[:0:0] as it leads to unwanted liveness when cloning a
+	// zero-length slice of a large array; see https://go.dev/issue/68488.
+	return append(Slice{}, collection...)
 }
 
 // Compact returns a slice of all non-zero elements.


### PR DESCRIPTION
This pull request updates the implementation of the `Clone` function in `slice.go` to improve its behavior and future compatibility. The main change is a safer cloning approach that avoids potential issues with slice liveness and preserves nilness, aligning with improvements in Go 1.21.

Improvements to slice cloning:

* Updated the `Clone` function to avoid using `collection[:0:0]`, which could cause unwanted liveness when cloning zero-length slices of large arrays. The new implementation uses `append(Slice{}, collection...)` for safer cloning.
* Added a check to preserve nilness of the input slice, ensuring that cloning a nil slice returns nil.
* Included a comment indicating that this is a backport from `slices.Clone` in Go 1.21 and can be replaced once support for Go 1.20 is dropped.