### PR TITLE
refactor: remove redundant map zero value initialization in throttleBy

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -315,10 +315,6 @@ func (th *throttleBy[T]) throttledFunc(key T) {
 	th.mu.Lock()
 	defer th.mu.Unlock()
 
-	if _, ok := th.count[key]; !ok {
-		th.count[key] = 0
-	}
-
 	if th.count[key] < th.countLimit {
 		th.count[key]++
 


### PR DESCRIPTION
Remove unnecessary existence check and zero value assignment.
Go maps return zero value for missing keys, making this redundant.