### PR TITLE
refactor: simplify `it.HasSuffix` implementation

### DIFF
--- a/it/find.go
+++ b/it/find.go
@@ -78,23 +78,17 @@ func HasSuffix[T comparable](collection iter.Seq[T], suffix ...T) bool {
 	}
 
 	n := len(suffix)
-	buf := make([]T, 0, n)
+	buf := make([]T, n)
 	var i int
 
-	for item := range collection {
-		if len(buf) < n {
-			buf = append(buf, item)
-		} else {
-			buf[i] = item
-		}
-		i = (i + 1) % n
+	for buf[i%n] = range collection {
+		i++
 	}
 
-	if len(buf) < n {
+	if i < n {
 		return false
 	}
 
-	i += n
 	for j := range suffix {
 		if suffix[j] != buf[(i+j)%n] {
 			return false

--- a/it/find_test.go
+++ b/it/find_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/samber/lo/internal/xrand"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/samber/lo/internal/xrand"
 )
 
 func TestIndexOf(t *testing.T) {
@@ -38,6 +39,7 @@ func TestHasPrefix(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
+	is.True(HasPrefix(values(1, 2, 3, 4), 1, 2, 3, 4))
 	is.True(HasPrefix(values(1, 2, 3, 4), 1, 2))
 	is.False(HasPrefix(values(1, 2, 3, 4), 42))
 	is.False(HasPrefix(values(1, 2), 1, 2, 3, 4))
@@ -48,11 +50,13 @@ func TestHasSuffix(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
+	is.True(HasSuffix(values(1, 2, 3, 4), 1, 2, 3, 4))
 	is.True(HasSuffix(values(1, 2, 3, 4), 3, 4))
 	is.True(HasSuffix(values(1, 2, 3, 4, 5), 3, 4, 5))
 	is.False(HasSuffix(values(1, 2, 3, 4), 42))
 	is.False(HasSuffix(values(1, 2), 1, 2, 3, 4))
 	is.True(HasSuffix(values(1, 2, 3, 4)))
+	is.False(HasSuffix(values(0), 0, 0))
 }
 
 func TestFind(t *testing.T) {


### PR DESCRIPTION
Simplify circular buffer logic:
- simplified calculation of the buf index
- remove append-based construction
- reduce unnecessary copying