### PR TITLE
perf: use `Ternary()` instead `If().Else()` in `Range`/`RangeFrom`

### DIFF
--- a/it/math.go
+++ b/it/math.go
@@ -12,8 +12,8 @@ import (
 // Range creates a sequence of numbers (positive and/or negative) with given length.
 // Play: https://go.dev/play/p/6ksL0W6KEuQ
 func Range(elementNum int) iter.Seq[int] {
-	length := lo.If(elementNum < 0, -elementNum).Else(elementNum)
-	step := lo.If(elementNum < 0, -1).Else(1)
+	step := lo.Ternary(elementNum < 0, -1, 1)
+	length := elementNum * step
 	return func(yield func(int) bool) {
 		for i, j := 0, 0; i < length; i, j = i+1, j+step {
 			if !yield(j) {
@@ -26,8 +26,8 @@ func Range(elementNum int) iter.Seq[int] {
 // RangeFrom creates a sequence of numbers from start with specified length.
 // Play: https://go.dev/play/p/WHP_NI5scj9
 func RangeFrom[T constraints.Integer | constraints.Float](start T, elementNum int) iter.Seq[T] {
-	length := lo.If(elementNum < 0, -elementNum).Else(elementNum)
-	step := lo.If(elementNum < 0, -1).Else(1)
+	step := lo.Ternary(elementNum < 0, -1, 1)
+	length := elementNum * step
 	return func(yield func(T) bool) {
 		for i, j := 0, start; i < length; i, j = i+1, j+T(step) {
 			if !yield(j) {

--- a/it/math_test.go
+++ b/it/math_test.go
@@ -30,11 +30,15 @@ func TestRangeFrom(t *testing.T) {
 	result3 := RangeFrom(10, 0)
 	result4 := RangeFrom(2.0, 3)
 	result5 := RangeFrom(-2.0, -3)
+	result6 := RangeFrom(2.5, 3)
+	result7 := RangeFrom(-2.5, -3)
 	is.Equal([]int{1, 2, 3, 4, 5}, slices.Collect(result1))
 	is.Equal([]int{-1, -2, -3, -4, -5}, slices.Collect(result2))
 	is.Empty(slices.Collect(result3))
 	is.Equal([]float64{2.0, 3.0, 4.0}, slices.Collect(result4))
 	is.Equal([]float64{-2.0, -3.0, -4.0}, slices.Collect(result5))
+	is.Equal([]float64{2.5, 3.5, 4.5}, slices.Collect(result6))
+	is.Equal([]float64{-2.5, -3.5, -4.5}, slices.Collect(result7))
 }
 
 func TestRangeClose(t *testing.T) {

--- a/math.go
+++ b/math.go
@@ -7,9 +7,9 @@ import (
 // Range creates a slice of numbers (positive and/or negative) with given length.
 // Play: https://go.dev/play/p/0r6VimXAi9H
 func Range(elementNum int) []int {
-	length := If(elementNum < 0, -elementNum).Else(elementNum)
+	step := Ternary(elementNum < 0, -1, 1)
+	length := elementNum * step
 	result := make([]int, length)
-	step := If(elementNum < 0, -1).Else(1)
 	for i, j := 0, 0; i < length; i, j = i+1, j+step {
 		result[i] = j
 	}
@@ -19,9 +19,9 @@ func Range(elementNum int) []int {
 // RangeFrom creates a slice of numbers from start with specified length.
 // Play: https://go.dev/play/p/0r6VimXAi9H
 func RangeFrom[T constraints.Integer | constraints.Float](start T, elementNum int) []T {
-	length := If(elementNum < 0, -elementNum).Else(elementNum)
+	step := Ternary(elementNum < 0, -1, 1)
+	length := elementNum * step
 	result := make([]T, length)
-	step := If(elementNum < 0, -1).Else(1)
 	for i, j := 0, start; i < length; i, j = i+1, j+T(step) {
 		result[i] = j
 	}

--- a/math_test.go
+++ b/math_test.go
@@ -27,11 +27,15 @@ func TestRangeFrom(t *testing.T) {
 	result3 := RangeFrom(10, 0)
 	result4 := RangeFrom(2.0, 3)
 	result5 := RangeFrom(-2.0, -3)
+	result6 := RangeFrom(2.5, 3)
+	result7 := RangeFrom(-2.5, -3)
 	is.Equal([]int{1, 2, 3, 4, 5}, result1)
 	is.Equal([]int{-1, -2, -3, -4, -5}, result2)
 	is.Empty(result3)
 	is.Equal([]float64{2.0, 3.0, 4.0}, result4)
 	is.Equal([]float64{-2.0, -3.0, -4.0}, result5)
+	is.Equal([]float64{2.5, 3.5, 4.5}, result6)
+	is.Equal([]float64{-2.5, -3.5, -4.5}, result7)
 }
 
 func TestRangeClose(t *testing.T) {


### PR DESCRIPTION
No allocs in it.Range, it.RangeFrom

For Benchmarks like:

```go
func BenchmarkRange(b *testing.B) {
	for i := 0; i < b.N; i++ {
		for range Range(0) {
		}
	}
}
```


```go
pkg: github.com/samber/lo

            │   old.txt    │               new.txt                │
            │    sec/op    │    sec/op     vs base                │
RangeFrom-4   6.9015n ± 1%   0.2802n ± 1%  -95.94% (p=0.000 n=10)
Range-4       6.8400n ± 1%   0.2803n ± 0%  -95.90% (p=0.000 n=10)

            │   old.txt    │               new.txt               │
            │     B/op     │    B/op     vs base                 │
RangeFrom-4   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10)
Range-4       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10)

            │   old.txt    │               new.txt               │
            │  allocs/op   │ allocs/op   vs base                 │
RangeFrom-4   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10)
Range-4       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10)

pkg: github.com/samber/lo/it
            │    old.txt     │                new.txt                │
            │     sec/op     │    sec/op      vs base                │
RangeFrom-4   85.8800n ±  2%   0.2802n ±  1%  -99.67% (p=0.000 n=10)
Range-4       67.8400n ± 13%   0.2807n ± 32%  -99.59% (p=0.000 n=10)

            │  old.txt   │                new.txt                 │
            │    B/op    │   B/op     vs base                     │
RangeFrom-4   72.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)
Range-4       48.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)

            │  old.txt   │                 new.txt                 │
            │ allocs/op  │ allocs/op   vs base                     │
RangeFrom-4   3.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
Range-4       3.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```