### PR TITLE
perf: preallocate result slice in RangeWithSteps

### DIFF
--- a/it/math_test.go
+++ b/it/math_test.go
@@ -41,7 +41,7 @@ func TestRangeFrom(t *testing.T) {
 	is.Equal([]float64{-2.5, -3.5, -4.5}, slices.Collect(result7))
 }
 
-func TestRangeClose(t *testing.T) {
+func TestRangeWithSteps(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -51,12 +51,23 @@ func TestRangeClose(t *testing.T) {
 	result4 := RangeWithSteps(3, 2, 1)
 	result5 := RangeWithSteps(1.0, 4.0, 2.0)
 	result6 := RangeWithSteps[float32](-1.0, -4.0, -1.0)
+	result7 := RangeWithSteps(0.0, 0.5, 1.0)
+	result8 := RangeWithSteps(0.0, 0.3, 0.1)
+	result9 := RangeWithSteps(0.0, 5.5, 2.5)
+
+	type f64 float64
+	result10 := RangeWithSteps[f64](0.0, 0.3, 0.1)
+
 	is.Equal([]int{0, 6, 12, 18}, slices.Collect(result1))
 	is.Empty(slices.Collect(result2))
 	is.Empty(slices.Collect(result3))
 	is.Empty(slices.Collect(result4))
 	is.Equal([]float64{1.0, 3.0}, slices.Collect(result5))
 	is.Equal([]float32{-1.0, -2.0, -3.0}, slices.Collect(result6))
+	is.Equal([]float64{0.0}, slices.Collect(result7))
+	is.Equal([]float64{0.0, 0.1, 0.2}, slices.Collect(result8))
+	is.Equal([]float64{0.0, 2.5, 5.0}, slices.Collect(result9))
+	is.Equal([]f64{0.0, 0.1, 0.2}, slices.Collect(result10))
 }
 
 func TestSum(t *testing.T) {

--- a/map.go
+++ b/map.go
@@ -264,12 +264,7 @@ func ChunkEntries[K comparable, V any](m map[K]V, size int) []map[K]V {
 		return []map[K]V{}
 	}
 
-	chunksNum := count / size
-	if count%size != 0 {
-		chunksNum++
-	}
-
-	result := make([]map[K]V, 0, chunksNum)
+	result := make([]map[K]V, 0, ((count-1)/size)+1)
 
 	for k, v := range m {
 		if len(result) == 0 || len(result[len(result)-1]) == size {

--- a/math.go
+++ b/math.go
@@ -1,6 +1,8 @@
 package lo
 
 import (
+	"math"
+
 	"github.com/samber/lo/internal/constraints"
 )
 
@@ -32,22 +34,32 @@ func RangeFrom[T constraints.Integer | constraints.Float](start T, elementNum in
 // step set to zero will return an empty slice.
 // Play: https://go.dev/play/p/0r6VimXAi9H
 func RangeWithSteps[T constraints.Integer | constraints.Float](start, end, step T) []T {
-	result := []T{}
 	if start == end || step == 0 {
-		return result
+		return []T{}
 	}
+
+	capacity := func(count, delta T) int {
+		// Use math.Ceil instead of (count-1)/delta+1 because integer division
+		// fails for floats (e.g., 5.5/2.5=2.2 → ceil=3, not 2).
+		return int(math.Ceil(float64(count) / float64(delta)))
+	}
+
 	if start < end {
 		if step < 0 {
-			return result
+			return []T{}
 		}
+
+		result := make([]T, 0, capacity(end-start, step))
 		for i := start; i < end; i += step {
 			result = append(result, i)
 		}
 		return result
 	}
 	if step > 0 {
-		return result
+		return []T{}
 	}
+
+	result := make([]T, 0, capacity(start-end, -step))
 	for i := start; i > end; i += step {
 		result = append(result, i)
 	}

--- a/math_test.go
+++ b/math_test.go
@@ -38,7 +38,7 @@ func TestRangeFrom(t *testing.T) {
 	is.Equal([]float64{-2.5, -3.5, -4.5}, result7)
 }
 
-func TestRangeClose(t *testing.T) {
+func TestRangeWithSteps(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -48,12 +48,23 @@ func TestRangeClose(t *testing.T) {
 	result4 := RangeWithSteps(3, 2, 1)
 	result5 := RangeWithSteps(1.0, 4.0, 2.0)
 	result6 := RangeWithSteps[float32](-1.0, -4.0, -1.0)
+	result7 := RangeWithSteps(0.0, 0.5, 1.0)
+	result8 := RangeWithSteps(0.0, 0.3, 0.1)
+	result9 := RangeWithSteps(0.0, 5.5, 2.5)
+
+	type f64 float64
+	result10 := RangeWithSteps[f64](0.0, 0.3, 0.1)
+
 	is.Equal([]int{0, 6, 12, 18}, result1)
 	is.Empty(result2)
 	is.Empty(result3)
 	is.Empty(result4)
 	is.Equal([]float64{1.0, 3.0}, result5)
 	is.Equal([]float32{-1.0, -2.0, -3.0}, result6)
+	is.Equal([]float64{0.0}, result7)
+	is.Equal([]float64{0.0, 0.1, 0.2}, result8)
+	is.Equal([]float64{0.0, 2.5, 5.0}, result9)
+	is.Equal([]f64{0.0, 0.1, 0.2}, result10)
 }
 
 func TestClamp(t *testing.T) {


### PR DESCRIPTION
- RangeWithSteps now preallocates result slice using math.Ceil for better performance
- Fix edge cases for floating point values with small steps
- Add test cases for float and custom type validation
- Rename TestRangeClose → TestRangeWithSteps for consistency
- Simplify ChunkEntries chunk count calculation using ((count-1)/size)+1 formula