### PR TITLE
refactor: improve SamplesBy performance and revert non-panic behavior for negative count

### DIFF
--- a/find.go
+++ b/find.go
@@ -671,11 +671,7 @@ func NthOr[T any, N constraints.Integer](collection []T, nth N, fallback T) T {
 // If `nth` is out of slice bounds, it returns the zero value (empty value) for that type.
 // Play: https://go.dev/play/p/sHoh88KWt6B
 func NthOrEmpty[T any, N constraints.Integer](collection []T, nth N) T {
-	value, err := Nth(collection, nth)
-	if err != nil {
-		var zeroValue T
-		return zeroValue
-	}
+	value, _ := Nth(collection, nth)
 	return value
 }
 
@@ -686,8 +682,7 @@ type randomIntGenerator func(n int) int
 // Sample returns a random item from collection.
 // Play: https://go.dev/play/p/vCcSJbh5s6l
 func Sample[T any](collection []T) T {
-	result := SampleBy(collection, xrand.IntN)
-	return result
+	return SampleBy(collection, xrand.IntN)
 }
 
 // SampleBy returns a random item from collection, using randomIntGenerator as the random index generator.
@@ -709,26 +704,29 @@ func Samples[T any, Slice ~[]T](collection Slice, count int) Slice {
 // SamplesBy returns N random unique items from collection, using randomIntGenerator as the random index generator.
 // Play: https://go.dev/play/p/HDmKmMgq0XN
 func SamplesBy[T any, Slice ~[]T](collection Slice, count int, randomIntGenerator randomIntGenerator) Slice {
+	if count <= 0 {
+		return Slice{}
+	}
+
 	size := len(collection)
 
 	if size < count {
 		count = size
 	}
 
-	cOpy := append(Slice{}, collection...)
-
+	indexes := Range(size)
 	results := make(Slice, count)
 
-	for i := 0; i < count; i++ {
-		copyLength := size - i
+	for i := range results {
+		n := len(indexes)
 
-		index := randomIntGenerator(copyLength)
-		results[i] = cOpy[index]
+		index := randomIntGenerator(n)
+		results[i] = collection[indexes[index]]
 
-		// Removes element.
+		// Removes index.
 		// It is faster to swap with last element and remove it.
-		cOpy[index] = cOpy[copyLength-1]
-		cOpy = cOpy[:copyLength-1]
+		indexes[index] = indexes[n-1]
+		indexes = indexes[:n-1]
 	}
 
 	return results

--- a/find_test.go
+++ b/find_test.go
@@ -767,9 +767,22 @@ func TestSamplesBy(t *testing.T) {
 
 	result1 := SamplesBy([]string{"a", "b", "c"}, 3, r.Intn)
 	result2 := SamplesBy([]string{}, 3, r.Intn)
+	result3 := SamplesBy([]string{"a", "b", "c"}, 3, func(n int) int { return n - 1 })
+	result4 := SamplesBy([]string{"a", "b", "c"}, 3, func(int) int { return 0 })
+	result5 := SamplesBy([]string{"a", "b", "c"}, 0, func(int) int { return 1 })
+	result6 := SamplesBy([]string{"a", "b", "c"}, -1, nil)
+
+	// index out of range [1] with length 1
+	is.Panics(func() {
+		SamplesBy([]string{"a", "b", "c"}, 3, func(int) int { return 1 })
+	})
 
 	is.ElementsMatch(result1, []string{"a", "b", "c"})
 	is.Empty(result2)
+	is.Equal([]string{"c", "b", "a"}, result3)
+	is.Equal([]string{"a", "c", "b"}, result4)
+	is.Empty(result5)
+	is.Empty(result6)
 
 	type myStrings []string
 	allStrings := myStrings{"", "foo", "bar"}

--- a/it/find_test.go
+++ b/it/find_test.go
@@ -720,9 +720,22 @@ func TestSamplesBy(t *testing.T) {
 
 	result1 := SamplesBy(values("a", "b", "c"), 3, xrand.IntN)
 	result2 := SamplesBy(values[string](), 3, xrand.IntN)
+	result3 := SamplesBy(values("a", "b", "c"), 3, func(n int) int { return n - 1 })
+	result4 := SamplesBy(values("a", "b", "c"), 3, func(int) int { return 0 })
+	result5 := SamplesBy(values("a", "b", "c"), 0, func(int) int { return 1 })
+	result6 := SamplesBy(values("a", "b", "c"), -1, nil)
+
+	// index out of range [1] with length 1
+	is.Panics(func() {
+		SamplesBy(values("a", "b", "c"), 3, func(int) int { return 1 })
+	})
 
 	is.ElementsMatch(slices.Collect(result1), []string{"a", "b", "c"})
 	is.Empty(slices.Collect(result2))
+	is.Equal([]string{"c", "b", "a"}, slices.Collect(result3))
+	is.Equal([]string{"a", "c", "b"}, slices.Collect(result4))
+	is.Empty(slices.Collect(result5))
+	is.Empty(slices.Collect(result6))
 
 	type myStrings iter.Seq[string]
 	allStrings := myStrings(values("", "foo", "bar"))


### PR DESCRIPTION
Regression introduced in 1c66270 (perf: preallocate result slice in SamplesBy) where
`make(Slice, count)` with negative count causes panic. Previously used
`Slice{}` with `append`, which handled negative counts gracefully.

- Simplify NthOrEmpty by removing redundant error handling
- Simplify Sample by removing intermediate variable
- Refactor SamplesBy to use index tracking instead of collection copying
  - More efficient: avoids copying the entire collection
  - Uses Range to generate indexes and swaps/removes from index slice
  - Uses `n := len(indexes)` to eliminate redundant bounds checks
- Add early return for count <= 0 in SamplesBy (fixes panic with make)
- Add edge case tests for SamplesBy:
  - Test with deterministic random generators (always last index, always 0)
  - Test count = 0 and count = -1 (verifies non-panic behavior)
  - Add panic test for out-of-range index generation