### PR TITLE
perf: use direct index assignment in RepeatBy, Fill, Repeat

### DIFF
--- a/benchmark/core_benchmark_test.go
+++ b/benchmark/core_benchmark_test.go
@@ -1,0 +1,1119 @@
+package benchmark
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/samber/lo"
+)
+
+var coreLengths = []int{10, 100, 1000}
+
+func genMap(n int) map[string]int {
+	m := make(map[string]int, n)
+	for i := 0; i < n; i++ {
+		m[strconv.Itoa(i)] = i
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// map.go
+// ---------------------------------------------------------------------------
+
+func BenchmarkKeys(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Keys(m)
+			}
+		})
+	}
+}
+
+func BenchmarkCoreUniqKeys(b *testing.B) {
+	for _, n := range coreLengths {
+		m1 := genMap(n)
+		m2 := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.UniqKeys(m1, m2)
+			}
+		})
+	}
+}
+
+func BenchmarkHasKey(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		key := strconv.Itoa(n / 2)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.HasKey(m, key)
+			}
+		})
+	}
+}
+
+func BenchmarkValues(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Values(m)
+			}
+		})
+	}
+}
+
+func BenchmarkUniqValues(b *testing.B) {
+	for _, n := range coreLengths {
+		m1 := genMap(n)
+		m2 := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.UniqValues(m1, m2)
+			}
+		})
+	}
+}
+
+func BenchmarkValueOr(b *testing.B) {
+	m := genMap(100)
+	b.Run("hit", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = lo.ValueOr(m, "50", -1)
+		}
+	})
+	b.Run("miss", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = lo.ValueOr(m, "missing", -1)
+		}
+	})
+}
+
+func BenchmarkPickBy(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.PickBy(m, func(_ string, v int) bool { return v%2 == 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkPickByKeys(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		keys := make([]string, n/2)
+		for i := range keys {
+			keys[i] = strconv.Itoa(i * 2)
+		}
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.PickByKeys(m, keys)
+			}
+		})
+	}
+}
+
+func BenchmarkPickByValues(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		vals := make([]int, n/2)
+		for i := range vals {
+			vals[i] = i * 2
+		}
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.PickByValues(m, vals)
+			}
+		})
+	}
+}
+
+func BenchmarkOmitBy(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.OmitBy(m, func(_ string, v int) bool { return v%2 == 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkOmitByKeys(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		keys := make([]string, n/4)
+		for i := range keys {
+			keys[i] = strconv.Itoa(i)
+		}
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.OmitByKeys(m, keys)
+			}
+		})
+	}
+}
+
+func BenchmarkOmitByValues(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		vals := make([]int, n/4)
+		for i := range vals {
+			vals[i] = i
+		}
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.OmitByValues(m, vals)
+			}
+		})
+	}
+}
+
+func BenchmarkEntries(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Entries(m)
+			}
+		})
+	}
+}
+
+func BenchmarkFromEntries(b *testing.B) {
+	for _, n := range coreLengths {
+		entries := make([]lo.Entry[string, int], n)
+		for i := 0; i < n; i++ {
+			entries[i] = lo.Entry[string, int]{Key: strconv.Itoa(i), Value: i}
+		}
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FromEntries(entries)
+			}
+		})
+	}
+}
+
+func BenchmarkInvert(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Invert(m)
+			}
+		})
+	}
+}
+
+func BenchmarkAssign(b *testing.B) {
+	for _, n := range coreLengths {
+		m1 := genMap(n)
+		m2 := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Assign(m1, m2)
+			}
+		})
+	}
+}
+
+func BenchmarkChunkEntries(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.ChunkEntries(m, 5)
+			}
+		})
+	}
+}
+
+func BenchmarkMapKeys(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.MapKeys(m, func(_ int, k string) string { return k + "_x" })
+			}
+		})
+	}
+}
+
+func BenchmarkMapValues(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.MapValues(m, func(v int, _ string) int { return v * 2 })
+			}
+		})
+	}
+}
+
+func BenchmarkMapEntries(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.MapEntries(m, func(k string, v int) (string, int) { return k, v * 2 })
+			}
+		})
+	}
+}
+
+func BenchmarkMapToSlice(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.MapToSlice(m, func(k string, v int) string { return k + "=" + strconv.Itoa(v) })
+			}
+		})
+	}
+}
+
+func BenchmarkFilterMapToSlice(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FilterMapToSlice(m, func(k string, v int) (string, bool) { return k, v%2 == 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkFilterKeys(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FilterKeys(m, func(_ string, v int) bool { return v%2 == 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkFilterValues(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FilterValues(m, func(_ string, v int) bool { return v%2 == 0 })
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// find.go
+// ---------------------------------------------------------------------------
+
+func BenchmarkIndexOf(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		target := ints[n-1] // worst case: last element
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.IndexOf(ints, target)
+			}
+		})
+	}
+}
+
+func BenchmarkLastIndexOf(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		target := ints[0]
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.LastIndexOf(ints, target)
+			}
+		})
+	}
+}
+
+func BenchmarkHasPrefix(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		prefix := ints[:n/10+1]
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.HasPrefix(ints, prefix)
+			}
+		})
+	}
+}
+
+func BenchmarkHasSuffix(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		suffix := ints[n-n/10-1:]
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.HasSuffix(ints, suffix)
+			}
+		})
+	}
+}
+
+func BenchmarkFind(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		target := ints[n-1]
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.Find(ints, func(v int) bool { return v == target })
+			}
+		})
+	}
+}
+
+func BenchmarkFindIndexOf(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		target := ints[n-1]
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _, _ = lo.FindIndexOf(ints, func(v int) bool { return v == target })
+			}
+		})
+	}
+}
+
+func BenchmarkFindLastIndexOf(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		target := ints[0]
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _, _ = lo.FindLastIndexOf(ints, func(v int) bool { return v == target })
+			}
+		})
+	}
+}
+
+func BenchmarkFindOrElse(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FindOrElse(ints, -1, func(v int) bool { return v == -999 })
+			}
+		})
+	}
+}
+
+func BenchmarkFindKey(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.FindKey(m, n/2)
+			}
+		})
+	}
+}
+
+func BenchmarkFindKeyBy(b *testing.B) {
+	for _, n := range coreLengths {
+		m := genMap(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.FindKeyBy(m, func(_ string, v int) bool { return v == n/2 })
+			}
+		})
+	}
+}
+
+func BenchmarkFindUniques(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FindUniques(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkFindUniquesBy(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FindUniquesBy(ints, func(v int) int { return v % 50 })
+			}
+		})
+	}
+}
+
+func BenchmarkFindDuplicates(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FindDuplicates(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkFindDuplicatesBy(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FindDuplicatesBy(ints, func(v int) int { return v % 50 })
+			}
+		})
+	}
+}
+
+func BenchmarkMin(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Min(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkMinIndex(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.MinIndex(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkMinBy(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.MinBy(ints, func(a, b int) bool { return a < b })
+			}
+		})
+	}
+}
+
+func BenchmarkMinIndexBy(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.MinIndexBy(ints, func(a, b int) bool { return a < b })
+			}
+		})
+	}
+}
+
+func BenchmarkMax(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Max(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkMaxIndex(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.MaxIndex(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkMaxBy(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.MaxBy(ints, func(a, b int) bool { return a > b })
+			}
+		})
+	}
+}
+
+func BenchmarkMaxIndexBy(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.MaxIndexBy(ints, func(a, b int) bool { return a > b })
+			}
+		})
+	}
+}
+
+func BenchmarkFirst(b *testing.B) {
+	ints := genSliceInt(100)
+	for i := 0; i < b.N; i++ {
+		_, _ = lo.First(ints)
+	}
+}
+
+func BenchmarkFirstOrEmpty(b *testing.B) {
+	ints := genSliceInt(100)
+	for i := 0; i < b.N; i++ {
+		_ = lo.FirstOrEmpty(ints)
+	}
+}
+
+func BenchmarkLast(b *testing.B) {
+	ints := genSliceInt(100)
+	for i := 0; i < b.N; i++ {
+		_, _ = lo.Last(ints)
+	}
+}
+
+func BenchmarkLastOrEmpty(b *testing.B) {
+	ints := genSliceInt(100)
+	for i := 0; i < b.N; i++ {
+		_ = lo.LastOrEmpty(ints)
+	}
+}
+
+func BenchmarkNth(b *testing.B) {
+	ints := genSliceInt(100)
+	for i := 0; i < b.N; i++ {
+		_, _ = lo.Nth(ints, 50)
+	}
+}
+
+func BenchmarkSample(b *testing.B) {
+	ints := genSliceInt(100)
+	for i := 0; i < b.N; i++ {
+		_ = lo.Sample(ints)
+	}
+}
+
+func BenchmarkSamples(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Samples(ints, n/4)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// intersect.go
+// ---------------------------------------------------------------------------
+
+func BenchmarkContains(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		target := ints[n-1]
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Contains(ints, target)
+			}
+		})
+	}
+}
+
+func BenchmarkContainsBy(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		target := ints[n-1]
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.ContainsBy(ints, func(v int) bool { return v == target })
+			}
+		})
+	}
+}
+
+func BenchmarkEvery(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		subset := ints[:n/2]
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Every(ints, subset)
+			}
+		})
+	}
+}
+
+func BenchmarkEveryBy(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.EveryBy(ints, func(v int) bool { return v >= 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkSome(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		subset := []int{ints[n-1]}
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Some(ints, subset)
+			}
+		})
+	}
+}
+
+func BenchmarkSomeBy(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.SomeBy(ints, func(v int) bool { return v < 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkNone(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		subset := []int{-1, -2, -3}
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.None(ints, subset)
+			}
+		})
+	}
+}
+
+func BenchmarkNoneBy(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.NoneBy(ints, func(v int) bool { return v < 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkIntersect(b *testing.B) {
+	for _, n := range coreLengths {
+		a := genSliceInt(n)
+		c := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Intersect(a, c)
+			}
+		})
+	}
+}
+
+func BenchmarkIntersectBy(b *testing.B) {
+	for _, n := range coreLengths {
+		a := genSliceInt(n)
+		c := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.IntersectBy(func(v int) int { return v }, a, c)
+			}
+		})
+	}
+}
+
+func BenchmarkDifference(b *testing.B) {
+	for _, n := range coreLengths {
+		a := genSliceInt(n)
+		c := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.Difference(a, c)
+			}
+		})
+	}
+}
+
+func BenchmarkUnion(b *testing.B) {
+	for _, n := range coreLengths {
+		a := genSliceInt(n)
+		c := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Union(a, c)
+			}
+		})
+	}
+}
+
+func BenchmarkWithout(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Without(ints, 1, 2, 3, 4, 5)
+			}
+		})
+	}
+}
+
+func BenchmarkWithoutBy(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.WithoutBy(ints, func(v int) int { return v % 100 }, 1, 2, 3, 4, 5)
+			}
+		})
+	}
+}
+
+func BenchmarkWithoutEmpty(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		// sprinkle some zeroes
+		for j := 0; j < n/10; j++ {
+			ints[j*10] = 0
+		}
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.WithoutEmpty(ints) //nolint:staticcheck
+			}
+		})
+	}
+}
+
+func BenchmarkWithoutNth(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.WithoutNth(ints, 0, n/2, n-1)
+			}
+		})
+	}
+}
+
+func BenchmarkElementsMatch(b *testing.B) {
+	for _, n := range coreLengths {
+		a := genSliceInt(n)
+		c := make([]int, n)
+		copy(c, a)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.ElementsMatch(a, c)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// math.go
+// ---------------------------------------------------------------------------
+
+func BenchmarkRange(b *testing.B) {
+	for _, n := range coreLengths {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Range(n)
+			}
+		})
+	}
+}
+
+func BenchmarkRangeFrom(b *testing.B) {
+	for _, n := range coreLengths {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.RangeFrom(0, n)
+			}
+		})
+	}
+}
+
+func BenchmarkRangeWithSteps(b *testing.B) {
+	for _, n := range coreLengths {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.RangeWithSteps(0, n, 1)
+			}
+		})
+	}
+}
+
+func BenchmarkClamp(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.Clamp(15, 0, 10)
+	}
+}
+
+func BenchmarkSum(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Sum(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkSumBy(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.SumBy(ints, func(v int) int { return v })
+			}
+		})
+	}
+}
+
+func BenchmarkProduct(b *testing.B) {
+	for _, n := range coreLengths {
+		floats := make([]float64, n)
+		for j := range floats {
+			floats[j] = 1.0001
+		}
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Product(floats)
+			}
+		})
+	}
+}
+
+func BenchmarkProductBy(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.ProductBy(ints, func(v int) float64 { return float64(v) * 0.001 })
+			}
+		})
+	}
+}
+
+func BenchmarkMean(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Mean(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkMeanBy(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.MeanBy(ints, func(v int) int { return v })
+			}
+		})
+	}
+}
+
+func BenchmarkMode(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Mode(ints)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// string.go
+// ---------------------------------------------------------------------------
+
+func BenchmarkRandomString(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.RandomString(64, lo.AlphanumericCharset)
+	}
+}
+
+func BenchmarkSubstring(b *testing.B) {
+	s := lo.RandomString(1000, lo.LettersCharset)
+	for i := 0; i < b.N; i++ {
+		_ = lo.Substring(s, 100, 200)
+	}
+}
+
+func BenchmarkChunkString(b *testing.B) {
+	s := lo.RandomString(1000, lo.LettersCharset)
+	for i := 0; i < b.N; i++ {
+		_ = lo.ChunkString(s, 10)
+	}
+}
+
+func BenchmarkRuneLength(b *testing.B) {
+	s := lo.RandomString(1000, lo.LettersCharset)
+	for i := 0; i < b.N; i++ {
+		_ = lo.RuneLength(s)
+	}
+}
+
+func BenchmarkPascalCase(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.PascalCase("some_long_variable_name")
+	}
+}
+
+func BenchmarkCamelCase(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.CamelCase("some_long_variable_name")
+	}
+}
+
+func BenchmarkKebabCase(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.KebabCase("someLongVariableName")
+	}
+}
+
+func BenchmarkSnakeCase(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.SnakeCase("someLongVariableName")
+	}
+}
+
+func BenchmarkWords(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.Words("someLongVariableName")
+	}
+}
+
+func BenchmarkCapitalize(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.Capitalize("hello world")
+	}
+}
+
+func BenchmarkEllipsis(b *testing.B) {
+	s := lo.RandomString(200, lo.LettersCharset)
+	for i := 0; i < b.N; i++ {
+		_ = lo.Ellipsis(s, 50)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// type_manipulation.go
+// ---------------------------------------------------------------------------
+
+func BenchmarkToPtr(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.ToPtr(42)
+	}
+}
+
+func BenchmarkFromPtr(b *testing.B) {
+	p := lo.ToPtr(42)
+	for i := 0; i < b.N; i++ {
+		_ = lo.FromPtr(p)
+	}
+}
+
+func BenchmarkFromPtrOr(b *testing.B) {
+	var p *int
+	for i := 0; i < b.N; i++ {
+		_ = lo.FromPtrOr(p, 99)
+	}
+}
+
+func BenchmarkCoreToSlicePtr(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.ToSlicePtr(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkFromSlicePtr(b *testing.B) {
+	for _, n := range coreLengths {
+		ptrs := lo.ToSlicePtr(genSliceInt(n))
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FromSlicePtr(ptrs)
+			}
+		})
+	}
+}
+
+func BenchmarkFromSlicePtrOr(b *testing.B) {
+	for _, n := range coreLengths {
+		ptrs := lo.ToSlicePtr(genSliceInt(n))
+		// sprinkle nils
+		for j := 0; j < n/10; j++ {
+			ptrs[j*10] = nil
+		}
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FromSlicePtrOr(ptrs, -1)
+			}
+		})
+	}
+}
+
+func BenchmarkToAnySlice(b *testing.B) {
+	for _, n := range coreLengths {
+		ints := genSliceInt(n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.ToAnySlice(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkFromAnySlice(b *testing.B) {
+	for _, n := range coreLengths {
+		anys := lo.ToAnySlice(genSliceInt(n))
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.FromAnySlice[int](anys)
+			}
+		})
+	}
+}
+
+func BenchmarkIsEmpty(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.IsEmpty(0)
+	}
+}
+
+func BenchmarkIsNotEmpty(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.IsNotEmpty(42)
+	}
+}
+
+func BenchmarkCoalesce(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = lo.Coalesce(0, 0, 0, 42, 99)
+	}
+}

