### PR TITLE
perf: optimize it.CountBy by removing Filter iterator chain

### DIFF
--- a/benchmark/seq_benchmark_test.go
+++ b/benchmark/seq_benchmark_test.go
@@ -239,3 +239,14 @@ func BenchmarkItTrimSuffix(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkItCountBy(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.CountBy(ints, func(x int) bool { return x%2 == 0 })
+			}
+		})
+	}
+}

--- a/it/seq.go
+++ b/it/seq.go
@@ -830,8 +830,10 @@ func Count[T comparable](collection iter.Seq[T], value T) int {
 func CountBy[T any](collection iter.Seq[T], predicate func(item T) bool) int {
 	var count int
 
-	for range Filter(collection, predicate) {
-		count++
+	for item := range collection {
+		if predicate(item) {
+			count++
+		}
 	}
 
 	return count


### PR DESCRIPTION
- Remove unnecessary Filter(collection, predicate) chain
- Use direct loop with predicate check instead
- Results: -36.68% time geomean, -100% B/op, -100% allocs/op

Benchstat results:

```lua
                      │   old.txt    │              new.txt               │
                      │    sec/op    │   sec/op     vs base               │
ItCountBy/ints_10-4     433.0n ± 23%   186.2n ± 5%  -56.99% (p=0.000 n=8)
ItCountBy/ints_100-4    2.487µ ± 27%   1.678µ ± 6%  -32.55% (p=0.000 n=8)
ItCountBy/ints_1000-4   20.16µ ±  8%   17.64µ ± 4%  -12.50% (p=0.005 n=8)
geomean                 2.790µ         1.766µ       -36.68%

                      │  old.txt   │               new.txt                │
                      │    B/op    │   B/op    vs base                    │
ItCountBy/ints_10-4     160.0 ± 0%   0.0 ± 0%  -100.00% (p=0.000 n=8)
ItCountBy/ints_100-4    160.0 ± 0%   0.0 ± 0%  -100.00% (p=0.000 n=8)
ItCountBy/ints_1000-4   160.0 ± 0%   0.0 ± 0%  -100.00% (p=0.000 n=8)

                      │  old.txt   │                new.txt                 │
                      │ allocs/op  │ allocs/op   vs base                    │
ItCountBy/ints_10-4     6.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=8)
ItCountBy/ints_100-4    6.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=8)
ItCountBy/ints_1000-4   6.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=8)
```