### PR TITLE
perf: use direct loop in FromSlicePtr, FromSlicePtrOr

### DIFF
--- a/benchmark/slice_benchmark_test.go
+++ b/benchmark/slice_benchmark_test.go
@@ -226,6 +226,46 @@ func BenchmarkToSlicePtr(b *testing.B) {
 	}
 }
 
+func BenchmarkFromSlicePtr(b *testing.B) {
+	for _, n := range lengths {
+		ptrs := lo.ToSlicePtr(genSliceInt(n))
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FromSlicePtr(ptrs)
+			}
+		})
+	}
+
+	for _, n := range lengths {
+		ptrs := lo.ToSlicePtr(genSliceString(n))
+		b.Run(fmt.Sprintf("strings_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FromSlicePtr(ptrs)
+			}
+		})
+	}
+}
+
+func BenchmarkFromSlicePtrOr(b *testing.B) {
+	for _, n := range lengths {
+		ptrs := lo.ToSlicePtr(genSliceInt(n))
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FromSlicePtrOr(ptrs, -1)
+			}
+		})
+	}
+
+	for _, n := range lengths {
+		ptrs := lo.ToSlicePtr(genSliceString(n))
+		b.Run(fmt.Sprintf("strings_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FromSlicePtrOr(ptrs, "default")
+			}
+		})
+	}
+}
+
 func BenchmarkReject(b *testing.B) {
 	for _, n := range lengths {
 		strs := genSliceString(n)

--- a/type_manipulation.go
+++ b/type_manipulation.go
@@ -83,23 +83,31 @@ func ToSlicePtr[T any](collection []T) []*T {
 // Returns a zero value in case of a nil pointer element.
 // Play: https://go.dev/play/p/lbunFvzlUDX
 func FromSlicePtr[T any](collection []*T) []T {
-	return Map(collection, func(x *T, _ int) T {
-		if x == nil {
-			return Empty[T]()
+	result := make([]T, len(collection))
+
+	for i := range collection {
+		if collection[i] != nil {
+			result[i] = *collection[i]
 		}
-		return *x
-	})
+	}
+
+	return result
 }
 
 // FromSlicePtrOr returns a slice with the pointer values or the fallback value.
 // Play: https://go.dev/play/p/lbunFvzlUDX
 func FromSlicePtrOr[T any](collection []*T, fallback T) []T {
-	return Map(collection, func(x *T, _ int) T {
-		if x == nil {
-			return fallback
+	result := make([]T, len(collection))
+
+	for i := range collection {
+		if collection[i] != nil {
+			result[i] = *collection[i]
+		} else {
+			result[i] = fallback
 		}
-		return *x
-	})
+	}
+
+	return result
 }
 
 // ToAnySlice returns a slice with all elements mapped to `any` type.


### PR DESCRIPTION
## Summary
- **FromSlicePtr** and **FromSlicePtrOr** previously delegated to `Map()` with a closure, adding per-element indirect function call overhead
- Now uses a direct loop, eliminating closure overhead

## Benchstat

```
goos: darwin
goarch: arm64
pkg: github.com/samber/lo/benchmark
cpu: Apple M3
                            │    before     │    after      │  change            │
                            │    sec/op     │    sec/op     │                    │
FromSlicePtr/ints_10          21.91n ± 14%    18.34n ±  1%   -16.31% (p=0.000)
FromSlicePtr/ints_100         128.2n ±  6%    106.0n ±  2%   -17.35% (p=0.000)
FromSlicePtr/ints_1000        1042.0n ± 6%    907.6n ±  3%   -12.90% (p=0.000)
FromSlicePtrOr/ints_10        21.27n ±  2%    19.16n ± 11%    -9.90% (p=0.028)
FromSlicePtrOr/ints_100       123.6n ±  2%    105.5n ±  1%   -14.61% (p=0.000)
FromSlicePtrOr/ints_1000      1054.0n ± 4%    902.0n ± 31%         ~ (p=0.341)
geomean                       214.6n          199.5n          -7.05%
```