### PR TITLE
perf: add map capacity hints to Mode and it.UniqKeys/UniqValues

### DIFF
--- a/it/map.go
+++ b/it/map.go
@@ -27,7 +27,11 @@ func Keys[K comparable, V any](in ...map[K]V) iter.Seq[K] {
 // Play: https://go.dev/play/p/_NicwfgAHbO
 func UniqKeys[K comparable, V any](in ...map[K]V) iter.Seq[K] {
 	return func(yield func(K) bool) {
-		seen := make(map[K]struct{})
+		var total int
+		for i := range in {
+			total += len(in[i])
+		}
+		seen := make(map[K]struct{}, total)
 
 		for i := range in {
 			for k := range in[i] {
@@ -62,7 +66,11 @@ func Values[K comparable, V any](in ...map[K]V) iter.Seq[V] {
 // Play: https://go.dev/play/p/QQv4zGrk-fF
 func UniqValues[K, V comparable](in ...map[K]V) iter.Seq[V] {
 	return func(yield func(V) bool) {
-		seen := make(map[V]struct{})
+		var total int
+		for i := range in {
+			total += len(in[i])
+		}
+		seen := make(map[V]struct{}, total)
 
 		for i := range in {
 			for _, v := range in[i] {

--- a/math.go
+++ b/math.go
@@ -196,7 +196,7 @@ func Mode[T constraints.Integer | constraints.Float](collection []T) []T {
 
 	mode := make([]T, 0)
 	maxFreq := 0
-	frequency := make(map[T]int)
+	frequency := make(map[T]int, len(collection))
 
 	for _, item := range collection {
 		frequency[item]++


### PR DESCRIPTION
## Summary
- **Mode** (`math.go`): `make(map[T]int)` → `make(map[T]int, len(collection))`
- **it.UniqKeys** (`it/map.go`): compute total size from input maps for `seen` map hint
- **it.UniqValues** (`it/map.go`): compute total size from input maps for `seen` map hint

Avoids repeated map rehashing as entries are added.

## Benchstat (before → after)

```
                        │    before     │        after          │
                        │   sec/op     │   sec/op     vs base  │
Mode/10                   420.3n ± 295%   280.6n ±   8%  -33.24% (p=0.002 n=6)
Mode/100                  6.165µ ±  79%   1.708µ ±  66%  -72.30% (p=0.002 n=6)
Mode/1000                 42.15µ ±  69%   15.05µ ±  24%  -64.30% (p=0.002 n=6)
ItUniqKeys/map_10         521.2n ±  12%   366.0n ±  13%  -29.77% (p=0.002 n=6)
ItUniqKeys/map_100        5.589µ ±   6%   3.082µ ±  13%  -44.86% (p=0.002 n=6)
ItUniqKeys/map_1000       73.48µ ±  14%   34.90µ ±  18%  -52.50% (p=0.002 n=6)
ItUniqValues/map_10       404.2n ± 503%   309.7n ±  94%  -23.39% (p=0.026 n=6)
ItUniqValues/map_100      4.425µ ±  40%   2.589µ ±  60%  -41.49% (p=0.009 n=6)
ItUniqValues/map_1000     56.77µ ±  90%   28.42µ ±  33%  -49.94% (p=0.002 n=6)

                        │    B/op      │    B/op       vs base  │
Mode/100                  6.344Ki ± 0%   4.281Ki ± 0%  -32.51% (p=0.002 n=6)
Mode/1000                 80.63Ki ± 0%   60.70Ki ± 0%  -24.72% (p=0.002 n=6)
ItUniqKeys/map_100        6.539Ki ± 0%   3.414Ki ± 0%  -47.79% (p=0.002 n=6)
ItUniqKeys/map_1000       106.2Ki ± 0%    53.3Ki ± 0%  -49.79% (p=0.002 n=6)
ItUniqValues/map_100      4.352Ki ± 0%   2.289Ki ± 0%  -47.40% (p=0.002 n=6)
ItUniqValues/map_1000     72.52Ki ± 0%   36.08Ki ± 0%  -50.25% (p=0.002 n=6)

                        │ allocs/op   │ allocs/op   vs base     │
Mode/100                  17.00 ± 0%    11.00 ± 0%  -35.29% (p=0.002 n=6)
Mode/1000                 34.00 ± 0%    18.00 ± 0%  -47.06% (p=0.002 n=6)
ItUniqKeys/map_100         9.00 ± 0%     3.00 ± 0%  -66.67% (p=0.002 n=6)
ItUniqKeys/map_1000       20.00 ± 0%     5.00 ± 0%  -75.00% (p=0.002 n=6)
ItUniqValues/map_100       9.00 ± 0%     3.00 ± 0%  -66.67% (p=0.002 n=6)
ItUniqValues/map_1000     20.00 ± 0%     5.00 ± 0%  -75.00% (p=0.002 n=6)
```
