### PR TITLE
refactor: improve Slice logic and fix docstring

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -793,27 +793,24 @@ func Subset[T any, Slice ~[]T](collection Slice, offset int, length uint) Slice 
 	return collection[offset : offset+int(length)]
 }
 
-// Slice returns a copy of a slice from `start` up to, but not including `end`. Like `slice[start:end]`, but does not panic on overflow.
+// Slice returns a slice from `start` up to, but not including `end`. Like `slice[start:end]`, but does not panic on overflow.
 // Play: https://go.dev/play/p/8XWYhfMMA1h
 func Slice[T any, Slice ~[]T](collection Slice, start, end int) Slice {
-	size := len(collection)
-
 	if start >= end {
 		return Slice{}
 	}
 
-	if start > size {
-		start = size
-	}
+	size := len(collection)
 	if start < 0 {
 		start = 0
+	} else if start > size {
+		start = size
 	}
 
-	if end > size {
-		end = size
-	}
 	if end < 0 {
 		end = 0
+	} else if end > size {
+		end = size
 	}
 
 	return collection[start:end]

--- a/slice_test.go
+++ b/slice_test.go
@@ -1231,6 +1231,7 @@ func TestSlice(t *testing.T) {
 	out16 := Slice(in, -10, 1)
 	out17 := Slice(in, -1, 3)
 	out18 := Slice(in, -10, 7)
+	out19 := Slice(in, -10, -1)
 
 	is.Empty(out1)
 	is.Equal([]int{0}, out2)
@@ -1250,6 +1251,7 @@ func TestSlice(t *testing.T) {
 	is.Equal([]int{0}, out16)
 	is.Equal([]int{0, 1, 2}, out17)
 	is.Equal([]int{0, 1, 2, 3, 4}, out18)
+	is.Empty(out19)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}


### PR DESCRIPTION
- Fix docstring: clarify Slice returns a slice view, not a copy
- Reorder boundary checks to use else-if
- Add test case for negative start and end indices