### PR TITLE
perf: avoid double iteration in UniqMap

### DIFF
--- a/benchmark/slice_benchmark_test.go
+++ b/benchmark/slice_benchmark_test.go
@@ -240,7 +240,7 @@ func BenchmarkReject(b *testing.B) {
 		ints := genSliceInt(n)
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_ = lo.Reject(ints, func(v int, _ int) bool { return v < 50000 })
+				_ = lo.Reject(ints, func(v, _ int) bool { return v < 50000 })
 			}
 		})
 	}
@@ -260,7 +260,7 @@ func BenchmarkRejectErr(b *testing.B) {
 		ints := genSliceInt(n)
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, _ = lo.RejectErr(ints, func(v int, _ int) (bool, error) { return v < 50000, nil })
+				_, _ = lo.RejectErr(ints, func(v, _ int) (bool, error) { return v < 50000, nil })
 			}
 		})
 	}
@@ -280,7 +280,27 @@ func BenchmarkRejectMap(b *testing.B) {
 		ints := genSliceInt(n)
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_ = lo.RejectMap(ints, func(v int, _ int) (int, bool) { return v, v < 50000 })
+				_ = lo.RejectMap(ints, func(v, _ int) (int, bool) { return v, v < 50000 })
+			}
+		})
+	}
+}
+
+func BenchmarkUniqMap(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.UniqMap(ints, func(v, _ int) int { return v % 50 })
+			}
+		})
+	}
+
+	for _, n := range lengths {
+		strs := genSliceString(n)
+		b.Run(fmt.Sprintf("strings_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.UniqMap(strs, func(v string, _ int) string { return v })
 			}
 		})
 	}

--- a/slice.go
+++ b/slice.go
@@ -71,16 +71,18 @@ func MapErr[T, R any](collection []T, transform func(item T, index int) (R, erro
 // UniqMap manipulates a slice and transforms it to a slice of another type with unique values.
 // Play: https://go.dev/play/p/fygzLBhvUdB
 func UniqMap[T any, R comparable](collection []T, transform func(item T, index int) R) []R {
+	result := make([]R, 0, len(collection))
 	seen := make(map[R]struct{}, len(collection))
 
 	for i := range collection {
 		r := transform(collection[i], i)
 		if _, ok := seen[r]; !ok {
 			seen[r] = struct{}{}
+			result = append(result, r)
 		}
 	}
 
-	return Keys(seen)
+	return result
 }
 
 // FilterMap returns a slice obtained after both filtering and mapping using the given callback function.


### PR DESCRIPTION
UniqMap previously built a map then called Keys(seen) which:
1. Iterated the map a second time to extract keys
2. Returned keys in non-deterministic map iteration order
3. Allocated a separate slice inside Keys()

Now collects results directly during the single pass, preserving insertion order and eliminating the redundant iteration.