### PR TITLE
Fix Clone() go playground link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,7 +1192,7 @@ in[0] = 99
 // cloned is []int{1, 2, 3, 4, 5}
 ```
 
-[[play](https://go.dev/play/p/tXiy-iK6PAc)]
+[[play](https://go.dev/play/p/hgHmoOIxmuH)]
 
 ### Compact
 


### PR DESCRIPTION
## What?
- fix copy-paste error in README.md

## Why?
New link points to the correct Go playground example for Clone() method.