### PR TITLE
WithoutNth handle non-comparable types

### DIFF
--- a/intersect.go
+++ b/intersect.go
@@ -291,7 +291,7 @@ func WithoutEmpty[T comparable, Slice ~[]T](collection Slice) Slice {
 
 // WithoutNth returns a slice excluding the nth value.
 // Play: https://go.dev/play/p/5g3F9R2H1xL
-func WithoutNth[T comparable, Slice ~[]T](collection Slice, nths ...int) Slice {
+func WithoutNth[T any, Slice ~[]T](collection Slice, nths ...int) Slice {
 	toRemove := Keyify(nths)
 
 	result := make(Slice, 0, len(collection))

--- a/intersect_test.go
+++ b/intersect_test.go
@@ -394,6 +394,10 @@ func TestWithoutNth(t *testing.T) {
 	allStrings := myStrings{"", "foo", "bar"}
 	nonempty := WithoutNth(allStrings)
 	is.IsType(nonempty, allStrings, "type preserved")
+
+	// This works for non-comparable as well
+	result5 := WithoutNth([]func() int{func() int { return 1 }, func() int { return 2 }, func() int { return 3 }}, 1)
+	is.Equal([]int{1, 3}, Map(result5, func(f func() int, _ int) int { return f() }))
 }
 
 func TestElementsMatch(t *testing.T) {


### PR DESCRIPTION
Allow WithoutNth to handle any type, because filtering is by index