### PR TITLE
fix: ChunkString return empty slice for empty string

### DIFF
--- a/docs/data/core-chunkstring.md
+++ b/docs/data/core-chunkstring.md
@@ -18,7 +18,7 @@ signatures:
   - "func ChunkString[T ~string](str T, size int) []T"
 ---
 
-Splits a string into chunks of the given size. The last chunk may be shorter. Returns [""] for empty input.
+Splits a string into chunks of the given size. The last chunk may be shorter. Returns an empty slice for empty input.
 
 ```go
 lo.ChunkString("1234567", 2)

--- a/docs/data/it-chunkstring.md
+++ b/docs/data/it-chunkstring.md
@@ -38,6 +38,6 @@ for s := range seq { out = append(out, s) }
 // Empty and small inputs
 seq1 := it.ChunkString("", 2)
 seq2 := it.ChunkString("1", 2)
-// seq1 yields ""
+// seq1 yields empty sequence
 // seq2 yields "1"
 ```

--- a/it/string.go
+++ b/it/string.go
@@ -7,16 +7,17 @@ import "iter"
 // ChunkString returns a sequence of strings split into groups of length size. If the string can't be split evenly,
 // the final chunk will be the remaining characters.
 // Play: https://go.dev/play/p/Y4mN8bB2cXw
-//
-// Note: it.ChunkString and it.Chunk functions behave inconsistently for empty input: it.ChunkString("", n) returns [""] instead of [].
-// See https://github.com/samber/lo/issues/788
 func ChunkString[T ~string](str T, size int) iter.Seq[T] {
 	if size <= 0 {
 		panic("it.ChunkString: size must be greater than 0")
 	}
 
 	return func(yield func(T) bool) {
-		if len(str) == 0 || size >= len(str) {
+		if len(str) == 0 {
+			return
+		}
+
+		if size >= len(str) {
 			yield(str)
 			return
 		}

--- a/it/string_test.go
+++ b/it/string_test.go
@@ -26,7 +26,7 @@ func TestChunkString(t *testing.T) {
 	is.Equal([]string{"123456"}, slices.Collect(result4))
 
 	result5 := ChunkString("", 2)
-	is.Equal([]string{""}, slices.Collect(result5)) // @TODO: should be [] - see https://github.com/samber/lo/issues/788
+	is.Empty(slices.Collect(result5))
 
 	result6 := ChunkString("明1好休2林森", 2)
 	is.Equal([]string{"明1", "好休", "2林", "森"}, slices.Collect(result6))

--- a/string.go
+++ b/string.go
@@ -127,12 +127,13 @@ func Substring[T ~string](str T, offset int, length uint) T {
 // ChunkString returns a slice of strings split into groups of length size. If the string can't be split evenly,
 // the final chunk will be the remaining characters.
 // Play: https://go.dev/play/p/__FLTuJVz54
-//
-// Note: lo.ChunkString and lo.Chunk functions behave inconsistently for empty input: lo.ChunkString("", n) returns [""] instead of [].
-// See https://github.com/samber/lo/issues/788
 func ChunkString[T ~string](str T, size int) []T {
 	if size <= 0 {
 		panic("lo.ChunkString: size must be greater than 0")
+	}
+
+	if len(str) == 0 {
+		return []T{}
 	}
 
 	if size >= len(str) {

--- a/string_test.go
+++ b/string_test.go
@@ -48,7 +48,7 @@ func TestChunkString(t *testing.T) {
 	is.Equal([]string{"123456"}, result4)
 
 	result5 := ChunkString("", 2)
-	is.Equal([]string{""}, result5) // @TODO: should be [] - see https://github.com/samber/lo/issues/788
+	is.Equal([]string{}, result5)
 
 	result6 := ChunkString("明1好休2林森", 2)
 	is.Equal([]string{"明1", "好休", "2林", "森"}, result6)


### PR DESCRIPTION
Fixes #788

Fixed `ChunkString("", n)` to return an empty slice.
Also attempted to update md files.