### PR TITLE
perf: optimize it.Trim to use DropLastWhile(DropWhile(...))

### DIFF
--- a/it/seq.go
+++ b/it/seq.go
@@ -916,7 +916,7 @@ func CutSuffix[T comparable, I ~func(func(T) bool)](collection I, separator []T)
 // Play: https://go.dev/play/p/4VpIM8-zu
 func Trim[T comparable, I ~func(func(T) bool)](collection I, cutset ...T) I {
 	predicate := lo.Partial(lo.HasKey, lo.Keyify(cutset))
-	return DropWhile(DropLastWhile(collection, predicate), predicate)
+	return DropLastWhile(DropWhile(collection, predicate), predicate)
 }
 
 // TrimFirst removes all the leading cutset from the collection.


### PR DESCRIPTION
Change Trim to use DropLastWhile(DropWhile(...)) instead of DropWhile(DropLastWhile(...))

This is more efficient because DropWhile doesn't use a buffer, so it removes leading elements first, then DropLastWhile works with a smaller collection.