--- a/benchmark/mutable_benchmark_test.go
+++ b/benchmark/mutable_benchmark_test.go
@@ -1,0 +1,86 @@
+package benchmark
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samber/lo/mutable"
+)
+
+func BenchmarkMutableFilter(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			src := genSliceInt(n)
+			for i := 0; i < b.N; i++ {
+				cp := make([]int, len(src))
+				copy(cp, src)
+				_ = mutable.Filter(cp, func(x int) bool { return x%2 == 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkMutableFilterI(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			src := genSliceInt(n)
+			for i := 0; i < b.N; i++ {
+				cp := make([]int, len(src))
+				copy(cp, src)
+				_ = mutable.FilterI(cp, func(x, _ int) bool { return x%2 == 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkMutableMap(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			src := genSliceInt(n)
+			for i := 0; i < b.N; i++ {
+				cp := make([]int, len(src))
+				copy(cp, src)
+				mutable.Map(cp, func(x int) int { return x * 2 })
+			}
+		})
+	}
+}
+
+func BenchmarkMutableMapI(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			src := genSliceInt(n)
+			for i := 0; i < b.N; i++ {
+				cp := make([]int, len(src))
+				copy(cp, src)
+				mutable.MapI(cp, func(x, i int) int { return x * i })
+			}
+		})
+	}
+}
+
+func BenchmarkMutableShuffle(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			src := genSliceInt(n)
+			for i := 0; i < b.N; i++ {
+				cp := make([]int, len(src))
+				copy(cp, src)
+				mutable.Shuffle(cp)
+			}
+		})
+	}
+}
+
+func BenchmarkMutableReverse(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			src := genSliceInt(n)
+			for i := 0; i < b.N; i++ {
+				cp := make([]int, len(src))
+				copy(cp, src)
+				mutable.Reverse(cp)
+			}
+		})
+	}
+}

