### PR TITLE
perf: optimize `PartitionBy` by eliminating redundant append

### DIFF
--- a/it/seq.go
+++ b/it/seq.go
@@ -326,13 +326,12 @@ func PartitionBy[T any, K comparable](collection iter.Seq[T], transform func(ite
 		key := transform(item)
 
 		resultIndex, ok := seen[key]
-		if !ok {
-			resultIndex = len(result)
-			seen[key] = resultIndex
-			result = append(result, []T{})
+		if ok {
+			result[resultIndex] = append(result[resultIndex], item)
+		} else {
+			seen[key] = len(result)
+			result = append(result, []T{item})
 		}
-
-		result[resultIndex] = append(result[resultIndex], item)
 	}
 
 	return result

--- a/parallel/slice.go
+++ b/parallel/slice.go
@@ -97,13 +97,13 @@ func PartitionBy[T any, K comparable, Slice ~[]T](collection Slice, iteratee fun
 		return iteratee(item)
 	})
 
-	for i, item := range collection {
-		if resultIndex, ok := seen[keys[i]]; ok {
-			result[resultIndex] = append(result[resultIndex], item)
+	for i := range collection {
+		resultIndex, ok := seen[keys[i]]
+		if ok {
+			result[resultIndex] = append(result[resultIndex], collection[i])
 		} else {
-			resultIndex = len(result)
-			seen[keys[i]] = resultIndex
-			result = append(result, Slice{item})
+			seen[keys[i]] = len(result)
+			result = append(result, Slice{collection[i]})
 		}
 	}
 

--- a/slice.go
+++ b/slice.go
@@ -244,13 +244,12 @@ func PartitionBy[T any, K comparable, Slice ~[]T](collection Slice, iteratee fun
 		key := iteratee(collection[i])
 
 		resultIndex, ok := seen[key]
-		if !ok {
-			resultIndex = len(result)
-			seen[key] = resultIndex
-			result = append(result, Slice{})
+		if ok {
+			result[resultIndex] = append(result[resultIndex], collection[i])
+		} else {
+			seen[key] = len(result)
+			result = append(result, Slice{collection[i]})
 		}
-
-		result[resultIndex] = append(result[resultIndex], collection[i])
 	}
 
 	return result


### PR DESCRIPTION
New groups are now initialized with the first element directly, avoiding an extra append operation in the hot loop.

Use a one style for lo/it/parallel