### PR TITLE
perf: preallocate result slices in Difference

### DIFF
--- a/benchmark/slice_benchmark_test.go
+++ b/benchmark/slice_benchmark_test.go
@@ -353,3 +353,25 @@ func BenchmarkFilterTakeVsFilterAndTake(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkDifference(b *testing.B) {
+	for _, n := range lengths {
+		ints1 := genSliceInt(n)
+		ints2 := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.Difference(ints1, ints2)
+			}
+		})
+	}
+
+	for _, n := range lengths {
+		strs1 := genSliceString(n)
+		strs2 := genSliceString(n)
+		b.Run(fmt.Sprintf("strings_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.Difference(strs1, strs2)
+			}
+		})
+	}
+}

--- a/intersect.go
+++ b/intersect.go
@@ -207,8 +207,8 @@ func IntersectBy[T any, K comparable, Slice ~[]T](transform func(T) K, lists ...
 // The second value is the collection of elements absent from list1.
 // Play: https://go.dev/play/p/pKE-JgzqRpz
 func Difference[T comparable, Slice ~[]T](list1, list2 Slice) (Slice, Slice) {
-	left := Slice{}
-	right := Slice{}
+	left := make(Slice, 0, len(list1))
+	right := make(Slice, 0, len(list2))
 
 	seenLeft := Keyify(list1)
 	seenRight := Keyify(list2)


### PR DESCRIPTION
## Summary
- **Difference** previously initialized `left` and `right` as empty slice literals (`Slice{}`), causing repeated grow-and-copy allocations as elements were appended
- Now preallocates with `make(Slice, 0, len(listN))` to avoid unnecessary reallocations

## Benchstat

```
goos: darwin
goarch: arm64
pkg: github.com/samber/lo/benchmark
cpu: Apple M3
                        │    before     │     after      │  change            │
                        │    sec/op     │    sec/op      │                    │
Difference/ints_10        501.7n ± 11%    438.5n ±  5%   -12.60% (p=0.002)
Difference/ints_100       4.991µ ± 21%    4.533µ ±  1%    -9.19% (p=0.000)
Difference/ints_1000      33.04µ ± 59%    29.58µ ±  1%   -10.47% (p=0.000)
Difference/strings_10     775.4n ±  9%    592.4n ±  2%   -23.61% (p=0.000)
Difference/strings_100    8.574µ ± 11%    6.616µ ± 11%   -22.84% (p=0.001)
Difference/strings_1000   67.31µ ± 17%    47.67µ ± 19%   -29.18% (p=0.010)
geomean                   5.773µ          4.715µ         -18.33%

                        │    B/op     │     B/op      │  change            │
Difference/ints_10         1040 ± 0%     816 ± 0%      -21.54% (p=0.000)
Difference/ints_100       8.45Ki ± 0%  6.33Ki ± 0%     -25.14% (p=0.000)
Difference/ints_1000     121.3Ki ± 0%  88.2Ki ± 0%     -27.31% (p=0.000)
Difference/strings_10    1.77Ki ± 0%   1.20Ki ± 0%     -31.86% (p=0.000)
Difference/strings_100   15.5Ki ± 0%   10.3Ki ± 0%     -33.16% (p=0.000)
Difference/strings_1000  175.3Ki ± 0%  138.7Ki ± 0%    -20.89% (p=0.000)
geomean                  13.07Ki       9.565Ki         -26.80%

                        │ allocs/op │ allocs/op │  change            │
Difference/ints_10           10         8         -20.00% (p=0.000)
Difference/ints_100          16         8         -50.00% (p=0.000)
Difference/ints_1000         28        12         -57.14% (p=0.000)
Difference/strings_10        12         8         -33.33% (p=0.000)
Difference/strings_100       18         8         -55.56% (p=0.000)
Difference/strings_1000      28        12         -57.14% (p=0.000)
geomean                     17.3       9.2        -47.16%
```