--- a/benchmark/parallel_benchmark_test.go
+++ b/benchmark/parallel_benchmark_test.go
@@ -1,0 +1,62 @@
+package benchmark
+
+import (
+	"fmt"
+	"testing"
+
+	lop "github.com/samber/lo/parallel"
+)
+
+func BenchmarkParallelMap(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			src := genSliceInt(n)
+			for i := 0; i < b.N; i++ {
+				_ = lop.Map(src, func(x, _ int) int { return x * 2 })
+			}
+		})
+	}
+}
+
+func BenchmarkParallelForEach(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			src := genSliceInt(n)
+			for i := 0; i < b.N; i++ {
+				lop.ForEach(src, func(_, _ int) {})
+			}
+		})
+	}
+}
+
+func BenchmarkParallelTimes(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lop.Times(n, func(i int) int { return i * 2 })
+			}
+		})
+	}
+}
+
+func BenchmarkParallelGroupBy(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			src := genSliceInt(n)
+			for i := 0; i < b.N; i++ {
+				_ = lop.GroupBy(src, func(x int) int { return x % 10 })
+			}
+		})
+	}
+}
+
+func BenchmarkParallelPartitionBy(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			src := genSliceInt(n)
+			for i := 0; i < b.N; i++ {
+				_ = lop.PartitionBy(src, func(x int) int { return x % 10 })
+			}
+		})
+	}
+}

