### PR TITLE
refactor: improve lo[it].Intersect[By] readability and performance

### DIFF
--- a/intersect.go
+++ b/intersect.go
@@ -121,10 +121,6 @@ func Intersect[T comparable, Slice ~[]T](lists ...Slice) Slice {
 		return Slice{}
 	}
 
-	if len(lists) == 1 {
-		return lists[0]
-	}
-
 	last := lists[len(lists)-1]
 
 	seen := make(map[T]bool, len(last))
@@ -165,10 +161,6 @@ func Intersect[T comparable, Slice ~[]T](lists ...Slice) Slice {
 func IntersectBy[T any, K comparable, Slice ~[]T](transform func(T) K, lists ...Slice) Slice {
 	if len(lists) == 0 {
 		return Slice{}
-	}
-
-	if len(lists) == 1 {
-		return lists[0]
 	}
 
 	last := lists[len(lists)-1]

--- a/intersect_test.go
+++ b/intersect_test.go
@@ -187,6 +187,7 @@ func TestIntersect(t *testing.T) {
 	result7 := Intersect([]int{0, 6, 0, 3}, []int{0, 1, 2, 3, 4, 5}, []int{0, 6})
 	result8 := Intersect([]int{0, 6, 0, 3}, []int{0, 1, 2, 3, 4, 5}, []int{1, 6})
 	result9 := Intersect([]int{0, 1, 1}, []int{2}, []int{3})
+	resultA := Intersect([]int{0, 1, 1})
 
 	is.Empty(result0)
 	is.ElementsMatch([]int{1}, result1)
@@ -198,6 +199,7 @@ func TestIntersect(t *testing.T) {
 	is.ElementsMatch([]int{0}, result7)
 	is.Empty(result8)
 	is.Empty(result9)
+	is.ElementsMatch([]int{0, 1}, resultA)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}
@@ -243,6 +245,9 @@ func TestIntersectBy(t *testing.T) {
 
 	result := IntersectBy(strconv.Itoa, []int{0, 6, 0, 3}, []int{0, 1, 2, 3, 4, 5}, []int{0, 6})
 	is.ElementsMatch(result, []int{0})
+
+	result = IntersectBy(strconv.Itoa, []int{0, 1, 1})
+	is.ElementsMatch(result, []int{0, 1})
 }
 
 func TestDifference(t *testing.T) {

--- a/it/intersect.go
+++ b/it/intersect.go
@@ -101,10 +101,6 @@ func Intersect[T comparable, I ~func(func(T) bool)](lists ...I) I { //nolint:goc
 		return I(Empty[T]())
 	}
 
-	if len(lists) == 1 {
-		return lists[0]
-	}
-
 	return func(yield func(T) bool) {
 		last := lists[len(lists)-1]
 
@@ -148,10 +144,6 @@ func Intersect[T comparable, I ~func(func(T) bool)](lists ...I) I { //nolint:goc
 func IntersectBy[T any, K comparable, I ~func(func(T) bool)](transform func(T) K, lists ...I) I { //nolint:gocyclo
 	if len(lists) == 0 {
 		return I(Empty[T]())
-	}
-
-	if len(lists) == 1 {
-		return lists[0]
 	}
 
 	return func(yield func(T) bool) {

--- a/it/intersect_test.go
+++ b/it/intersect_test.go
@@ -190,6 +190,7 @@ func TestIntersect(t *testing.T) {
 	result7 := Intersect(values(0, 1, 2), values(1, 2, 3), values(2, 3, 4))
 	result8 := Intersect(values(0, 1, 2), values(1, 2, 3), values(2, 3, 4), values(3, 4, 5))
 	result9 := Intersect(values(0, 1, 2), values(0, 1, 2), values(1, 2, 3), values(2, 3, 4), values(3, 4, 5))
+	resultA := Intersect(values(0, 1, 1))
 
 	is.Empty(slices.Collect(result1))
 	is.Equal([]int{0, 1, 2, 3, 4, 5}, slices.Collect(result2))
@@ -200,6 +201,7 @@ func TestIntersect(t *testing.T) {
 	is.Equal([]int{2}, slices.Collect(result7))
 	is.Empty(slices.Collect(result8))
 	is.Empty(slices.Collect(result9))
+	is.Equal([]int{0, 1}, slices.Collect(resultA))
 
 	type myStrings iter.Seq[string]
 	allStrings := myStrings(values("", "foo", "bar"))
@@ -222,6 +224,7 @@ func TestIntersectBy(t *testing.T) {
 	result7 := IntersectBy(transform, values(0, 1, 2), values(1, 2, 3), values(2, 3, 4))
 	result8 := IntersectBy(transform, values(0, 1, 2), values(1, 2, 3), values(2, 3, 4), values(3, 4, 5))
 	result9 := IntersectBy(transform, values(0, 1, 2), values(0, 1, 2), values(1, 2, 3), values(2, 3, 4), values(3, 4, 5))
+	resultA := IntersectBy(transform, values(0, 1, 1))
 
 	is.Empty(slices.Collect(result1))
 	is.Equal([]int{0, 1, 2, 3, 4, 5}, slices.Collect(result2))
@@ -232,6 +235,7 @@ func TestIntersectBy(t *testing.T) {
 	is.Equal([]int{2}, slices.Collect(result7))
 	is.Empty(slices.Collect(result8))
 	is.Empty(slices.Collect(result9))
+	is.Equal([]int{0, 1}, slices.Collect(resultA))
 
 	type myStrings iter.Seq[string]
 	allStrings := myStrings(values("", "foo", "bar"))


### PR DESCRIPTION
Preallocate seen map capacity.

Extract first and last list handling out of the main loop.

Remove redundant map traversal by combining the reset and delete passes into a single loop. Values are now initialized to false and toggled to true when found, allowing the cleanup pass to both reset (true→false) and delete in one iteration.

Move len(seen) == 0 check into loop condition, allowing early exit before processing next list when intersection becomes empty (skips redundant first iteration).