### PR TITLE
perf(map): add size hints to PickBy/OmitBy family

### DIFF
--- a/map.go
+++ b/map.go
@@ -103,7 +103,7 @@ func ValueOr[K comparable, V any](in map[K]V, key K, fallback V) V {
 // PickBy returns same map type filtered by given predicate.
 // Play: https://go.dev/play/p/kdg8GR_QMmf
 func PickBy[K comparable, V any, Map ~map[K]V](in Map, predicate func(key K, value V) bool) Map {
-	r := Map{}
+	r := make(Map, len(in))
 	for k, v := range in {
 		if predicate(k, v) {
 			r[k] = v
@@ -115,7 +115,7 @@ func PickBy[K comparable, V any, Map ~map[K]V](in Map, predicate func(key K, val
 // PickByErr returns same map type filtered by given predicate.
 // It returns the first error returned by the predicate.
 func PickByErr[K comparable, V any, Map ~map[K]V](in Map, predicate func(key K, value V) (bool, error)) (Map, error) {
-	r := Map{}
+	r := make(Map, len(in))
 	for k, v := range in {
 		ok, err := predicate(k, v)
 		if err != nil {
@@ -131,7 +131,7 @@ func PickByErr[K comparable, V any, Map ~map[K]V](in Map, predicate func(key K, 
 // PickByKeys returns same map type filtered by given keys.
 // Play: https://go.dev/play/p/R1imbuci9qU
 func PickByKeys[K comparable, V any, Map ~map[K]V](in Map, keys []K) Map {
-	r := Map{}
+	r := make(Map, len(keys))
 	for i := range keys {
 		if v, ok := in[keys[i]]; ok {
 			r[keys[i]] = v
@@ -143,7 +143,7 @@ func PickByKeys[K comparable, V any, Map ~map[K]V](in Map, keys []K) Map {
 // PickByValues returns same map type filtered by given values.
 // Play: https://go.dev/play/p/-_PPkSbO1Kc
 func PickByValues[K, V comparable, Map ~map[K]V](in Map, values []V) Map {
-	r := Map{}
+	r := make(Map, len(values))
 
 	seen := Keyify(values)
 	for k, v := range in {
@@ -157,7 +157,7 @@ func PickByValues[K, V comparable, Map ~map[K]V](in Map, values []V) Map {
 // OmitBy returns same map type filtered by given predicate.
 // Play: https://go.dev/play/p/EtBsR43bdsd
 func OmitBy[K comparable, V any, Map ~map[K]V](in Map, predicate func(key K, value V) bool) Map {
-	r := Map{}
+	r := make(Map, len(in))
 	for k, v := range in {
 		if !predicate(k, v) {
 			r[k] = v
@@ -169,7 +169,7 @@ func OmitBy[K comparable, V any, Map ~map[K]V](in Map, predicate func(key K, val
 // OmitByErr returns same map type filtered by given predicate.
 // It returns the first error returned by the predicate.
 func OmitByErr[K comparable, V any, Map ~map[K]V](in Map, predicate func(key K, value V) (bool, error)) (Map, error) {
-	r := Map{}
+	r := make(Map, len(in))
 	for k, v := range in {
 		ok, err := predicate(k, v)
 		if err != nil {
@@ -185,7 +185,7 @@ func OmitByErr[K comparable, V any, Map ~map[K]V](in Map, predicate func(key K, 
 // OmitByKeys returns same map type filtered by given keys.
 // Play: https://go.dev/play/p/t1QjCrs-ysk
 func OmitByKeys[K comparable, V any, Map ~map[K]V](in Map, keys []K) Map {
-	r := Map{}
+	r := make(Map, len(in))
 	for k, v := range in {
 		r[k] = v
 	}
@@ -198,7 +198,7 @@ func OmitByKeys[K comparable, V any, Map ~map[K]V](in Map, keys []K) Map {
 // OmitByValues returns same map type filtered by given values.
 // Play: https://go.dev/play/p/9UYZi-hrs8j
 func OmitByValues[K, V comparable, Map ~map[K]V](in Map, values []V) Map {
-	r := Map{}
+	r := make(Map, len(in))
 
 	seen := Keyify(values)
 	for k, v := range in {


### PR DESCRIPTION
## Summary
- Pre-allocate maps with size hints instead of empty map literals to avoid repeated rehashing as entries are added
- Affects 8 functions: `PickBy`, `PickByErr`, `PickByKeys`, `PickByValues`, `OmitBy`, `OmitByErr`, `OmitByKeys`, `OmitByValues`

## Benchstat (before → after)

```
                  │ before    │              after               │
                  │  sec/op   │   sec/op     vs base             │
PickBy/10            115.1n ±  3%   267.8n ± 0%  +132.72% (p=0.002 n=6)
PickBy/100           2.977µ ±  1%   1.933µ ± 1%   -35.07% (p=0.002 n=6)
PickBy/1000          39.16µ ±  3%   23.06µ ± 0%   -41.12% (p=0.002 n=6)
PickByKeys/10        68.42n ±  1%   70.94n ± 0%    +3.69% (p=0.002 n=6)
PickByKeys/100       2.025µ ±  4%   1.065µ ± 2%   -47.41% (p=0.002 n=6)
PickByKeys/1000     28.153µ ± 24%   9.621µ ± 0%   -65.82% (p=0.002 n=6)
PickByValues/10      174.8n ±  7%   176.3n ± 0%         ~ (p=0.058 n=6)
PickByValues/100     4.554µ ±  9%   3.424µ ± 9%   -24.82% (p=0.002 n=6)
PickByValues/1000    51.10µ ±  1%   33.95µ ± 1%   -33.56% (p=0.002 n=6)
OmitBy/10            114.3n ±  3%   267.7n ± 3%  +134.21% (p=0.002 n=6)
OmitBy/100           2.977µ ±  1%   1.927µ ± 0%   -35.27% (p=0.002 n=6)
OmitBy/1000          39.27µ ±  1%   23.34µ ± 0%   -40.55% (p=0.002 n=6)
OmitByKeys/10        454.0n ±  0%   345.6n ± 0%   -23.89% (p=0.002 n=6)
OmitByKeys/100       5.270µ ±  1%   3.125µ ± 1%   -40.70% (p=0.002 n=6)
OmitByKeys/1000      65.44µ ±  1%   32.00µ ± 1%   -51.09% (p=0.002 n=6)
OmitByValues/10      181.7n ±  1%   343.6n ± 0%   +89.08% (p=0.002 n=6)
OmitByValues/100     5.411µ ±  7%   3.345µ ± 0%   -38.18% (p=0.002 n=6)
OmitByValues/1000    46.99µ ±  1%   31.67µ ± 2%   -32.59% (p=0.002 n=6)
geomean              2.896µ         2.276µ        -21.41%

                  │  allocs/op  │  allocs/op   vs base            │
PickBy/100           7.000 ± 0%     3.000 ± 0%  -57.14% (p=0.002 n=6)
PickBy/1000         15.000 ± 0%     5.000 ± 0%  -66.67% (p=0.002 n=6)
PickByKeys/100       7.000 ± 0%     3.000 ± 0%  -57.14% (p=0.002 n=6)
PickByKeys/1000     15.000 ± 0%     3.000 ± 0%  -80.00% (p=0.002 n=6)
PickByValues/100    10.000 ± 0%     6.000 ± 0%  -40.00% (p=0.002 n=6)
PickByValues/1000   18.000 ± 0%     6.000 ± 0%  -66.67% (p=0.002 n=6)
OmitBy/100           7.000 ± 0%     3.000 ± 0%  -57.14% (p=0.002 n=6)
OmitBy/1000         15.000 ± 0%     5.000 ± 0%  -66.67% (p=0.002 n=6)
OmitByKeys/100       9.000 ± 0%     3.000 ± 0%  -66.67% (p=0.002 n=6)
OmitByKeys/1000     20.000 ± 0%     5.000 ± 0%  -75.00% (p=0.002 n=6)
OmitByValues/100    12.000 ± 0%     6.000 ± 0%  -50.00% (p=0.002 n=6)
OmitByValues/1000   18.000 ± 0%     8.000 ± 0%  -55.56% (p=0.002 n=6)
```

Small n=10 regressions for PickBy/OmitBy/OmitByValues due to upfront map allocation cost when the predicate filters most elements. The absolute overhead is ~150ns — negligible in practice. The n≥100 improvements (up to 66% faster, 80% fewer allocs) far outweigh this.