--- a/benchmark/seq_benchmark_test.go
+++ b/benchmark/seq_benchmark_test.go
@@ -7,6 +7,7 @@ import (
 	"iter"
 	"math/rand/v2"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/samber/lo/it"
@@ -304,6 +305,996 @@ func BenchmarkItNoneBy(b *testing.B) {
 			target := rand.IntN(100_000)
 			for range b.N {
 				_ = it.NoneBy(ints, func(x int) bool { return x == target })
+			}
+		})
+	}
+}
+
+func genIntPtrSeq(n int) iter.Seq[*int] {
+	return func(yield func(*int) bool) {
+		for range n {
+			v := rand.IntN(100_000)
+			if !yield(&v) {
+				break
+			}
+		}
+	}
+}
+
+func genMapStringInt(n int) map[string]int {
+	m := make(map[string]int, n)
+	for i := range n {
+		m[strconv.Itoa(i)] = rand.IntN(100_000)
+	}
+	return m
+}
+
+func genMapSeq(n int) iter.Seq[map[string]int] {
+	return func(yield func(map[string]int) bool) {
+		for range n {
+			m := map[string]int{strconv.Itoa(rand.IntN(100_000)): rand.IntN(100_000)}
+			if !yield(m) {
+				break
+			}
+		}
+	}
+}
+
+func BenchmarkItFilter(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Filter(ints, func(x int) bool { return x%2 == 0 }) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItMap(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Map(ints, func(x int) int { return x * 2 }) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItUniqMap(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.UniqMap(ints, func(x int) int { return x % 50 }) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItFilterMap(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.FilterMap(ints, func(x int) (int, bool) { return x * 2, x%2 == 0 }) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItFlatMap(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.FlatMap(ints, func(x int) iter.Seq[int] { //nolint:revive
+					return func(yield func(int) bool) {
+						yield(x)
+					}
+				}) {
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItReduce(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.Reduce(ints, func(agg, item int) int { return agg + item }, 0)
+			}
+		})
+	}
+}
+
+func BenchmarkItForEach(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				it.ForEach(ints, func(_ int) {})
+			}
+		})
+	}
+}
+
+func BenchmarkItForEachWhile(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				it.ForEachWhile(ints, func(_ int) bool { return true })
+			}
+		})
+	}
+}
+
+func BenchmarkItTimes(b *testing.B) {
+	for _, n := range itLengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Times(n, func(i int) int { return i * 2 }) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItUniq(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Uniq(ints) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItUniqBy(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.UniqBy(ints, func(x int) int { return x % 50 }) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItGroupBy(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.GroupBy(ints, func(x int) int { return x % 10 })
+			}
+		})
+	}
+}
+
+func BenchmarkItPartitionBy(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.PartitionBy(ints, func(x int) int { return x % 10 })
+			}
+		})
+	}
+}
+
+func BenchmarkItConcat(b *testing.B) {
+	for _, n := range itLengths {
+		a := genInts(n)
+		c := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Concat(a, c) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItInterleave(b *testing.B) {
+	for _, n := range itLengths {
+		a := genInts(n)
+		c := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Interleave(a, c) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItShuffle(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Shuffle(ints) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItReverse(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Reverse(ints) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItRepeatBy(b *testing.B) {
+	for _, n := range itLengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.RepeatBy(n, func(i int) int { return i * 2 }) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItKeyBy(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.KeyBy(ints, func(x int) int { return x })
+			}
+		})
+	}
+}
+
+func BenchmarkItAssociate(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.Associate(ints, func(x int) (int, int) { return x, x * 2 })
+			}
+		})
+	}
+}
+
+func BenchmarkItTake(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Take(ints, n/2) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItTakeWhile(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.TakeWhile(ints, func(x int) bool { return x < 90_000 }) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItTakeFilter(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.TakeFilter(ints, 5, func(x int) bool { return x%2 == 0 }) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItReject(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Reject(ints, func(x int) bool { return x%2 == 0 }) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItRejectMap(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.RejectMap(ints, func(x int) (int, bool) { return x * 2, x%2 == 0 }) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItCount(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.Count(ints, 42)
+			}
+		})
+	}
+}
+
+func BenchmarkItCountValues(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.CountValues(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkItCountValuesBy(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.CountValuesBy(ints, func(x int) int { return x % 10 })
+			}
+		})
+	}
+}
+
+func BenchmarkItSubset(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Subset(ints, n/4, n/2) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItSlice(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Slice(ints, n/4, n*3/4) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItReplaceAll(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.ReplaceAll(ints, 42, 99) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItCompact(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Compact(ints) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItIsSorted(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.IsSorted(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkItSplice(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Splice(ints, n/2, 1, 2, 3) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItCutPrefix(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				after, _ := it.CutPrefix(ints, []int{-1, -2})
+				for range after { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItBuffer(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Buffer(ints, 5) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItContains(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.Contains(ints, 42)
+			}
+		})
+	}
+}
+
+func BenchmarkItEvery(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.Every(ints, 1, 2, 3)
+			}
+		})
+	}
+}
+
+func BenchmarkItSome(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.Some(ints, 1, 2, 3)
+			}
+		})
+	}
+}
+
+func BenchmarkItNone(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.None(ints, -1, -2, -3)
+			}
+		})
+	}
+}
+
+func BenchmarkItIntersect(b *testing.B) {
+	for _, n := range itLengths {
+		a := genInts(n)
+		c := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Intersect(a, c) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItUnion(b *testing.B) {
+	for _, n := range itLengths {
+		a := genInts(n)
+		c := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Union(a, c) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItWithout(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Without(ints, 1, 2, 3, 4, 5) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItWithoutNth(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.WithoutNth(ints, 0, n/2, n-1) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItIndexOf(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.IndexOf(ints, -1)
+			}
+		})
+	}
+}
+
+func BenchmarkItLastIndexOf(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.LastIndexOf(ints, -1)
+			}
+		})
+	}
+}
+
+func BenchmarkItHasPrefix(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.HasPrefix(ints, -1, -2, -3)
+			}
+		})
+	}
+}
+
+func BenchmarkItHasSuffix(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.HasSuffix(ints, -1, -2, -3)
+			}
+		})
+	}
+}
+
+func BenchmarkItFindIndexOf(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_, _, _ = it.FindIndexOf(ints, func(x int) bool { return x == -1 })
+			}
+		})
+	}
+}
+
+func BenchmarkItFindOrElse(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.FindOrElse(ints, -1, func(x int) bool { return x == -1 })
+			}
+		})
+	}
+}
+
+func BenchmarkItFindUniques(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.FindUniques(ints) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItFindDuplicates(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.FindDuplicates(ints) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItMin(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.Min(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkItMax(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.Max(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkItMinBy(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.MinBy(ints, func(a, b int) bool { return a < b })
+			}
+		})
+	}
+}
+
+func BenchmarkItMaxBy(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.MaxBy(ints, func(a, b int) bool { return a > b })
+			}
+		})
+	}
+}
+
+func BenchmarkItFirst(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_, _ = it.First(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkItLast(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_, _ = it.Last(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkItNth(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_, _ = it.Nth(ints, n/2)
+			}
+		})
+	}
+}
+
+func BenchmarkItSample(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.Sample(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkItSamples(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Samples(ints, 5) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItSum(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.Sum(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkItSumBy(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.SumBy(ints, func(x int) int { return x })
+			}
+		})
+	}
+}
+
+func BenchmarkItProduct(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.Product(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkItMean(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.Mean(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkItMode(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.Mode(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkItRange(b *testing.B) {
+	for _, n := range itLengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Range(n) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItLength(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.Length(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkItKeys(b *testing.B) {
+	for _, n := range itLengths {
+		m := genMapStringInt(n)
+		b.Run(fmt.Sprintf("map_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Keys(m) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItUniqKeys(b *testing.B) {
+	for _, n := range itLengths {
+		m := genMapStringInt(n)
+		b.Run(fmt.Sprintf("map_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.UniqKeys(m) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItValues(b *testing.B) {
+	for _, n := range itLengths {
+		m := genMapStringInt(n)
+		b.Run(fmt.Sprintf("map_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Values(m) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItUniqValues(b *testing.B) {
+	for _, n := range itLengths {
+		m := genMapStringInt(n)
+		b.Run(fmt.Sprintf("map_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.UniqValues(m) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItEntries(b *testing.B) {
+	for _, n := range itLengths {
+		m := genMapStringInt(n)
+		b.Run(fmt.Sprintf("map_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Entries(m) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItFromEntries(b *testing.B) {
+	for _, n := range itLengths {
+		m := genMapStringInt(n)
+		entries := it.Entries(m)
+		b.Run(fmt.Sprintf("map_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.FromEntries(entries)
+			}
+		})
+	}
+}
+
+func BenchmarkItInvert(b *testing.B) {
+	for _, n := range itLengths {
+		m := genMapStringInt(n)
+		entries := it.Entries(m)
+		b.Run(fmt.Sprintf("map_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.Invert(entries) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItAssign(b *testing.B) {
+	for _, n := range itLengths {
+		seq := genMapSeq(n)
+		b.Run(fmt.Sprintf("maps_%d", n), func(b *testing.B) {
+			for range b.N {
+				_ = it.Assign(seq)
+			}
+		})
+	}
+}
+
+func BenchmarkItFilterKeys(b *testing.B) {
+	for _, n := range itLengths {
+		m := genMapStringInt(n)
+		b.Run(fmt.Sprintf("map_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.FilterKeys(m, func(_ string, v int) bool { return v%2 == 0 }) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItFilterValues(b *testing.B) {
+	for _, n := range itLengths {
+		m := genMapStringInt(n)
+		b.Run(fmt.Sprintf("map_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.FilterValues(m, func(_ string, v int) bool { return v%2 == 0 }) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItToSeqPtr(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.ToSeqPtr(ints) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItFromSeqPtr(b *testing.B) {
+	for _, n := range itLengths {
+		ptrs := genIntPtrSeq(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.FromSeqPtr(ptrs) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItToAnySeq(b *testing.B) {
+	for _, n := range itLengths {
+		ints := genInts(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.ToAnySeq(ints) { //nolint:revive
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkItChunkString(b *testing.B) {
+	for _, n := range itLengths {
+		s := ""
+		var sSb1288 strings.Builder
+		for range n {
+			sSb1288.WriteString("a")
+		}
+		s += sSb1288.String()
+		b.Run(fmt.Sprintf("len_%d", n), func(b *testing.B) {
+			for range b.N {
+				for range it.ChunkString(s, 5) { //nolint:revive
+				}
 			}
 		})
 	}

--- a/benchmark/slice_benchmark_test.go
+++ b/benchmark/slice_benchmark_test.go
@@ -306,6 +306,637 @@ func BenchmarkUniqMap(b *testing.B) {
 	}
 }
 
+func BenchmarkRepeatBy(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.RepeatBy(n, func(index int) int { return index * 2 })
+			}
+		})
+	}
+
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("strings_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.RepeatBy(n, strconv.Itoa)
+			}
+		})
+	}
+}
+
+type clonableString struct {
+	val string
+}
+
+func (c clonableString) Clone() clonableString {
+	return clonableString{c.val}
+}
+
+func BenchmarkFill(b *testing.B) {
+	for _, n := range lengths {
+		collection := make([]clonableString, n)
+		for i := range collection {
+			collection[i] = clonableString{strconv.Itoa(i)}
+		}
+		b.Run(fmt.Sprintf("size_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Fill(collection, clonableString{"hello"})
+			}
+		})
+	}
+}
+
+func BenchmarkRepeat(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("size_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Repeat(n, clonableString{"hello"})
+			}
+		})
+	}
+}
+
+func BenchmarkFilter(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Filter(ints, func(v, _ int) bool { return v%2 == 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkFilterErr(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.FilterErr(ints, func(v, _ int) (bool, error) { return v%2 == 0, nil })
+			}
+		})
+	}
+}
+
+func BenchmarkSliceMap(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Map(ints, func(v, _ int) int { return v * 2 })
+			}
+		})
+	}
+}
+
+func BenchmarkMapErr(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.MapErr(ints, func(v, _ int) (int, error) { return v * 2, nil })
+			}
+		})
+	}
+}
+
+func BenchmarkFilterMap(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FilterMap(ints, func(v, _ int) (int, bool) { return v * 2, v%2 == 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkFlatMap(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FlatMap(ints, func(v, _ int) []int { return []int{v, v + 1} })
+			}
+		})
+	}
+}
+
+func BenchmarkReduce(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Reduce(ints, func(agg, item, _ int) int { return agg + item }, 0)
+			}
+		})
+	}
+}
+
+func BenchmarkReduceRight(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.ReduceRight(ints, func(agg, item, _ int) int { return agg + item }, 0)
+			}
+		})
+	}
+}
+
+func BenchmarkForEach(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				lo.ForEach(ints, func(_, _ int) {})
+			}
+		})
+	}
+}
+
+func BenchmarkForEachWhile(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				lo.ForEachWhile(ints, func(_, _ int) bool { return true })
+			}
+		})
+	}
+}
+
+func BenchmarkTimes(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Times(n, func(i int) int { return i })
+			}
+		})
+	}
+}
+
+func BenchmarkUniq(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Uniq(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkUniqBy(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.UniqBy(ints, func(v int) int { return v % 100 })
+			}
+		})
+	}
+}
+
+func BenchmarkGroupBy(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.GroupBy(ints, func(v int) int { return v % 10 })
+			}
+		})
+	}
+}
+
+func BenchmarkGroupByMap(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.GroupByMap(ints, func(v int) (int, string) { return v % 10, strconv.Itoa(v) })
+			}
+		})
+	}
+}
+
+func BenchmarkPartitionBy(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.PartitionBy(ints, func(v int) int { return v % 5 })
+			}
+		})
+	}
+}
+
+func BenchmarkConcat(b *testing.B) {
+	for _, n := range lengths {
+		a := genSliceInt(n)
+		c := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Concat(a, c)
+			}
+		})
+	}
+}
+
+func BenchmarkWindow(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Window(ints, 5)
+			}
+		})
+	}
+}
+
+func BenchmarkSliding(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Sliding(ints, 5, 2)
+			}
+		})
+	}
+}
+
+func BenchmarkInterleave(b *testing.B) {
+	for _, n := range lengths {
+		a := genSliceInt(n)
+		c := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Interleave(a, c)
+			}
+		})
+	}
+}
+
+func BenchmarkShuffle(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Shuffle(ints) //nolint:staticcheck
+			}
+		})
+	}
+}
+
+func BenchmarkReverse(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Reverse(ints) //nolint:staticcheck
+			}
+		})
+	}
+}
+
+func BenchmarkRepeatByErr(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.RepeatByErr(n, func(index int) (int, error) { return index * 2, nil })
+			}
+		})
+	}
+}
+
+func BenchmarkKeyBy(b *testing.B) {
+	for _, n := range lengths {
+		strs := genSliceString(n)
+		b.Run(fmt.Sprintf("strings_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.KeyBy(strs, func(v string) string { return v })
+			}
+		})
+	}
+}
+
+func BenchmarkAssociate(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Associate(ints, func(v int) (int, string) { return v, strconv.Itoa(v) })
+			}
+		})
+	}
+}
+
+func BenchmarkSliceToMap(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.SliceToMap(ints, func(v int) (int, string) { return v, strconv.Itoa(v) })
+			}
+		})
+	}
+}
+
+func BenchmarkFilterSliceToMap(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.FilterSliceToMap(ints, func(v int) (int, string, bool) { return v, strconv.Itoa(v), v%2 == 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkKeyify(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Keyify(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkTake(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Take(ints, n/4)
+			}
+		})
+	}
+}
+
+func BenchmarkTakeWhile(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.TakeWhile(ints, func(v int) bool { return v < 50000 })
+			}
+		})
+	}
+}
+
+func BenchmarkTakeFilter(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.TakeFilter(ints, 5, func(v, _ int) bool { return v%2 == 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkFilterReject(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.FilterReject(ints, func(v, _ int) bool { return v%2 == 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkCount(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Count(ints, 42)
+			}
+		})
+	}
+}
+
+func BenchmarkCountBy(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.CountBy(ints, func(v int) bool { return v%2 == 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkCountValues(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.CountValues(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkCountValuesBy(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.CountValuesBy(ints, func(v int) int { return v % 100 })
+			}
+		})
+	}
+}
+
+func BenchmarkSubset(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Subset(ints, n/4, uint(n/2))
+			}
+		})
+	}
+}
+
+func BenchmarkSlice(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Slice(ints, n/4, n*3/4)
+			}
+		})
+	}
+}
+
+func BenchmarkReplaceAll(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.ReplaceAll(ints, ints[n/4], 123123)
+			}
+		})
+	}
+}
+
+func BenchmarkClone(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Clone(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkCompact(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Compact(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkIsSorted(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.IsSorted(ints)
+			}
+		})
+	}
+}
+
+func BenchmarkIsSortedBy(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.IsSortedBy(ints, func(v int) int { return v })
+			}
+		})
+	}
+}
+
+func BenchmarkSplice(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		extra := []int{1, 2, 3}
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Splice(ints, n/2, extra...)
+			}
+		})
+	}
+}
+
+func BenchmarkCut(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		sep := ints[n/4 : n/4+3]
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _, _ = lo.Cut(ints, sep)
+			}
+		})
+	}
+}
+
+func BenchmarkCutPrefix(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		prefix := ints[:3]
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.CutPrefix(ints, prefix)
+			}
+		})
+	}
+}
+
+func BenchmarkCutSuffix(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		suffix := ints[n-3:]
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.CutSuffix(ints, suffix)
+			}
+		})
+	}
+}
+
+func BenchmarkTrim(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		cutset := ints[:3]
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Trim(ints, cutset)
+			}
+		})
+	}
+}
+
+func BenchmarkTrimLeft(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		cutset := ints[:3]
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.TrimLeft(ints, cutset)
+			}
+		})
+	}
+}
+
+func BenchmarkTrimRight(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		cutset := ints[n-3:]
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.TrimRight(ints, cutset)
+			}
+		})
+	}
+}
+
+func BenchmarkTrimPrefix(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		prefix := ints[:3]
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.TrimPrefix(ints, prefix)
+			}
+		})
+	}
+}
+
+func BenchmarkTrimSuffix(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		suffix := ints[n-3:]
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.TrimSuffix(ints, suffix)
+			}
+		})
+	}
+}
+
 func BenchmarkFilterTakeVsFilterAndTake(b *testing.B) {
 	n := 1000
 	ints := genSliceInt(n)

--- a/optimizations2.txt
+++ b/optimizations2.txt
@@ -1,0 +1,33 @@
+# Performance Optimizations Report
+
+## PR #827 - Reject / RejectErr / RejectMap
+- Preallocate result slice with `make(Slice, 0, len(collection))` instead of `Slice{}`
+- Avoids repeated grow-and-copy reallocations as elements are appended
+
+## PR #829 - UniqMap
+- Collect results directly during the single map-building pass instead of calling `Keys(seen)` afterward
+- Eliminates a second full iteration over the map to extract keys
+- Eliminates a separate slice allocation inside `Keys()`
+- Preserves insertion order (old code returned non-deterministic map iteration order)
+
+## PR #830 - Difference
+- Preallocate result slices with `make(Slice, 0, len(listN))` instead of `Slice{}`
+- Avoids repeated grow-and-copy reallocations as elements are appended
+
+## PR #831 - FromSlicePtr / FromSlicePtrOr
+- Replace indirect `Map()` call with closure by a direct loop
+- Eliminates per-element function call overhead from the closure indirection
+
+## PR #833 - CountValues, UniqKeys, UniqValues, FilterKeys, FilterValues, FilterKeysErr, FilterValuesErr
+- Add size hint to map allocation in CountValues: `make(map[T]int)` → `make(map[T]int, len(collection))`
+- Avoids repeated map rehashing as entries are added
+- Add capacity hint to result slice in UniqKeys/UniqValues: `make([]K, 0)` → `make([]K, 0, size)`
+- Avoids repeated slice grow-and-copy reallocations
+- Add capacity hint to result slice in FilterKeys/FilterValues/FilterKeysErr/FilterValuesErr: `make([]K, 0)` → `make([]K, 0, len(in))`
+- Avoids repeated slice grow-and-copy reallocations
+
+## PR #??? - RepeatBy / Fill / Repeat
+- Replace `make([]T, 0, count)` + `append(result, ...)` with `make([]T, count)` + `result[i] = ...`
+- Eliminates per-element append overhead (bounds check, length increment, slice header update)
+- Size is known upfront so direct index assignment is safe and faster
+- RepeatByErr left unchanged: early error return makes direct index problematic (would allocate full slice then discard)

--- a/slice.go
+++ b/slice.go
@@ -550,10 +550,10 @@ func Reverse[T any, Slice ~[]T](collection Slice) Slice {
 // Fill fills elements of a slice with `initial` value.
 // Play: https://go.dev/play/p/VwR34GzqEub
 func Fill[T Clonable[T], Slice ~[]T](collection Slice, initial T) Slice {
-	result := make(Slice, 0, len(collection))
+	result := make(Slice, len(collection))
 
-	for range collection {
-		result = append(result, initial.Clone())
+	for i := range collection {
+		result[i] = initial.Clone()
 	}
 
 	return result
@@ -562,10 +562,10 @@ func Fill[T Clonable[T], Slice ~[]T](collection Slice, initial T) Slice {
 // Repeat builds a slice with N copies of initial value.
 // Play: https://go.dev/play/p/g3uHXbmc3b6
 func Repeat[T Clonable[T]](count int, initial T) []T {
-	result := make([]T, 0, count)
+	result := make([]T, count)
 
 	for i := 0; i < count; i++ {
-		result = append(result, initial.Clone())
+		result[i] = initial.Clone()
 	}
 
 	return result
@@ -574,10 +574,10 @@ func Repeat[T Clonable[T]](count int, initial T) []T {
 // RepeatBy builds a slice with values returned by N calls of callback.
 // Play: https://go.dev/play/p/ozZLCtX_hNU
 func RepeatBy[T any](count int, callback func(index int) T) []T {
-	result := make([]T, 0, count)
+	result := make([]T, count)
 
 	for i := 0; i < count; i++ {
-		result = append(result, callback(i))
+		result[i] = callback(i)
 	}
 
 	return result


### PR DESCRIPTION
## Summary
- Replace `make([]T, 0, count)` + `append` with `make([]T, count)` + `result[i] = ...` in `RepeatBy`, `Fill`, and `Repeat`
- The final size is known upfront, so direct index assignment avoids per-element append overhead (bounds check, length increment, slice header update)
- `RepeatByErr` left unchanged: early error return makes direct index problematic
- Also adds comprehensive benchmark coverage (282 benchmark functions) for all helpers across core, it, mutable, and parallel packages

## Benchstat

```
                      │ /tmp/bench_before.txt │        /tmp/bench_after.txt         │
                      │        sec/op         │    sec/op     vs base               │
RepeatBy/ints_10                 19.17n ±  8%   18.61n ±  6%        ~ (p=0.058 n=6)
RepeatBy/ints_100                92.91n ± 19%   90.93n ± 30%        ~ (p=0.132 n=6)
RepeatBy/ints_1000               789.6n ±  2%   740.4n ±  8%   -6.23% (p=0.041 n=6)
RepeatBy/strings_10              64.01n ±  3%   57.22n ± 13%  -10.61% (p=0.026 n=6)
RepeatBy/strings_100             439.9n ±  2%   381.9n ± 14%  -13.19% (p=0.002 n=6)
RepeatBy/strings_1000            14.40µ ±  3%   13.26µ ±  5%   -7.89% (p=0.002 n=6)
Fill/size_10                     59.33n ±  5%   53.71n ±  6%   -9.46% (p=0.002 n=6)
Fill/size_100                    410.4n ± 15%   366.4n ±  7%  -10.72% (p=0.002 n=6)
Fill/size_1000                   4.024µ ± 33%   3.525µ ± 17%  -12.40% (p=0.041 n=6)
Repeat/size_10                   56.72n ±  4%   57.22n ± 41%        ~ (p=0.937 n=6)
Repeat/size_100                  409.1n ±  7%   368.0n ±  2%  -10.04% (p=0.002 n=6)
Repeat/size_1000                 3.700µ ±  5%   3.467µ ± 15%        ~ (p=0.065 n=6)
geomean                          360.4n         332.7n         -7.68%
```