### PR TITLE
perf(chunk): Remove conditional from Chunk bounds computation

### DIFF
--- a/benchmark/core_slice_bench_test.go
+++ b/benchmark/core_slice_bench_test.go
@@ -1013,3 +1013,67 @@ func BenchmarkFromSlicePtrOr(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkChunkIntSmallDataSmallChunk(b *testing.B) {
+	data := genSliceInt(100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = lo.Chunk(data, 3)
+	}
+}
+
+func BenchmarkChunkIntSmallDataLargeChunk(b *testing.B) {
+	data := genSliceInt(100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = lo.Chunk(data, 50)
+	}
+}
+
+func BenchmarkChunkIntMediumDataSmallChunk(b *testing.B) {
+	data := genSliceInt(10_000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = lo.Chunk(data, 7)
+	}
+}
+
+func BenchmarkChunkIntMediumDataLargeChunk(b *testing.B) {
+	data := genSliceInt(10_000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = lo.Chunk(data, 1024)
+	}
+}
+
+func BenchmarkChunkIntLargeDataSmallChunk(b *testing.B) {
+	data := genSliceInt(1_000_000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = lo.Chunk(data, 13)
+	}
+}
+
+func BenchmarkChunkIntLargeDataLargeChunk(b *testing.B) {
+	data := genSliceInt(1_000_000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = lo.Chunk(data, 8192)
+	}
+}
+
+func BenchmarkChunkStringMediumDataSmallChunk(b *testing.B) {
+	data := genSliceString(10_000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = lo.Chunk(data, 7)
+	}
+}
+
+func BenchmarkChunkStringMediumDataLargeChunk(b *testing.B) {
+	data := genSliceString(10_000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = lo.Chunk(data, 1024)
+	}
+}

--- a/slice.go
+++ b/slice.go
@@ -351,29 +351,38 @@ func GroupByMapErr[T any, K comparable, V any](collection []T, transform func(it
 // Chunk returns a slice of elements split into groups of length size. If the slice can't be split evenly,
 // the final chunk will be the remaining elements.
 // Play: https://go.dev/play/p/kEMkFbdu85g
+// Chunk returns a slice of elements split into groups of length size.
+// If the slice can't be split evenly, the final chunk will be the remaining elements.
+// Copy chunk in a new slice, to prevent memory leak and free memory from initial collection.
+// Play: https://go.dev/play/p/kEMkFbdu85g
 func Chunk[T any, Slice ~[]T](collection Slice, size int) []Slice {
 	if size <= 0 {
 		panic("lo.Chunk: size must be greater than 0")
 	}
 
-	chunksNum := len(collection) / size
-	if len(collection)%size != 0 {
-		chunksNum++
+	if len(collection) == 0 {
+		return []Slice{}
 	}
 
-	result := make([]Slice, 0, chunksNum)
-
-	for i := 0; i < chunksNum; i++ {
-		last := (i + 1) * size
-		if last > len(collection) {
-			last = len(collection)
-		}
-
-		// Copy chunk in a new slice, to prevent memory leak and free memory from initial collection.
-		newSlice := make(Slice, last-i*size)
-		copy(newSlice, collection[i*size:last])
-		result = append(result, newSlice)
+	// Reason: https://github.com/golang/go/issues/77287
+	clone := func(s Slice) Slice {
+		dst := make(Slice, len(s))
+		copy(dst, s)
+		return dst
 	}
+
+	chunksNum := (len(collection) + size - 1) / size
+	result := make([]Slice, chunksNum)
+
+	// Process all full-sized chunks
+	i := 0
+	for ; i < chunksNum-1; i++ {
+		pos := i * size
+		result[i] = clone(collection[pos : pos+size])
+	}
+
+	// Handle the final chunk (may be smaller than size)
+	result[chunksNum-1] = clone(collection[i*size:])
 
 	return result
 }


### PR DESCRIPTION
Hi! The change replaces explicit branching in Chunk bounds computation with a min call.
This reduces a conditional branch in the hot loop, which can slightly improve CPU pipeline efficiency and reduce branch misprediction overhead in microbenchmarks.

With branching:
```
goos: darwin
goarch: arm64
pkg: example.com/chunk
cpu: Apple M1 Pro
BenchmarkChunk_Int_SmallData_SmallChunk-8                7630644               195.8 ns/op           896 B/op          1 allocs/op
BenchmarkChunk_Int_SmallData_LargeChunk-8               51384144                23.07 ns/op           48 B/op          1 allocs/op
BenchmarkChunk_Int_MediumData_SmallChunk-8                201576              9345 ns/op           40960 B/op          1 allocs/op
BenchmarkChunk_Int_MediumData_LargeChunk-8              18150696                96.05 ns/op          240 B/op          1 allocs/op
BenchmarkChunk_Int_LargeData_SmallChunk-8                   3394            305885 ns/op         1851396 B/op          1 allocs/op
BenchmarkChunk_Int_LargeData_LargeChunk-8                2734935               485.0 ns/op          3072 B/op          1 allocs/op
BenchmarkChunk_String_MediumData_SmallChunk-8             176158              8038 ns/op           40960 B/op          1 allocs/op
BenchmarkChunk_String_MediumData_LargeChunk-8           17061892                85.97 ns/op          240 B/op          1 allocs/op
PASS
ok      example.com/chunk       14.800s

```

With min:
```
goos: darwin
goarch: arm64
pkg: example.com/chunk
cpu: Apple M1 Pro
BenchmarkChunk_Int_SmallData_SmallChunk-8                6017160               196.5 ns/op           896 B/op          1 allocs/op
BenchmarkChunk_Int_SmallData_LargeChunk-8               48013203                24.48 ns/op           48 B/op          1 allocs/op
BenchmarkChunk_Int_MediumData_SmallChunk-8                174127              7696 ns/op           40960 B/op          1 allocs/op
BenchmarkChunk_Int_MediumData_LargeChunk-8              17045635                80.26 ns/op          240 B/op          1 allocs/op
BenchmarkChunk_Int_LargeData_SmallChunk-8                   3836            307079 ns/op         1851397 B/op          1 allocs/op
BenchmarkChunk_Int_LargeData_LargeChunk-8                2470082               466.4 ns/op          3072 B/op          1 allocs/op
BenchmarkChunk_String_MediumData_SmallChunk-8             157682              7114 ns/op           40960 B/op          1 allocs/op
BenchmarkChunk_String_MediumData_LargeChunk-8           17324402                64.36 ns/op          240 B/op          1 allocs/op
PASS
ok      example.com/chunk       10.934s
```