### PR TITLE
fix(docs): fix 404 links for iter and experimental pages

### DIFF
--- a/docs/data/core-channeldispatcher.md
+++ b/docs/data/core-channeldispatcher.md
@@ -9,8 +9,8 @@ signatures:
 similarHelpers:
   - core#channel#fanin
   - core#channel#fanout
-  - it#channel#seqtochannel
-  - it#channel#channeltoseq
+  - iter#channel#seqtochannel
+  - iter#channel#channeltoseq
 position: 250
 ---
 

--- a/docs/data/core-channeltoslice.md
+++ b/docs/data/core-channeltoslice.md
@@ -9,8 +9,8 @@ signatures:
 similarHelpers:
   - core#channel#slicetochannel
   - core#channel#buffer
-  - it#channel#seqtochannel
-  - it#channel#channeltoseq
+  - iter#channel#seqtochannel
+  - iter#channel#channeltoseq
 position: 252
 ---
 

--- a/docs/data/core-concat.md
+++ b/docs/data/core-concat.md
@@ -8,7 +8,7 @@ playUrl: https://go.dev/play/p/Ux2UuR2xpRK
 variantHelpers:
   - core#slice#concat
 similarHelpers:
-  - it#sequence#concat
+  - iter#sequence#concat
   - core#slice#flatten
   - core#intersection#union
 position: 160

--- a/docs/data/core-fanout.md
+++ b/docs/data/core-fanout.md
@@ -9,7 +9,7 @@ signatures:
 similarHelpers:
   - core#channel#fanin
   - core#channel#channeldispatcher
-  - it#channel#channelseq
+  - iter#channel#channelseq
 position: 256
 ---
 

--- a/docs/data/core-generator.md
+++ b/docs/data/core-generator.md
@@ -9,7 +9,7 @@ signatures:
 similarHelpers:
   - core#channel#slicetochannel
   - core#channel#fanin
-  - it#channel#seqtochannel
+  - iter#channel#seqtochannel
 position: 253
 ---
 

--- a/docs/data/core-intersect.md
+++ b/docs/data/core-intersect.md
@@ -9,8 +9,8 @@ variantHelpers:
   - core#intersect#intersect
 similarHelpers:
   - core#intersect#intersectby
-  - it#intersect#intersect
-  - it#intersect#intersectby
+  - iter#intersect#intersect
+  - iter#intersect#intersectby
   - core#intersect#difference
   - core#intersect#union
   - core#intersect#without

--- a/docs/data/core-intersectby.md
+++ b/docs/data/core-intersectby.md
@@ -9,8 +9,8 @@ variantHelpers:
   - core#intersect#intersectby
 similarHelpers:
   - core#intersect#intersect
-  - it#intersect#intersect
-  - it#intersect#intersectby
+  - iter#intersect#intersect
+  - iter#intersect#intersectby
   - core#intersect#difference
   - core#intersect#union
   - core#intersect#without

--- a/docs/data/core-slicetochannel.md
+++ b/docs/data/core-slicetochannel.md
@@ -9,8 +9,8 @@ signatures:
 similarHelpers:
   - core#channel#channeltoslice
   - core#channel#buffer
-  - it#channel#seqtochannel
-  - it#channel#channeltoseq
+  - iter#channel#seqtochannel
+  - iter#channel#channeltoseq
 position: 251
 ---
 

--- a/docs/data/core-sliding.md
+++ b/docs/data/core-sliding.md
@@ -12,7 +12,7 @@ similarHelpers:
   - core#slice#chunk
   - core#slice#partitionby
   - core#slice#flatten
-  - it#sequence#sliding
+  - iter#sequence#sliding
 position: 150
 signatures:
   - "func Sliding[T any, Slice ~[]T](collection Slice, size, step int) []Slice"

--- a/docs/data/core-take.md
+++ b/docs/data/core-take.md
@@ -14,7 +14,7 @@ similarHelpers:
   - core#slice#first
   - core#slice#filtermap
   - core#slice#takefilter
-  - it#sequence#take
+  - iter#sequence#take
 position: 175
 signatures:
   - "func Take[T any, Slice ~[]T](collection Slice, n int) Slice"

--- a/docs/data/core-takefilter.md
+++ b/docs/data/core-takefilter.md
@@ -13,7 +13,7 @@ similarHelpers:
   - core#slice#takewhile
   - core#slice#filtermap
   - core#slice#filterreject
-  - it#sequence#takefilter
+  - iter#sequence#takefilter
 position: 125
 signatures:
   - "func TakeFilter[T any, Slice ~[]T](collection Slice, n int, predicate func(item T, index int) bool) Slice"

--- a/docs/data/core-takewhile.md
+++ b/docs/data/core-takewhile.md
@@ -14,7 +14,7 @@ similarHelpers:
   - core#slice#filter
   - core#slice#takefilter
   - core#slice#first
-  - it#sequence#takewhile
+  - iter#sequence#takewhile
 position: 195
 signatures:
   - "func TakeWhile[T any, Slice ~[]T](collection Slice, predicate func(item T) bool) Slice"

--- a/docs/data/core-window.md
+++ b/docs/data/core-window.md
@@ -11,7 +11,7 @@ similarHelpers:
   - core#slice#chunk
   - core#slice#partitionby
   - core#slice#flatten
-  - it#sequence#window
+  - iter#sequence#window
 position: 145
 signatures:
   - "func Window[T any, Slice ~[]T](collection Slice, size int) []Slice"

--- a/docs/data/it-assign.md
+++ b/docs/data/it-assign.md
@@ -2,16 +2,16 @@
 name: Assign
 slug: assign
 sourceRef: it/map.go#L122
-category: it
+category: iter
 subCategory: map
 signatures:
   - "func Assign[K comparable, V any, Map ~map[K]V](maps ...iter.Seq[Map]) Map"
 variantHelpers:
-  - it#map#assign
+  - iter#map#assign
 similarHelpers:
   - core#map#assign
-  - it#map#fromentries
-  - it#map#invert
+  - iter#map#fromentries
+  - iter#map#invert
 position: 50
 ---
 

--- a/docs/data/it-associate.md
+++ b/docs/data/it-associate.md
@@ -2,7 +2,7 @@
 name: Associate
 slug: associate
 sourceRef: it/seq.go#L412
-category: it
+category: iter
 subCategory: map
 signatures:
   - "func Associate[T any, K comparable, V any](collection iter.Seq[T], transform func(item T) (K, V)) map[K]V"
@@ -12,16 +12,16 @@ signatures:
   - "func FilterSeqToMap[T any, K comparable, V any](collection iter.Seq[T], transform func(item T) (K, V, bool)) map[K]V"
   - "func FilterSeqToMapI[T any, K comparable, V any](collection iter.Seq[T], transform func(item T, index int) (K, V, bool)) map[K]V"
 variantHelpers:
-  - it#sequence#associate
-  - it#sequence#associatei
-  - it#sequence#seqtomap
-  - it#sequence#seqtomapi
-  - it#sequence#filterseqtomap
-  - it#sequence#filterseqtomapi
+  - iter#sequence#associate
+  - iter#sequence#associatei
+  - iter#sequence#seqtomap
+  - iter#sequence#seqtomapi
+  - iter#sequence#filterseqtomap
+  - iter#sequence#filterseqtomapi
 similarHelpers:
   - core#slice#associate
   - core#map#keyby
-  - it#map#keyby
+  - iter#map#keyby
 position: 140
 ---
 

--- a/docs/data/it-buffer.md
+++ b/docs/data/it-buffer.md
@@ -2,17 +2,17 @@
 name: Buffer
 slug: buffer
 sourceRef: it/seq.go#L1162
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Buffer[T any](seq iter.Seq[T], size int) iter.Seq[[]T]"
 playUrl: https://go.dev/play/p/zDZdcCA20ut
 variantHelpers:
-  - it#sequence#buffer
+  - iter#sequence#buffer
 similarHelpers:
-  - it#sequence#chunk
-  - it#sequence#sliding
-  - it#sequence#window
+  - iter#sequence#chunk
+  - iter#sequence#sliding
+  - iter#sequence#window
 position: 65
 ---
 

--- a/docs/data/it-channelseq.md
+++ b/docs/data/it-channelseq.md
@@ -2,15 +2,15 @@
 name: ChannelToSeq
 slug: channeltoseq
 sourceRef: it/channel.go#L39
-category: it
+category: iter
 subCategory: channel
 signatures:
   - "func ChannelToSeq[T any](ch <-chan T) iter.Seq[T]"
 playUrl: "https://go.dev/play/p/IXqSs2Ooqpm"
 variantHelpers:
-  - it#channel#channeltoseq
+  - iter#channel#channeltoseq
 similarHelpers:
-  - it#channel#seqtochannel
+  - iter#channel#seqtochannel
 position: 10
 ---
 

--- a/docs/data/it-channeltoseq.md
+++ b/docs/data/it-channeltoseq.md
@@ -2,16 +2,16 @@
 name: SeqToChannel2
 slug: channeltoseq
 sourceRef: it/channel.go#L26
-category: it
+category: iter
 subCategory: channel
 signatures:
   - "func SeqToChannel2[K, V any](bufferSize int, collection iter.Seq2[K, V]) <-chan lo.Tuple2[K, V]"
   - "func ChannelToSeq[T any](ch <-chan T) iter.Seq[T]"
 playUrl: "https://go.dev/play/p/IXqSs2Ooqpm"
 variantHelpers:
-  - it#channel#seqtochannel
-  - it#channel#seqtochannel2
-  - it#channel#channeltoseq
+  - iter#channel#seqtochannel
+  - iter#channel#seqtochannel2
+  - iter#channel#channeltoseq
 similarHelpers:
   - core#channel#channelseq
 position: 10

--- a/docs/data/it-chunk.md
+++ b/docs/data/it-chunk.md
@@ -2,16 +2,16 @@
 name: Chunk
 slug: chunk
 sourceRef: it/seq.go#L264
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Chunk[T any](collection iter.Seq[T], size int) iter.Seq[[]T]"
 playUrl: https://go.dev/play/p/qo8esZ_L60Q
 variantHelpers:
-  - it#sequence#chunk
+  - iter#sequence#chunk
 similarHelpers:
   - core#slice#chunk
-  - it#sequence#partitionby
+  - iter#sequence#partitionby
 position: 60
 ---
 

--- a/docs/data/it-chunkentries.md
+++ b/docs/data/it-chunkentries.md
@@ -2,17 +2,17 @@
 name: ChunkEntries
 slug: chunkentries
 sourceRef: it/map.go#L138
-category: it
+category: iter
 subCategory: map
 signatures:
   - "func ChunkEntries[K comparable, V any](m map[K]V, size int) iter.Seq[map[K]V]"
 variantHelpers:
-  - it#map#chunkentries
+  - iter#map#chunkentries
 similarHelpers:
   - core#map#chunkentries
-  - it#sequence#chunk
-  - it#map#keys
-  - it#map#values
+  - iter#sequence#chunk
+  - iter#map#keys
+  - iter#map#values
 position: 60
 ---
 

--- a/docs/data/it-chunkstring.md
+++ b/docs/data/it-chunkstring.md
@@ -2,11 +2,11 @@
 name: ChunkString
 slug: chunkstring
 sourceRef: it/string.go#L130
-category: it
+category: iter
 subCategory: string
 playUrl: "https://go.dev/play/p/Bcc5ixTQQoQ"
 variantHelpers:
-  - it#string#chunkstring
+  - iter#string#chunkstring
 similarHelpers:
   - core#string#chunkstring
 position: 0

--- a/docs/data/it-coalesceseq.md
+++ b/docs/data/it-coalesceseq.md
@@ -2,14 +2,14 @@
 name: CoalesceSeq
 slug: coalesceseq
 sourceRef: it/type_manipulation.go#L65
-category: it
+category: iter
 subCategory: type
 signatures:
   - "func CoalesceSeq[T any](v ...iter.Seq[T]) (iter.Seq[T], bool)"
 variantHelpers:
-  - it#type#coalesceseq
+  - iter#type#coalesceseq
 similarHelpers:
-  - it#type#coalesceseqorempty
+  - iter#type#coalesceseqorempty
   - core#type#coalesce
   - core#type#coalesceslice
 position: 100

--- a/docs/data/it-coalesceseqorempty.md
+++ b/docs/data/it-coalesceseqorempty.md
@@ -2,14 +2,14 @@
 name: CoalesceSeqOrEmpty
 slug: coalesceseqorempty
 sourceRef: it/type_manipulation.go#L76
-category: it
+category: iter
 subCategory: type
 signatures:
   - "func CoalesceSeqOrEmpty[T any](v ...iter.Seq[T]) iter.Seq[T]"
 variantHelpers:
-  - it#type#coalesceseqorempty
+  - iter#type#coalesceseqorempty
 similarHelpers:
-  - it#type#coalesceseq
+  - iter#type#coalesceseq
   - core#type#coalesceorempty
   - core#type#coalescesliceorempty
 position: 102

--- a/docs/data/it-compact.md
+++ b/docs/data/it-compact.md
@@ -2,12 +2,12 @@
 name: Compact
 slug: compact
 sourceRef: it/seq.go#L699
-category: it
+category: iter
 subCategory: slice
 signatures:
   - "func Compact[T comparable, I ~func(func(T) bool)](collection I) I"
 variantHelpers:
-  - it#slice#compact
+  - iter#slice#compact
 similarHelpers:
   - core#slice#compact
 position: 192

--- a/docs/data/it-concat.md
+++ b/docs/data/it-concat.md
@@ -2,13 +2,13 @@
 name: Concat
 slug: concat
 sourceRef: it/seq.go#L358
-category: it
+category: iter
 subCategory: sequence
 playUrl: https://go.dev/play/p/Fa0u7xT2JOR
 variantHelpers:
-  - it#sequence#concat
+  - iter#sequence#concat
 similarHelpers:
-  - it#sequence#flatten
+  - iter#sequence#flatten
   - core#slice#concat
 position: 160
 signatures:

--- a/docs/data/it-contains.md
+++ b/docs/data/it-contains.md
@@ -2,17 +2,17 @@
 name: Contains
 slug: contains
 sourceRef: it/intersect.go#L13
-category: it
+category: iter
 subCategory: intersect
 signatures:
   - "func Contains[T comparable](collection iter.Seq[T], element T) bool"
 playUrl: "https://go.dev/play/p/1edj7hH3TS2"
 variantHelpers:
-  - it#intersect#contains
+  - iter#intersect#contains
 similarHelpers:
   - core#slice#contains
-  - it#intersect#containsby
-  - it#intersect#some
+  - iter#intersect#containsby
+  - iter#intersect#some
 position: 0
 ---
 

--- a/docs/data/it-containsby.md
+++ b/docs/data/it-containsby.md
@@ -2,13 +2,13 @@
 name: ContainsBy
 slug: containsby
 sourceRef: it/intersect.go#L17
-category: it
+category: iter
 subCategory: intersect
 signatures:
   - "func ContainsBy[T any](collection iter.Seq[T], predicate func(item T) bool) bool"
 playUrl: https://go.dev/play/p/m86Cpsoyv8k
 variantHelpers:
-  - it#intersect#containsby
+  - iter#intersect#containsby
 similarHelpers:
   - core#slice#containsby
 position: 650

--- a/docs/data/it-count.md
+++ b/docs/data/it-count.md
@@ -2,18 +2,18 @@
 name: Count / CountBy
 slug: count
 sourceRef: it/seq.go#L630
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Count[T comparable](collection iter.Seq[T], value T) int"
   - "func CountBy[T any](collection iter.Seq[T], predicate func(item T) bool) int"
 playUrl: https://go.dev/play/p/UcJ-6cANwfY
 variantHelpers:
-  - it#sequence#count
-  - it#sequence#countby
+  - iter#sequence#count
+  - iter#sequence#countby
 similarHelpers:
   - core#slice#count
-  - it#sequence#countvalues
+  - iter#sequence#countvalues
 position: 110
 ---
 

--- a/docs/data/it-countby.md
+++ b/docs/data/it-countby.md
@@ -2,13 +2,13 @@
 name: CountBy
 slug: countby
 sourceRef: it/seq.go#L325
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func CountBy[T any](collection iter.Seq[T], predicate func(item T) bool) int"
 playUrl: https://go.dev/play/p/m6G0o3huCOG
 variantHelpers:
-  - it#find#count
+  - iter#find#count
 similarHelpers:
   - core#slice#countby
   - core#slice#count

--- a/docs/data/it-countvalues.md
+++ b/docs/data/it-countvalues.md
@@ -2,7 +2,7 @@
 name: CountValues
 slug: countvalues
 sourceRef: it/seq.go#L720
-category: it
+category: iter
 subCategory: slice
 signatures:
   - "func CountValues[T comparable](collection iter.Seq[T]) map[T]int"

--- a/docs/data/it-countvaluesby.md
+++ b/docs/data/it-countvaluesby.md
@@ -2,7 +2,7 @@
 name: CountValuesBy
 slug: countvaluesby
 sourceRef: it/seq.go#L720
-category: it
+category: iter
 subCategory: slice
 signatures:
   - "func CountValuesBy[T any, U comparable](collection iter.Seq[T], transform func(item T) U) map[U]int"

--- a/docs/data/it-crossjoinbyx.md
+++ b/docs/data/it-crossjoinbyx.md
@@ -2,7 +2,7 @@
 name: CrossJoinByX
 slug: crossjoinbyx
 sourceRef: it/tuples.go#L439
-category: it
+category: iter
 subCategory: tuple
 signatures:
   - "func CrossJoinBy2[T1, T2, R any](seq1 iter.Seq[T1], seq2 iter.Seq[T2], transform func(T1, T2) R) iter.Seq[R]"
@@ -15,10 +15,10 @@ signatures:
   - "func CrossJoinBy9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R any](seq1 iter.Seq[T1], seq2 iter.Seq[T2], seq3 iter.Seq[T3], seq4 iter.Seq[T4], seq5 iter.Seq[T5], seq6 iter.Seq[T6], seq7 iter.Seq[T7], seq8 iter.Seq[T8], seq9 iter.Seq[T9], transform func(T1, T2, T3, T4, T5, T6, T7, T8, T9) R) iter.Seq[R]"
 playUrl: https://go.dev/play/p/6QGp3W-bQU1
 variantHelpers:
-  - it#tuple#crossjoinbyx
+  - iter#tuple#crossjoinbyx
 similarHelpers:
   - core#tuple#crossjoinbyx
-  - it#tuple#crossjoinx
+  - iter#tuple#crossjoinx
   - core#slice#map
 position: 20
 ---

--- a/docs/data/it-crossjoinx.md
+++ b/docs/data/it-crossjoinx.md
@@ -2,7 +2,7 @@
 name: CrossJoinX
 slug: crossjoinx
 sourceRef: it/tuples.go#L370
-category: it
+category: iter
 subCategory: tuple
 signatures:
   - "func CrossJoin2[T1, T2 any](list1 iter.Seq[T1], list2 iter.Seq[T2]) iter.Seq[lo.Tuple2[T1, T2]]"
@@ -15,11 +15,11 @@ signatures:
   - "func CrossJoin9[T1, T2, T3, T4, T5, T6, T7, T8, T9 any](list1 iter.Seq[T1], list2 iter.Seq[T2], list3 iter.Seq[T3], list4 iter.Seq[T4], list5 iter.Seq[T5], list6 iter.Seq[T6], list7 iter.Seq[T7], list8 iter.Seq[T8], list9 iter.Seq[T9]) iter.Seq[lo.Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]]"
 playUrl: https://go.dev/play/p/OFe8xjZFjWU
 variantHelpers:
-  - it#tuple#crossjoinx
+  - iter#tuple#crossjoinx
 similarHelpers:
   - core#tuple#crossjoinx
-  - it#tuple#zipx
-  - it#tuple#crossjoinbyx
+  - iter#tuple#zipx
+  - iter#tuple#crossjoinbyx
 position: 10
 ---
 

--- a/docs/data/it-cutprefix.md
+++ b/docs/data/it-cutprefix.md
@@ -2,7 +2,7 @@
 name: CutPrefix
 slug: cutprefix
 sourceRef: it/seq.go#L778
-category: it
+category: iter
 subCategory: string
 signatures:
   - "func CutPrefix[T comparable, I ~func(func(T) bool)](collection I, separator []T) (after I, found bool)"

--- a/docs/data/it-cutsuffix.md
+++ b/docs/data/it-cutsuffix.md
@@ -2,7 +2,7 @@
 name: CutSuffix
 slug: cutsuffix
 sourceRef: it/seq.go#L778
-category: it
+category: iter
 subCategory: string
 signatures:
   - "func CutSuffix[T comparable, I ~func(func(T) bool)](collection I, separator []T) (before I, found bool)"

--- a/docs/data/it-drain.md
+++ b/docs/data/it-drain.md
@@ -2,7 +2,7 @@
 name: Drain
 slug: drain
 sourceRef: it/seq.go#L26
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Drain[T any](collection iter.Seq[T])"

--- a/docs/data/it-drop.md
+++ b/docs/data/it-drop.md
@@ -2,16 +2,16 @@
 name: Drop
 slug: drop
 sourceRef: it/seq.go#L498
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Drop[T any, I ~func(func(T) bool)](collection I, n int) I"
 playUrl: https://go.dev/play/p/O1J1-uWc3z9
 variantHelpers:
-  - it#sequence#drop
+  - iter#sequence#drop
 similarHelpers:
   - core#slice#drop
-  - it#sequence#droplast
+  - iter#sequence#droplast
 position: 100
 ---
 

--- a/docs/data/it-dropbyindex.md
+++ b/docs/data/it-dropbyindex.md
@@ -2,13 +2,13 @@
 name: DropByIndex
 slug: dropbyindex
 sourceRef: it/seq.go#L581
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func DropByIndex[T any, I ~func(func(T) bool)](collection I, indexes ...int) I"
 playUrl: https://go.dev/play/p/vPbrZYgiU4q
 variantHelpers:
-  - it#slice#drop
+  - iter#slice#drop
 similarHelpers:
   - core#slice#dropbyindex
   - core#slice#withoutnth

--- a/docs/data/it-droplast.md
+++ b/docs/data/it-droplast.md
@@ -2,18 +2,18 @@
 name: DropLast
 slug: droplast
 sourceRef: it/seq.go#L512
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func DropLast[T any, I ~func(func(T) bool)](collection I, n int) I"
 variantHelpers:
-  - it#sequence#droplast
+  - iter#sequence#droplast
 similarHelpers:
-  - it#sequence#drop
-  - it#sequence#dropwhile
-  - it#sequence#droplastwhile
-  - it#sequence#trim
-  - it#sequence#trimsuffix
+  - iter#sequence#drop
+  - iter#sequence#dropwhile
+  - iter#sequence#droplastwhile
+  - iter#sequence#trim
+  - iter#sequence#trimsuffix
 position: 78
 ---
 

--- a/docs/data/it-droplastwhile.md
+++ b/docs/data/it-droplastwhile.md
@@ -2,7 +2,7 @@
 name: DropLastWhile
 slug: droplastwhile
 sourceRef: it/seq.go#L180
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func DropLastWhile[T any, I ~func(func(T) bool)](collection I, predicate func(item T) bool) I"

--- a/docs/data/it-dropslice.md
+++ b/docs/data/it-dropslice.md
@@ -2,7 +2,7 @@
 name: DropLast
 slug: dropslice
 sourceRef: it/seq.go#L510
-category: it
+category: iter
 subCategory: slice
 signatures:
   - "func DropLast[T any, I ~func(func(T) bool)](collection I, n int) I"
@@ -10,10 +10,10 @@ signatures:
   - "func Subset[T any, I ~func(func(T) bool)](collection I, offset, length int) I"
   - "func Slice[T any, I ~func(func(T) bool)](collection I, start, end int) I"
 variantHelpers:
-  - it#slice#droplast
-  - it#slice#dropbyindex
-  - it#slice#subset
-  - it#slice#slice
+  - iter#slice#droplast
+  - iter#slice#dropbyindex
+  - iter#slice#subset
+  - iter#slice#slice
 similarHelpers:
   - core#slice#drop
   - core#slice#droplast

--- a/docs/data/it-dropwhile.md
+++ b/docs/data/it-dropwhile.md
@@ -2,14 +2,14 @@
 name: DropWhile
 slug: dropwhile
 sourceRef: it/seq.go#L180
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func DropWhile[T any, I ~func(func(T) bool)](collection I, predicate func(item T) bool) I"
 variantHelpers: []
 similarHelpers:
   - core#slice#dropwhile
-  - it#sequence#drop
+  - iter#sequence#drop
 position: 162
 ---
 

--- a/docs/data/it-earliest.md
+++ b/docs/data/it-earliest.md
@@ -2,13 +2,13 @@
 name: Earliest
 slug: earliest
 sourceRef: it/find.go#L278
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func Earliest(times iter.Seq[time.Time]) time.Time"
 playUrl: https://go.dev/play/p/fI6_S10H7Py
 variantHelpers:
-  - it#find#earliest
+  - iter#find#earliest
 similarHelpers:
   - core#slice#earliest
 position: 500

--- a/docs/data/it-earliestby.md
+++ b/docs/data/it-earliestby.md
@@ -2,13 +2,13 @@
 name: EarliestBy
 slug: earliestby
 sourceRef: it/find.go#L285
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func EarliestBy[T any](collection iter.Seq[T], transform func(item T) time.Time) T"
 playUrl: https://go.dev/play/p/y_Pf3Jmw-B4
 variantHelpers:
-  - it#find#earliestby
+  - iter#find#earliestby
 similarHelpers:
   - core#slice#earliestby
 position: 510

--- a/docs/data/it-elementsmatch.md
+++ b/docs/data/it-elementsmatch.md
@@ -2,13 +2,13 @@
 name: ElementsMatch
 slug: elementsmatch
 sourceRef: it/intersect.go#L174
-category: it
+category: iter
 subCategory: intersect
 signatures:
   - "func ElementsMatch[T comparable](list1, list2 iter.Seq[T]) bool"
 playUrl: "https://go.dev/play/p/24SGQm1yMRe"
 variantHelpers:
-  - it#intersect#elementsmatch
+  - iter#intersect#elementsmatch
 similarHelpers:
   - core#slice#elementsmatch
 position: 720

--- a/docs/data/it-elementsmatchby.md
+++ b/docs/data/it-elementsmatchby.md
@@ -2,13 +2,13 @@
 name: ElementsMatchBy
 slug: elementsmatchby
 sourceRef: it/intersect.go#L183
-category: it
+category: iter
 subCategory: intersect
 signatures:
   - "func ElementsMatchBy[T any, K comparable](list1, list2 iter.Seq[T], transform func(item T) K) bool"
 playUrl: "https://go.dev/play/p/I3vFrmQo43E"
 variantHelpers:
-  - it#intersect#elementsmatchby
+  - iter#intersect#elementsmatchby
 similarHelpers:
   - core#slice#elementsmatchby
 position: 730

--- a/docs/data/it-empty.md
+++ b/docs/data/it-empty.md
@@ -2,16 +2,16 @@
 name: Empty
 slug: empty
 sourceRef: it/type_manipulation.go#L44
-category: it
+category: iter
 subCategory: type
 signatures:
   - "func Empty[T any]() iter.Seq[T]"
 playUrl: "https://go.dev/play/p/E5fF1hH8Bc3"
 variantHelpers:
-  - it#type#empty
+  - iter#type#empty
 similarHelpers:
-  - it#type#isempty
-  - it#type#isnotempty
+  - iter#type#isempty
+  - iter#type#isnotempty
 position: 0
 ---
 

--- a/docs/data/it-entries.md
+++ b/docs/data/it-entries.md
@@ -2,17 +2,17 @@
 name: Entries
 slug: entries
 sourceRef: it/map.go#L77
-category: it
+category: iter
 subCategory: map
 signatures:
   - "func Entries[K comparable, V any](in ...map[K]V) iter.Seq2[K, V]"
 playUrl: https://go.dev/play/p/ckLxqTE9KCz
 variantHelpers:
-  - it#map#entries
+  - iter#map#entries
 similarHelpers:
   - core#slice#entries
-  - it#map#fromentries
-  - it#map#topairs
+  - iter#map#fromentries
+  - iter#map#topairs
 position: 20
 ---
 

--- a/docs/data/it-every.md
+++ b/docs/data/it-every.md
@@ -2,17 +2,17 @@
 name: Every
 slug: every
 sourceRef: it/intersect.go#L25
-category: it
+category: iter
 subCategory: intersect
 signatures:
   - "func Every[T comparable](collection iter.Seq[T], subset ...T) bool"
 playUrl: "https://go.dev/play/p/rwM9Y353aIC"
 variantHelpers:
-  - it#intersect#every
+  - iter#intersect#every
 similarHelpers:
   - core#slice#every
-  - it#intersect#some
-  - it#intersect#none
+  - iter#intersect#some
+  - iter#intersect#none
 position: 30
 ---
 

--- a/docs/data/it-everyby.md
+++ b/docs/data/it-everyby.md
@@ -2,13 +2,13 @@
 name: EveryBy
 slug: everyby
 sourceRef: it/intersect.go#L43
-category: it
+category: iter
 subCategory: intersect
 signatures:
   - "func EveryBy[T any](collection iter.Seq[T], predicate func(item T) bool) bool"
 playUrl: https://go.dev/play/p/7OvV1BRWsER
 variantHelpers:
-  - it#intersect#everyby
+  - iter#intersect#everyby
 similarHelpers:
   - core#slice#everyby
 position: 660

--- a/docs/data/it-fill.md
+++ b/docs/data/it-fill.md
@@ -2,7 +2,7 @@
 name: Fill
 slug: fill
 sourceRef: it/seq.go#L26
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Fill[T lo.Clonable[T], I ~func(func(T) bool)](collection I, initial T) I"

--- a/docs/data/it-filter.md
+++ b/docs/data/it-filter.md
@@ -2,19 +2,19 @@
 name: Filter
 slug: filter
 sourceRef: it/seq.go#L33
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Filter[T any, I ~func(func(T) bool)](collection I, predicate func(item T) bool) I"
   - "func FilterI[T any, I ~func(func(T) bool)](collection I, predicate func(item T, index int) bool) I"
 playUrl: "https://go.dev/play/p/psenko2KKsX"
 variantHelpers:
-  - it#sequence#filter
-  - it#sequence#filteri
+  - iter#sequence#filter
+  - iter#sequence#filteri
 similarHelpers:
   - core#slice#filter
   - core#slice#filteri
-  - it#sequence#reject
+  - iter#sequence#reject
 position: 10
 ---
 

--- a/docs/data/it-filterkeys.md
+++ b/docs/data/it-filterkeys.md
@@ -2,17 +2,17 @@
 name: FilterKeys
 slug: filterkeys
 sourceRef: it/map.go#L238
-category: it
+category: iter
 subCategory: map
 signatures:
   - "func FilterKeys[K comparable, V any](in map[K]V, predicate func(key K, value V) bool) []K"
 variantHelpers:
-  - it#map#filterkeys
+  - iter#map#filterkeys
 similarHelpers:
   - core#map#filterkeys
-  - it#map#filtervalues
-  - it#map#keys
-  - it#map#values
+  - iter#map#filtervalues
+  - iter#map#keys
+  - iter#map#values
 position: 56
 ---
 

--- a/docs/data/it-filtermap.md
+++ b/docs/data/it-filtermap.md
@@ -2,19 +2,19 @@
 name: FilterMap
 slug: filtermap
 sourceRef: it/seq.go#L86
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func FilterMap[T, R any](collection iter.Seq[T], callback func(item T) (R, bool)) iter.Seq[R]"
   - "func FilterMapI[T, R any](collection iter.Seq[T], callback func(item T, index int) (R, bool)) iter.Seq[R]"
 variantHelpers:
-  - it#sequence#filtermap
-  - it#sequence#filtermapi
+  - iter#sequence#filtermap
+  - iter#sequence#filtermapi
 similarHelpers:
-  - it#sequence#map
-  - it#sequence#filter
-  - it#sequence#filtermaptoslice
-  - it#sequence#rejectmap
+  - iter#sequence#map
+  - iter#sequence#filter
+  - iter#sequence#filtermaptoslice
+  - iter#sequence#rejectmap
 position: 40
 ---
 

--- a/docs/data/it-filtermaptoseq.md
+++ b/docs/data/it-filtermaptoseq.md
@@ -2,17 +2,17 @@
 name: FilterMapToSeq
 slug: filtermaptoseq
 sourceRef: it/map.go#L178
-category: it
+category: iter
 subCategory: map
 signatures:
   - "func FilterMapToSeq[K comparable, V, R any](in map[K]V, transform func(key K, value V) (R, bool)) iter.Seq[R]"
 variantHelpers:
-  - it#map#filtermaptoseq
+  - iter#map#filtermaptoseq
 similarHelpers:
-  - it#map#maptoseq
+  - iter#map#maptoseq
   - core#map#filtermaptoslice
-  - it#map#filterkeys
-  - it#map#filtervalues
+  - iter#map#filterkeys
+  - iter#map#filtervalues
 position: 54
 ---
 

--- a/docs/data/it-filtervalues.md
+++ b/docs/data/it-filtervalues.md
@@ -2,17 +2,17 @@
 name: FilterValues
 slug: filtervalues
 sourceRef: it/map.go#L253
-category: it
+category: iter
 subCategory: map
 signatures:
   - "func FilterValues[K comparable, V any](in map[K]V, predicate func(key K, value V) bool) []V"
 variantHelpers:
-  - it#map#filtervalues
+  - iter#map#filtervalues
 similarHelpers:
   - core#map#filtervalues
-  - it#map#filterkeys
-  - it#map#keys
-  - it#map#values
+  - iter#map#filterkeys
+  - iter#map#keys
+  - iter#map#values
 position: 58
 ---
 

--- a/docs/data/it-find.md
+++ b/docs/data/it-find.md
@@ -2,17 +2,17 @@
 name: Find
 slug: find
 sourceRef: it/find.go#L105
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func Find[T any](collection iter.Seq[T], predicate func(item T) bool) (T, bool)"
 playUrl: https://go.dev/play/p/4w28pF_l58a
 variantHelpers:
-  - it#find#find
+  - iter#find#find
 similarHelpers:
   - core#slice#find
-  - it#find#findindexof
-  - it#find#findorelse
+  - iter#find#findindexof
+  - iter#find#findorelse
 position: 40
 ---
 

--- a/docs/data/it-findduplicates.md
+++ b/docs/data/it-findduplicates.md
@@ -2,17 +2,17 @@
 name: FindDuplicates
 slug: findduplicates
 sourceRef: it/find.go#L196
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func FindDuplicates[T comparable, I ~func(func(T) bool)](collection I) I"
 playUrl: https://go.dev/play/p/dw-VLQXKijT
 variantHelpers:
-  - it#find#findduplicates
+  - iter#find#findduplicates
 similarHelpers:
   - core#slice#findduplicates
-  - it#find#finduniques
-  - it#find#findduplicatesby
+  - iter#find#finduniques
+  - iter#find#findduplicatesby
 position: 90
 ---
 

--- a/docs/data/it-findduplicatesby.md
+++ b/docs/data/it-findduplicatesby.md
@@ -2,13 +2,13 @@
 name: FindDuplicatesBy
 slug: findduplicatesby
 sourceRef: it/find.go#L200
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func FindDuplicatesBy[T any, U comparable, I ~func(func(T) bool)](collection I, transform func(item T) U) I"
 playUrl: https://go.dev/play/p/tm1tZdC93OH
 variantHelpers:
-  - it#find#findduplicatesby
+  - iter#find#findduplicatesby
 similarHelpers:
   - core#slice#findduplicatesby
 position: 640

--- a/docs/data/it-findindexof.md
+++ b/docs/data/it-findindexof.md
@@ -2,17 +2,17 @@
 name: FindIndexOf
 slug: findindexof
 sourceRef: it/find.go#L112
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func FindIndexOf[T any](collection iter.Seq[T], predicate func(item T) bool) (T, int, bool)"
 playUrl: https://go.dev/play/p/ihchBAEkhXO
 variantHelpers:
-  - it#find#findindexof
+  - iter#find#findindexof
 similarHelpers:
   - core#slice#findindexof
-  - it#find#find
-  - it#find#findlastindexof
+  - iter#find#find
+  - iter#find#findlastindexof
 position: 50
 ---
 

--- a/docs/data/it-findlastindexof.md
+++ b/docs/data/it-findlastindexof.md
@@ -2,17 +2,17 @@
 name: FindLastIndexOf
 slug: findlastindexof
 sourceRef: it/find.go#L127
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func FindLastIndexOf[T any](collection iter.Seq[T], predicate func(item T) bool) (T, int, bool)"
 playUrl: https://go.dev/play/p/ezz6hXaC4Md
 variantHelpers:
-  - it#find#findlastindexof
+  - iter#find#findlastindexof
 similarHelpers:
   - core#slice#findlastindexof
-  - it#find#findindexof
-  - it#find#find
+  - iter#find#findindexof
+  - iter#find#find
 position: 60
 ---
 

--- a/docs/data/it-findorelse.md
+++ b/docs/data/it-findorelse.md
@@ -2,16 +2,16 @@
 name: FindOrElse
 slug: findorelse
 sourceRef: it/find.go#L147
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func FindOrElse[T any](collection iter.Seq[T], fallback T, predicate func(item T) bool) T"
 playUrl: https://go.dev/play/p/1harvaiGMfI
 variantHelpers:
-  - it#find#findorelse
+  - iter#find#findorelse
 similarHelpers:
   - core#slice#findorelse
-  - it#find#find
+  - iter#find#find
 position: 70
 ---
 

--- a/docs/data/it-finduniques.md
+++ b/docs/data/it-finduniques.md
@@ -2,17 +2,17 @@
 name: FindUniques
 slug: finduniques
 sourceRef: it/find.go#L159
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func FindUniques[T comparable, I ~func(func(T) bool)](collection I) I"
 playUrl: https://go.dev/play/p/O8dwXEbT56F
 variantHelpers:
-  - it#find#finduniques
+  - iter#find#finduniques
 similarHelpers:
   - core#slice#finduniques
-  - it#find#findduplicates
-  - it#find#finduniquesby
+  - iter#find#findduplicates
+  - iter#find#finduniquesby
 position: 80
 ---
 

--- a/docs/data/it-finduniquesby.md
+++ b/docs/data/it-finduniquesby.md
@@ -2,13 +2,13 @@
 name: FindUniquesBy
 slug: finduniquesby
 sourceRef: it/find.go#L163
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func FindUniquesBy[T any, U comparable, I ~func(func(T) bool)](collection I, transform func(item T) U) I"
 playUrl: https://go.dev/play/p/TiwGIzeDuML
 variantHelpers:
-  - it#find#finduniquesby
+  - iter#find#finduniquesby
 similarHelpers:
   - core#slice#finduniquesby
 position: 630

--- a/docs/data/it-first.md
+++ b/docs/data/it-first.md
@@ -2,17 +2,17 @@
 name: First
 slug: first
 sourceRef: it/find.go#L362
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func First[T any](collection iter.Seq[T]) (T, bool)"
 playUrl: https://go.dev/play/p/EhNyrc8jPfY
 variantHelpers:
-  - it#find#first
+  - iter#find#first
 similarHelpers:
   - core#slice#first
-  - it#find#last
-  - it#find#firstor
+  - iter#find#last
+  - iter#find#firstor
 position: 120
 ---
 

--- a/docs/data/it-firstor.md
+++ b/docs/data/it-firstor.md
@@ -2,13 +2,13 @@
 name: FirstOr
 slug: firstor
 sourceRef: it/find.go#L377
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func FirstOr[T any](collection iter.Seq[T], fallback T) T"
 playUrl: https://go.dev/play/p/wGFXI5NHkE2
 variantHelpers:
-  - it#find#firstor
+  - iter#find#firstor
 similarHelpers:
   - core#slice#firstor
 position: 550

--- a/docs/data/it-firstorempty.md
+++ b/docs/data/it-firstorempty.md
@@ -2,13 +2,13 @@
 name: FirstOrEmpty
 slug: firstorempty
 sourceRef: it/find.go#L370
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func FirstOrEmpty[T any](collection iter.Seq[T]) T"
 playUrl: https://go.dev/play/p/NTUTgPCfevx
 variantHelpers:
-  - it#find#firstorempty
+  - iter#find#firstorempty
 similarHelpers:
   - core#slice#firstorempty
 position: 540

--- a/docs/data/it-flatmap.md
+++ b/docs/data/it-flatmap.md
@@ -2,18 +2,18 @@
 name: FlatMap
 slug: flatmap
 sourceRef: it/seq.go#L109
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func FlatMap[T, R any](collection iter.Seq[T], transform func(item T) iter.Seq[R]) iter.Seq[R]"
   - "func FlatMapI[T, R any](collection iter.Seq[T], transform func(item T, index int) iter.Seq[R]) iter.Seq[R]"
 playUrl: https://go.dev/play/p/6toB9w2gpSy
 variantHelpers:
-  - it#sequence#flatmap
-  - it#sequence#flatmapi
+  - iter#sequence#flatmap
+  - iter#sequence#flatmapi
 similarHelpers:
   - core#slice#flatmap
-  - it#sequence#map
+  - iter#sequence#map
 position: 120
 ---
 

--- a/docs/data/it-flatten.md
+++ b/docs/data/it-flatten.md
@@ -2,7 +2,7 @@
 name: Flatten
 slug: flatten
 sourceRef: it/seq.go#L26
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Flatten[T any, I ~func(func(T) bool)](collection []I) I"

--- a/docs/data/it-foreach.md
+++ b/docs/data/it-foreach.md
@@ -2,17 +2,17 @@
 name: ForEach
 slug: foreach
 sourceRef: it/seq.go#L166
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func ForEach[T any](collection iter.Seq[T], callback func(item T))"
 playUrl: "https://go.dev/play/p/agIsKpG-S-P"
 variantHelpers:
-  - it#sequence#foreach
-  - it#sequence#foreachi
+  - iter#sequence#foreach
+  - iter#sequence#foreachi
 similarHelpers:
   - core#slice#foreach
-  - it#sequence#map
+  - iter#sequence#map
 position: 40
 ---
 

--- a/docs/data/it-foreachwhile.md
+++ b/docs/data/it-foreachwhile.md
@@ -2,16 +2,16 @@
 name: ForEachWhile
 slug: foreachwhile
 sourceRef: it/seq.go#L180
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func ForEachWhile[T any](collection iter.Seq[T], predicate func(item T) bool)"
   - "func ForEachWhileI[T any](collection iter.Seq[T], predicate func(item T, index int) bool)"
 variantHelpers:
-  - it#sequence#foreachwhile
-  - it#sequence#foreachwhilei
+  - iter#sequence#foreachwhile
+  - iter#sequence#foreachwhilei
 similarHelpers:
-  - it#sequence#foreach
+  - iter#sequence#foreach
 position: 160
 ---
 

--- a/docs/data/it-fromanyseq.md
+++ b/docs/data/it-fromanyseq.md
@@ -2,12 +2,12 @@
 name: FromAnySeq
 slug: fromanyseq
 sourceRef: it/type_manipulation.go#L11
-category: it
+category: iter
 subCategory: type
 signatures:
   - "func FromAnySeq[T any](collection iter.Seq[any]) iter.Seq[T]"
 variantHelpers:
-  - it#type#toanyseq
+  - iter#type#toanyseq
 playUrl: "https://go.dev/play/p/wnOma1j5Uzu"
 similarHelpers:
   - core#type#fromany

--- a/docs/data/it-fromentries.md
+++ b/docs/data/it-fromentries.md
@@ -2,17 +2,17 @@
 name: FromEntries
 slug: fromentries
 sourceRef: it/map.go#L96
-category: it
+category: iter
 subCategory: map
 signatures:
   - "func FromEntries[K comparable, V any](entries ...iter.Seq2[K, V]) map[K]V"
 playUrl: https://go.dev/play/p/MgEF1J5-tuK
 variantHelpers:
-  - it#map#fromentries
-  - it#map#frompairs
+  - iter#map#fromentries
+  - iter#map#frompairs
 similarHelpers:
   - core#slice#fromentries
-  - it#map#entries
+  - iter#map#entries
 position: 30
 ---
 

--- a/docs/data/it-frompairs.md
+++ b/docs/data/it-frompairs.md
@@ -2,13 +2,13 @@
 name: FromPairs
 slug: frompairs
 sourceRef: it/map.go#L104
-category: it
+category: iter
 subCategory: map
 signatures:
   - "func FromPairs[K comparable, V any](entries ...iter.Seq2[K, V]) map[K]V"
 playUrl: "https://go.dev/play/p/K3wL9j7TmXs" 
 variantHelpers:
-  - it#map#fromentries
+  - iter#map#fromentries
 similarHelpers:
   - core#slice#frompairs
   - core#slice#fromentries

--- a/docs/data/it-fromseqptr.md
+++ b/docs/data/it-fromseqptr.md
@@ -2,12 +2,12 @@
 name: FromSeqPtr
 slug: fromseqptr
 sourceRef: it/type_manipulation.go#L11
-category: it
+category: iter
 subCategory: type
 signatures:
   - "func FromSeqPtr[T any](collection iter.Seq[*T]) iter.Seq[T]"
 variantHelpers:
-  - it#type#fromseqptror
+  - iter#type#fromseqptror
 playUrl: "https://go.dev/play/p/_eO6scpLcBF"
 similarHelpers:
   - core#type#fromptr

--- a/docs/data/it-fromseqptror.md
+++ b/docs/data/it-fromseqptror.md
@@ -2,12 +2,12 @@
 name: FromSeqPtrOr
 slug: fromseqptror
 sourceRef: it/type_manipulation.go#L11
-category: it
+category: iter
 subCategory: type
 signatures:
   - "func FromSeqPtrOr[T any](collection iter.Seq[*T], fallback T) iter.Seq[T]"
 variantHelpers:
-  - it#type#fromseqptr
+  - iter#type#fromseqptr
 playUrl: "https://go.dev/play/p/LJ17S4pvOjo"
 similarHelpers: []
 position: 242

--- a/docs/data/it-groupby.md
+++ b/docs/data/it-groupby.md
@@ -2,17 +2,17 @@
 name: GroupBy
 slug: groupby
 sourceRef: it/seq.go#L244
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func GroupBy[T any, U comparable](collection iter.Seq[T], transform func(item T) U) map[U][]T"
 playUrl: https://go.dev/play/p/oRIakS89OYy
 variantHelpers:
-  - it#sequence#groupby
+  - iter#sequence#groupby
 similarHelpers:
   - core#slice#groupby
-  - it#sequence#partitionby
-  - it#sequence#groupbymap
+  - iter#sequence#partitionby
+  - iter#sequence#groupbymap
 position: 80
 ---
 

--- a/docs/data/it-hasprefix.md
+++ b/docs/data/it-hasprefix.md
@@ -2,16 +2,16 @@
 name: HasPrefix
 slug: hasprefix
 sourceRef: it/find.go#L49
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func HasPrefix[T comparable](collection iter.Seq[T], prefix ...T) bool"
 playUrl: https://go.dev/play/p/Fyj6uq-G5IH
 variantHelpers:
-  - it#find#hasprefix
+  - iter#find#hasprefix
 similarHelpers:
   - core#slice#hasprefix
-  - it#find#hassuffix
+  - iter#find#hassuffix
 position: 20
 ---
 

--- a/docs/data/it-hassuffix.md
+++ b/docs/data/it-hassuffix.md
@@ -2,16 +2,16 @@
 name: HasSuffix
 slug: hassuffix
 sourceRef: it/find.go#L71
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func HasSuffix[T comparable](collection iter.Seq[T], suffix ...T) bool"
 playUrl: https://go.dev/play/p/r6bF9Rmq5S0
 variantHelpers:
-  - it#find#hassuffix
+  - iter#find#hassuffix
 similarHelpers:
   - core#slice#hassuffix
-  - it#find#hasprefix
+  - iter#find#hasprefix
 position: 30
 ---
 

--- a/docs/data/it-indexof.md
+++ b/docs/data/it-indexof.md
@@ -2,16 +2,16 @@
 name: IndexOf
 slug: indexof
 sourceRef: it/find.go#L19
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func IndexOf[T comparable](collection iter.Seq[T], element T) int"
 playUrl: "https://go.dev/play/p/1OZHU2yfb-m"
 variantHelpers:
-  - it#find#indexof
+  - iter#find#indexof
 similarHelpers:
   - core#slice#indexof
-  - it#find#lastindexof
+  - iter#find#lastindexof
 position: 0
 ---
 

--- a/docs/data/it-interleave.md
+++ b/docs/data/it-interleave.md
@@ -2,7 +2,7 @@
 name: Interleave
 slug: interleave
 sourceRef: it/seq.go#L26
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Interleave[T any](collections ...iter.Seq[T]) iter.Seq[T]"

--- a/docs/data/it-intersect.md
+++ b/docs/data/it-intersect.md
@@ -2,18 +2,18 @@
 name: Intersect
 slug: intersect
 sourceRef: it/intersect.go#L78
-category: it
+category: iter
 subCategory: intersect
 signatures:
   - "func Intersect[T comparable, I ~func(func(T) bool)](lists ...I) I"
 playUrl: "https://go.dev/play/p/kz3cGhGZZWF"
 variantHelpers:
-  - it#intersect#intersect
+  - iter#intersect#intersect
 similarHelpers:
-  - it#intersect#intersectby
+  - iter#intersect#intersectby
   - core#slice#intersect
   - core#slice#intersectby
-  - it#intersect#union
+  - iter#intersect#union
 position: 10
 ---
 

--- a/docs/data/it-intersectby.md
+++ b/docs/data/it-intersectby.md
@@ -2,18 +2,18 @@
 name: IntersectBy
 slug: intersectby
 sourceRef: it/intersect.go#L78
-category: it
+category: iter
 subCategory: intersect
 signatures:
   - "func IntersectBy[T any, K comparable, I ~func(func(T) bool)](func(T) K, lists ...I) I"
 playUrl: https://go.dev/play/p/X2nEvHC-lE2
 variantHelpers:
-  - it#intersect#intersectby
+  - iter#intersect#intersectby
 similarHelpers:
-  - it#intersect#intersect
+  - iter#intersect#intersect
   - core#slice#intersect
   - core#slice#intersectby
-  - it#intersect#union
+  - iter#intersect#union
 position: 10
 ---
 

--- a/docs/data/it-invert.md
+++ b/docs/data/it-invert.md
@@ -2,16 +2,16 @@
 name: Invert
 slug: invert
 sourceRef: it/map.go#L111
-category: it
+category: iter
 subCategory: map
 signatures:
   - "func Invert[K, V comparable](in iter.Seq2[K, V]) iter.Seq2[V, K]"
 playUrl: https://go.dev/play/p/Iph19Lgcsx-
 variantHelpers:
-  - it#map#invert
+  - iter#map#invert
 similarHelpers:
   - core#slice#invert
-  - it#map#entries
+  - iter#map#entries
 position: 40
 ---
 

--- a/docs/data/it-isempty.md
+++ b/docs/data/it-isempty.md
@@ -2,17 +2,17 @@
 name: IsEmpty
 slug: isempty
 sourceRef: it/type_manipulation.go#L50
-category: it
+category: iter
 subCategory: type
 signatures:
   - "func IsEmpty[T any](collection iter.Seq[T]) bool"
 playUrl: https://go.dev/play/p/krZ-laaVi2C
 variantHelpers:
-  - it#type#isempty
+  - iter#type#isempty
 similarHelpers:
-  - it#type#isnotempty
-  - it#type#empty
-  - it#sequence#length
+  - iter#type#isnotempty
+  - iter#type#empty
+  - iter#sequence#length
 position: 10
 ---
 

--- a/docs/data/it-isnotempty.md
+++ b/docs/data/it-isnotempty.md
@@ -2,13 +2,13 @@
 name: IsNotEmpty
 slug: isnotempty
 sourceRef: it/type_manipulation.go#L59
-category: it
+category: iter
 subCategory: condition
 signatures:
   - "func IsNotEmpty[T any](collection iter.Seq[T]) bool"
 playUrl: "https://go.dev/play/p/G7hH3jJ0De5" 
 variantHelpers:
-  - it#condition#isempty
+  - iter#condition#isempty
 similarHelpers:
   - core#slice#isnotempty
   - core#slice#isempty

--- a/docs/data/it-issorted.md
+++ b/docs/data/it-issorted.md
@@ -2,7 +2,7 @@
 name: IsSorted
 slug: issorted
 sourceRef: it/seq.go#L720
-category: it
+category: iter
 subCategory: slice
 signatures:
   - "func IsSorted[T constraints.Ordered](collection iter.Seq[T]) bool"

--- a/docs/data/it-issortedby.md
+++ b/docs/data/it-issortedby.md
@@ -2,7 +2,7 @@
 name: IsSortedBy
 slug: issortedby
 sourceRef: it/seq.go#L720
-category: it
+category: iter
 subCategory: slice
 signatures:
   - "func IsSortedBy[T any, K constraints.Ordered](collection iter.Seq[T], transform func(item T) K) bool"

--- a/docs/data/it-keyby.md
+++ b/docs/data/it-keyby.md
@@ -2,13 +2,13 @@
 name: KeyBy
 slug: keyby
 sourceRef: it/seq.go#L398
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func KeyBy[K comparable, V any](collection iter.Seq[V], transform func(item V) K) map[K]V"
 playUrl: https://go.dev/play/p/MMaHpzTqY0a
 variantHelpers:
-  - it#map#associate
+  - iter#map#associate
 similarHelpers:
   - core#slice#keyby
   - core#slice#associate

--- a/docs/data/it-keyify.md
+++ b/docs/data/it-keyify.md
@@ -2,7 +2,7 @@
 name: Keyify
 slug: keyify
 sourceRef: it/seq.go#L720
-category: it
+category: iter
 subCategory: slice
 signatures:
   - "func Keyify[T comparable](collection iter.Seq[T]) map[T]struct{}"

--- a/docs/data/it-keys.md
+++ b/docs/data/it-keys.md
@@ -2,17 +2,17 @@
 name: Keys
 slug: keys
 sourceRef: it/map.go#L11
-category: it
+category: iter
 subCategory: map
 signatures:
   - "func Keys[K comparable, V any](in ...map[K]V) iter.Seq[K]"
 playUrl: "https://go.dev/play/p/Fu7h-eW18QM"
 variantHelpers:
-  - it#map#keys
+  - iter#map#keys
 similarHelpers:
   - core#slice#keys
-  - it#map#values
-  - it#map#uniqkeys
+  - iter#map#values
+  - iter#map#uniqkeys
 position: 0
 ---
 

--- a/docs/data/it-last.md
+++ b/docs/data/it-last.md
@@ -2,17 +2,17 @@
 name: Last
 slug: last
 sourceRef: it/find.go#L389
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func Last[T any](collection iter.Seq[T]) (T, bool)"
 playUrl: https://go.dev/play/p/eGZV-sSmn_Q
 variantHelpers:
-  - it#find#last
+  - iter#find#last
 similarHelpers:
   - core#slice#last
-  - it#find#first
-  - it#find#lastor
+  - iter#find#first
+  - iter#find#lastor
 position: 130
 ---
 

--- a/docs/data/it-lastindexof.md
+++ b/docs/data/it-lastindexof.md
@@ -2,16 +2,16 @@
 name: LastIndexOf
 slug: lastindexof
 sourceRef: it/find.go#L34
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func LastIndexOf[T comparable](collection iter.Seq[T], element T) int"
 playUrl: https://go.dev/play/p/QPATR3VC5wT
 variantHelpers:
-  - it#find#lastindexof
+  - iter#find#lastindexof
 similarHelpers:
   - core#slice#lastindexof
-  - it#find#indexof
+  - iter#find#indexof
 position: 10
 ---
 

--- a/docs/data/it-lastor.md
+++ b/docs/data/it-lastor.md
@@ -2,13 +2,13 @@
 name: LastOr
 slug: lastor
 sourceRef: it/find.go#L407
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func LastOr[T any](collection iter.Seq[T], fallback T) T"
 playUrl: https://go.dev/play/p/HNubjW2Mrxs
 variantHelpers:
-  - it#find#lastor
+  - iter#find#lastor
 similarHelpers:
   - core#slice#lastor
 position: 570

--- a/docs/data/it-lastorempty.md
+++ b/docs/data/it-lastorempty.md
@@ -2,13 +2,13 @@
 name: LastOrEmpty
 slug: lastorempty
 sourceRef: it/find.go#L400
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func LastOrEmpty[T any](collection iter.Seq[T]) T"
 playUrl: https://go.dev/play/p/teODFK4YqM4
 variantHelpers:
-  - it#find#lastorempty
+  - iter#find#lastorempty
 similarHelpers:
   - core#slice#lastorempty
 position: 560

--- a/docs/data/it-latest.md
+++ b/docs/data/it-latest.md
@@ -2,13 +2,13 @@
 name: Latest
 slug: latest
 sourceRef: it/find.go#L346
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func Latest(times iter.Seq[time.Time]) time.Time"
 playUrl: https://go.dev/play/p/r5Yq6ATSHoH
 variantHelpers:
-  - it#find#latest
+  - iter#find#latest
 similarHelpers:
   - core#slice#latest
 position: 520

--- a/docs/data/it-latestby.md
+++ b/docs/data/it-latestby.md
@@ -2,13 +2,13 @@
 name: LatestBy
 slug: latestby
 sourceRef: it/find.go#L353
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func LatestBy[T any](collection iter.Seq[T], transform func(item T) time.Time) T"
 playUrl: https://go.dev/play/p/o_daRzHrDUU
 variantHelpers:
-  - it#find#latestby
+  - iter#find#latestby
 similarHelpers:
   - core#slice#latestby
 position: 530

--- a/docs/data/it-length.md
+++ b/docs/data/it-length.md
@@ -2,17 +2,17 @@
 name: Length
 slug: length
 sourceRef: it/seq.go#L16
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Length[T any](collection iter.Seq[T]) int"
 playUrl: "https://go.dev/play/p/3dnbOjTbL-o"
 variantHelpers:
-  - it#sequence#length
+  - iter#sequence#length
 similarHelpers:
   - core#slice#length
-  - it#sequence#isempty
-  - it#sequence#isnotempty
+  - iter#sequence#isempty
+  - iter#sequence#isnotempty
 position: 0
 ---
 

--- a/docs/data/it-map.md
+++ b/docs/data/it-map.md
@@ -2,19 +2,19 @@
 name: Map
 slug: map
 sourceRef: it/seq.go#L51
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Map[T, R any](collection iter.Seq[T], transform func(item T) R) iter.Seq[R]"
   - "func MapI[T, R any](collection iter.Seq[T], transform func(item T, index int) R) iter.Seq[R]"
 playUrl: "https://go.dev/play/p/rWZiPB-RZOo"
 variantHelpers:
-  - it#sequence#map
-  - it#sequence#mapi
+  - iter#sequence#map
+  - iter#sequence#mapi
 similarHelpers:
   - core#slice#map
-  - it#sequence#filtermap
-  - it#sequence#flatmap
+  - iter#sequence#filtermap
+  - iter#sequence#flatmap
 position: 20
 ---
 

--- a/docs/data/it-maptoseq.md
+++ b/docs/data/it-maptoseq.md
@@ -2,18 +2,18 @@
 name: MapToSeq
 slug: maptoseq
 sourceRef: it/map.go#L164
-category: it
+category: iter
 subCategory: map
 signatures:
   - "func MapToSeq[K comparable, V, R any](in map[K]V, transform func(key K, value V) R) iter.Seq[R]"
 variantHelpers:
-  - it#map#maptoseq
+  - iter#map#maptoseq
 similarHelpers:
   - core#map#maptoslice
-  - it#map#values
-  - it#map#keys
-  - it#map#entries
-  - it#map#filtermaptoseq
+  - iter#map#values
+  - iter#map#keys
+  - iter#map#entries
+  - iter#map#filtermaptoseq
 position: 52
 ---
 

--- a/docs/data/it-max.md
+++ b/docs/data/it-max.md
@@ -2,17 +2,17 @@
 name: Max
 slug: max
 sourceRef: it/find.go#L295
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func Max[T constraints.Ordered](collection iter.Seq[T]) T"
 playUrl: https://go.dev/play/p/C2ZtW2bsBZ6
 variantHelpers:
-  - it#find#max
+  - iter#find#max
 similarHelpers:
   - core#slice#max
-  - it#find#min
-  - it#find#maxby
+  - iter#find#min
+  - iter#find#maxby
 position: 110
 ---
 

--- a/docs/data/it-maxby.md
+++ b/docs/data/it-maxby.md
@@ -2,17 +2,17 @@
 name: MaxBy
 slug: maxby
 sourceRef: it/find.go#L310
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func MaxBy[T any](collection iter.Seq[T], comparison func(a, b T) bool) T"
 playUrl: https://go.dev/play/p/yBhXFJb5oxC
 variantHelpers:
-  - it#find#maxby
+  - iter#find#maxby
 similarHelpers:
   - core#slice#maxby
-  - it#find#minby
-  - it#find#max
+  - iter#find#minby
+  - iter#find#max
 position: 150
 ---
 

--- a/docs/data/it-maxindex.md
+++ b/docs/data/it-maxindex.md
@@ -2,13 +2,13 @@
 name: MaxIndex
 slug: maxindex
 sourceRef: it/find.go#L299
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func MaxIndex[T constraints.Ordered](collection iter.Seq[T]) (T, int)"
 playUrl: https://go.dev/play/p/zeu2wUvhl5e
 variantHelpers:
-  - it#find#maxindex
+  - iter#find#maxindex
 similarHelpers:
   - core#slice#maxindex
 position: 480

--- a/docs/data/it-maxindexby.md
+++ b/docs/data/it-maxindexby.md
@@ -2,13 +2,13 @@
 name: MaxIndexBy
 slug: maxindexby
 sourceRef: it/find.go#L326
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func MaxIndexBy[T any](collection iter.Seq[T], comparison func(a, b T) bool) (T, int)"
 playUrl: https://go.dev/play/p/MXyE6BTILjx
 variantHelpers:
-  - it#find#maxindexby
+  - iter#find#maxindexby
 similarHelpers:
   - core#slice#maxindexby
 position: 490

--- a/docs/data/it-mean.md
+++ b/docs/data/it-mean.md
@@ -2,15 +2,15 @@
 name: Mean / MeanBy
 slug: mean
 sourceRef: it/math.go#L80
-category: it
+category: iter
 subCategory: math
 signatures:
   - "func Mean[T constraints.Float | constraints.Integer](collection iter.Seq[T]) T"
   - "func MeanBy[T any, R constraints.Float | constraints.Integer](collection iter.Seq[T], iteratee func(item T) R) R"
 playUrl: "https://go.dev/play/p/Lez0CsvVRl_l"
 variantHelpers:
-  - it#math#mean
-  - it#math#meanby
+  - iter#math#mean
+  - iter#math#meanby
 similarHelpers:
   - core#slice#mean
   - core#slice#meanby

--- a/docs/data/it-meanby.md
+++ b/docs/data/it-meanby.md
@@ -2,13 +2,13 @@
 name: MeanBy
 slug: meanby
 sourceRef: it/math.go#L106
-category: it
+category: iter
 subCategory: math
 signatures:
   - "func MeanBy[T any, R constraints.Float | constraints.Integer](collection iter.Seq[T], transform func(item T) R) R"
 playUrl: https://go.dev/play/p/Ked4rpztH5Y
 variantHelpers:
-  - it#math#mean
+  - iter#math#mean
 similarHelpers:
   - core#slice#meanby
   - core#slice#mean

--- a/docs/data/it-min.md
+++ b/docs/data/it-min.md
@@ -2,17 +2,17 @@
 name: Min
 slug: min
 sourceRef: it/find.go#L227
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func Min[T constraints.Ordered](collection iter.Seq[T]) T"
 playUrl: https://go.dev/play/p/0VihyYEaM-M
 variantHelpers:
-  - it#find#min
+  - iter#find#min
 similarHelpers:
   - core#slice#min
-  - it#find#max
-  - it#find#minby
+  - iter#find#max
+  - iter#find#minby
 position: 100
 ---
 

--- a/docs/data/it-minby.md
+++ b/docs/data/it-minby.md
@@ -2,17 +2,17 @@
 name: MinBy
 slug: minby
 sourceRef: it/find.go#L242
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func MinBy[T any](collection iter.Seq[T], comparison func(a, b T) bool) T"
 playUrl: https://go.dev/play/p/J5koo8khN-g
 variantHelpers:
-  - it#find#minby
+  - iter#find#minby
 similarHelpers:
   - core#slice#minby
-  - it#find#maxby
-  - it#find#min
+  - iter#find#maxby
+  - iter#find#min
 position: 140
 ---
 

--- a/docs/data/it-minindex.md
+++ b/docs/data/it-minindex.md
@@ -2,13 +2,13 @@
 name: MinIndex
 slug: minindex
 sourceRef: it/find.go#L231
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func MinIndex[T constraints.Ordered](collection iter.Seq[T]) (T, int)"
 playUrl: https://go.dev/play/p/70ncPxECj6l
 variantHelpers:
-  - it#find#minindex
+  - iter#find#minindex
 similarHelpers:
   - core#slice#minindex
 position: 460

--- a/docs/data/it-minindexby.md
+++ b/docs/data/it-minindexby.md
@@ -2,13 +2,13 @@
 name: MinIndexBy
 slug: minindexby
 sourceRef: it/find.go#L258
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func MinIndexBy[T any](collection iter.Seq[T], comparison func(a, b T) bool) (T, int)"
 playUrl: https://go.dev/play/p/blldzWJpqVa
 variantHelpers:
-  - it#find#minindexby
+  - iter#find#minindexby
 similarHelpers:
   - core#slice#minindexby
 position: 470

--- a/docs/data/it-mode.md
+++ b/docs/data/it-mode.md
@@ -2,13 +2,13 @@
 name: Mode
 slug: mode
 sourceRef: it/math.go#L124
-category: it
+category: iter
 subCategory: math
 signatures:
   - "func Mode[T constraints.Integer | constraints.Float](collection iter.Seq[T]) []T"
 playUrl: "https://go.dev/play/p/c_cmMMA5EhH"
 variantHelpers:
-  - it#math#mode
+  - iter#math#mode
 similarHelpers:
   - core#slice#mode
 position: 40

--- a/docs/data/it-none.md
+++ b/docs/data/it-none.md
@@ -2,13 +2,13 @@
 name: None
 slug: none
 sourceRef: it/intersect.go#L63
-category: it
+category: iter
 subCategory: intersect
 signatures:
   - "func None[T comparable](collection iter.Seq[T], subset ...T) bool"
 playUrl: "https://go.dev/play/p/L7mm5S4a8Yo"
 variantHelpers:
-  - it#intersect#none
+  - iter#intersect#none
 similarHelpers:
   - core#slice#none
 position: 680

--- a/docs/data/it-noneby.md
+++ b/docs/data/it-noneby.md
@@ -2,13 +2,13 @@
 name: NoneBy
 slug: noneby
 sourceRef: it/intersect.go#L69
-category: it
+category: iter
 subCategory: intersect
 signatures:
   - "func NoneBy[T any](collection iter.Seq[T], predicate func(item T) bool) bool"
 playUrl: https://go.dev/play/p/PR7ddQ7Ckz5
 variantHelpers:
-  - it#intersect#noneby
+  - iter#intersect#noneby
 similarHelpers:
   - core#slice#noneby
 position: 690

--- a/docs/data/it-nth.md
+++ b/docs/data/it-nth.md
@@ -2,13 +2,13 @@
 name: Nth
 slug: nth
 sourceRef: it/find.go#L417
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func Nth[T any, N constraints.Integer](collection iter.Seq[T], nth N) (T, error)"
 playUrl: https://go.dev/play/p/FqgCobsKqva
 variantHelpers:
-  - it#find#nth
+  - iter#find#nth
 similarHelpers:
   - core#slice#nth
 position: 580

--- a/docs/data/it-nthor.md
+++ b/docs/data/it-nthor.md
@@ -2,13 +2,13 @@
 name: NthOr
 slug: nthor
 sourceRef: it/find.go#L433
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func NthOr[T any, N constraints.Integer](collection iter.Seq[T], nth N, fallback T) T"
 playUrl: https://go.dev/play/p/MNweuhpy4Ym
 variantHelpers:
-  - it#find#nthor
+  - iter#find#nthor
 similarHelpers:
   - core#slice#nthor
 position: 590

--- a/docs/data/it-nthorempty.md
+++ b/docs/data/it-nthorempty.md
@@ -2,13 +2,13 @@
 name: NthOrEmpty
 slug: nthorempty
 sourceRef: it/find.go#L444
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func NthOrEmpty[T any, N constraints.Integer](collection iter.Seq[T], nth N) T"
 playUrl: https://go.dev/play/p/pC0Zhu3EUhe
 variantHelpers:
-  - it#find#nthorempty
+  - iter#find#nthorempty
 similarHelpers:
   - core#slice#nthorempty
 position: 600

--- a/docs/data/it-partitionby.md
+++ b/docs/data/it-partitionby.md
@@ -2,7 +2,7 @@
 name: PartitionBy
 slug: partitionby
 sourceRef: it/seq.go#L26
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func PartitionBy[T any, K comparable](collection iter.Seq[T], transform func(item T) K) [][]T"

--- a/docs/data/it-product.md
+++ b/docs/data/it-product.md
@@ -2,15 +2,15 @@
 name: Product / ProductBy
 slug: product
 sourceRef: it/math.go#L70
-category: it
+category: iter
 subCategory: math
 signatures:
   - "func Product[T constraints.Float | constraints.Integer | constraints.Complex](collection iter.Seq[T]) T"
   - "func ProductBy[T any, R constraints.Float | constraints.Integer | constraints.Complex](collection iter.Seq[T], iteratee func(item T) R) R"
 playUrl: "https://go.dev/play/p/AOMCD1Yl5Bc"
 variantHelpers:
-  - it#math#product
-  - it#math#productby
+  - iter#math#product
+  - iter#math#productby
 similarHelpers:
   - core#slice#product
   - core#slice#productby

--- a/docs/data/it-productby.md
+++ b/docs/data/it-productby.md
@@ -2,13 +2,13 @@
 name: ProductBy
 slug: productby
 sourceRef: it/math.go#L90
-category: it
+category: iter
 subCategory: math
 signatures:
   - "func ProductBy[T any, R constraints.Float | constraints.Integer | constraints.Complex](collection iter.Seq[T], transform func(item T) R) R"
 playUrl: "https://go.dev/play/p/dgFCRJrlPHY"
 variantHelpers:
-  - it#math#product
+  - iter#math#product
 similarHelpers:
   - core#slice#productby
   - core#slice#product

--- a/docs/data/it-range.md
+++ b/docs/data/it-range.md
@@ -2,17 +2,17 @@
 name: Range
 slug: range
 sourceRef: it/math.go#L12
-category: it
+category: iter
 subCategory: math
 signatures:
   - "func Range(elementNum int) iter.Seq[int]"
 playUrl: "https://go.dev/play/p/79QUZBa8Ukn"
 variantHelpers:
-  - it#math#range
+  - iter#math#range
 similarHelpers:
   - core#slice#range
-  - it#math#rangefrom
-  - it#math#rangewithsteps
+  - iter#math#rangefrom
+  - iter#math#rangewithsteps
 position: 0
 ---
 

--- a/docs/data/it-rangefrom.md
+++ b/docs/data/it-rangefrom.md
@@ -2,17 +2,17 @@
 name: RangeFrom
 slug: rangefrom
 sourceRef: it/math.go#L25
-category: it
+category: iter
 subCategory: math
 signatures:
   - "func RangeFrom[T constraints.Integer | constraints.Float](start T, elementNum int) iter.Seq[T]"
 playUrl: "https://go.dev/play/p/WHP_NI5scj9"
 variantHelpers:
-  - it#math#rangefrom
+  - iter#math#rangefrom
 similarHelpers:
   - core#slice#rangefrom
-  - it#math#range
-  - it#math#rangewithsteps
+  - iter#math#range
+  - iter#math#rangewithsteps
 position: 10
 ---
 

--- a/docs/data/it-rangewithsteps.md
+++ b/docs/data/it-rangewithsteps.md
@@ -2,17 +2,17 @@
 name: RangeWithSteps
 slug: rangewithsteps
 sourceRef: it/math.go#L35
-category: it
+category: iter
 subCategory: math
 signatures:
   - "func RangeWithSteps[T constraints.Integer | constraints.Float](start, end, step T) iter.Seq[T]"
 playUrl: "https://go.dev/play/p/qxm2YNLG0vT"
 variantHelpers:
-  - it#math#rangewithsteps
+  - iter#math#rangewithsteps
 similarHelpers:
   - core#slice#rangewithsteps
-  - it#math#range
-  - it#math#rangefrom
+  - iter#math#range
+  - iter#math#rangefrom
 position: 20
 ---
 

--- a/docs/data/it-reduce.md
+++ b/docs/data/it-reduce.md
@@ -2,15 +2,15 @@
 name: Reduce
 slug: reduce
 sourceRef: it/seq.go#L133
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Reduce[T, R any](collection iter.Seq[T], accumulator func(agg R, item T) R, initial R) R"
   - "func ReduceI[T, R any](collection iter.Seq[T], accumulator func(agg R, item T, index int) R, initial R) R"
 playUrl: "https://go.dev/play/p/FmkVUf39ZP_Y"
 variantHelpers:
-  - it#sequence#reduce
-  - it#sequence#reducei
+  - iter#sequence#reduce
+  - iter#sequence#reducei
 similarHelpers:
   - core#slice#reduce
   - core#slice#reducei

--- a/docs/data/it-reducelast.md
+++ b/docs/data/it-reducelast.md
@@ -2,17 +2,17 @@
 name: ReduceLast
 slug: reducelast
 sourceRef: it/seq.go#L153
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func ReduceLast[T, R any](collection iter.Seq[T], accumulator func(agg R, item T) R, initial R) R"
   - "func ReduceLastI[T, R any](collection iter.Seq[T], accumulator func(agg R, item T, index int) R, initial R) R"
 playUrl: https://go.dev/play/p/D2ZGZ2pN270
 variantHelpers:
-  - it#sequence#reduce
-  - it#sequence#reducei
-  - it#sequence#reducelast
-  - it#sequence#reducelasti
+  - iter#sequence#reduce
+  - iter#sequence#reducei
+  - iter#sequence#reducelast
+  - iter#sequence#reducelasti
 similarHelpers:
   - core#slice#reducelast
   - core#slice#reducelasti

--- a/docs/data/it-reject.md
+++ b/docs/data/it-reject.md
@@ -2,7 +2,7 @@
 name: Reject
 slug: reject
 sourceRef: it/seq.go#L586
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Reject[T any, I ~func(func(T) bool)](collection I, predicate func(item T) bool) I"
@@ -10,15 +10,15 @@ signatures:
   - "func RejectMap[T, R any](collection iter.Seq[T], callback func(item T) (R, bool)) iter.Seq[R]"
   - "func RejectMapI[T, R any](collection iter.Seq[T], callback func(item T, index int) (R, bool)) iter.Seq[R]"
 variantHelpers:
-  - it#sequence#reject
-  - it#sequence#rejecti
-  - it#sequence#rejectmap
-  - it#sequence#rejectmapi
+  - iter#sequence#reject
+  - iter#sequence#rejecti
+  - iter#sequence#rejectmap
+  - iter#sequence#rejectmapi
 similarHelpers:
   - core#slice#reject
   - core#slice#filter
-  - it#sequence#filter
-  - it#sequence#filtermap
+  - iter#sequence#filter
+  - iter#sequence#filtermap
 position: 180
 ---
 

--- a/docs/data/it-rejectmap.md
+++ b/docs/data/it-rejectmap.md
@@ -2,17 +2,17 @@
 name: RejectMap
 slug: rejectmap
 sourceRef: it/seq.go#L608
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func RejectMap[T, R any](collection iter.Seq[T], callback func(item T) (R, bool)) iter.Seq[R]"
 variantHelpers:
-  - it#sequence#rejectmap
+  - iter#sequence#rejectmap
 similarHelpers:
-  - it#sequence#filtermap
-  - it#sequence#map
-  - it#sequence#filter
-  - it#sequence#reject
+  - iter#sequence#filtermap
+  - iter#sequence#map
+  - iter#sequence#filter
+  - iter#sequence#reject
 position: 42
 ---
 

--- a/docs/data/it-repeat.md
+++ b/docs/data/it-repeat.md
@@ -2,13 +2,13 @@
 name: Repeat
 slug: repeat
 sourceRef: it/seq.go#L384
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Repeat[T lo.Clonable[T]](count int, initial T) iter.Seq[T]"
 playUrl: https://go.dev/play/p/xs-aq0p_uDP
 variantHelpers:
-  - it#slice#repeatby
+  - iter#slice#repeatby
 similarHelpers:
   - core#slice#repeat
   - core#slice#repeatby

--- a/docs/data/it-repeatby.md
+++ b/docs/data/it-repeatby.md
@@ -2,17 +2,17 @@
 name: RepeatBy
 slug: repeatby
 sourceRef: it/seq.go#L388
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func RepeatBy[T any](count int, callback func(index int) T) iter.Seq[T]"
 playUrl: https://go.dev/play/p/i7BuZQBcUzZ
 variantHelpers:
-  - it#sequence#repeatby
+  - iter#sequence#repeatby
 similarHelpers:
   - core#slice#repeat
   - core#slice#times
-  - it#sequence#times
+  - iter#sequence#times
 position: 130
 ---
 

--- a/docs/data/it-replace.md
+++ b/docs/data/it-replace.md
@@ -2,12 +2,12 @@
 name: Replace
 slug: replace
 sourceRef: it/seq.go#L699
-category: it
+category: iter
 subCategory: slice
 signatures:
   - "func Replace[T comparable, I ~func(func(T) bool)](collection I, old, nEw T, n int) I"
 variantHelpers:
-  - it#slice#replace
+  - iter#slice#replace
 similarHelpers:
   - core#slice#replace
 position: 190

--- a/docs/data/it-replaceall.md
+++ b/docs/data/it-replaceall.md
@@ -2,12 +2,12 @@
 name: ReplaceAll
 slug: replaceall
 sourceRef: it/seq.go#L699
-category: it
+category: iter
 subCategory: slice
 signatures:
   - "func ReplaceAll[T comparable, I ~func(func(T) bool)](collection I, old, nEw T) I"
 variantHelpers:
-  - it#slice#replaceall
+  - iter#slice#replaceall
 similarHelpers:
   - core#slice#replaceall
 position: 191

--- a/docs/data/it-reverse.md
+++ b/docs/data/it-reverse.md
@@ -2,16 +2,16 @@
 name: Reverse
 slug: reverse
 sourceRef: it/seq.go#L366
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Reverse[T any, I ~func(func(T) bool)](collection I) I"
 playUrl: https://go.dev/play/p/R6-lR8yiNwa
 variantHelpers:
-  - it#sequence#reverse
+  - iter#sequence#reverse
 similarHelpers:
   - core#slice#reverse
-  - it#sequence#shuffle
+  - iter#sequence#shuffle
 position: 90
 ---
 

--- a/docs/data/it-sample.md
+++ b/docs/data/it-sample.md
@@ -2,18 +2,18 @@
 name: Sample
 slug: sample
 sourceRef: it/find.go#L455
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func Sample[T any](collection iter.Seq[T]) T"
 playUrl: https://go.dev/play/p/YDJVX0UXYDi
 variantHelpers:
-  - it#find#sample
+  - iter#find#sample
 similarHelpers:
   - core#slice#sample
-  - it#find#samples
-  - it#find#sampleBy
-  - it#find#samplesBy
+  - iter#find#samples
+  - iter#find#sampleBy
+  - iter#find#samplesBy
 position: 160
 ---
 

--- a/docs/data/it-sampleby.md
+++ b/docs/data/it-sampleby.md
@@ -2,18 +2,18 @@
 name: SampleBy
 slug: sampleby
 sourceRef: it/find.go#L455
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func SampleBy[T any](collection iter.Seq[T], randomIntGenerator func(int) int) T"
 playUrl: https://go.dev/play/p/QQooySxORib
 variantHelpers:
-  - it#find#sampleby
+  - iter#find#sampleby
 similarHelpers:
   - core#slice#sample
-  - it#find#sample
-  - it#find#samples
-  - it#find#samplesby
+  - iter#find#sample
+  - iter#find#samples
+  - iter#find#samplesby
 position: 160
 ---
 

--- a/docs/data/it-samples.md
+++ b/docs/data/it-samples.md
@@ -2,18 +2,18 @@
 name: Samples
 slug: samples
 sourceRef: it/find.go#L467
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func Samples[T any, I ~func(func(T) bool)](collection I, count int) I"
 playUrl: https://go.dev/play/p/GUTFx9LQ8pP
 variantHelpers:
-  - it#find#samples
+  - iter#find#samples
 similarHelpers:
   - core#slice#samples
-  - it#find#sample
-  - it#find#sampleby
-  - it#find#samplesby
+  - iter#find#sample
+  - iter#find#sampleby
+  - iter#find#samplesby
 position: 610
 ---
 

--- a/docs/data/it-samplesby.md
+++ b/docs/data/it-samplesby.md
@@ -2,18 +2,18 @@
 name: SamplesBy
 slug: samplesby
 sourceRef: it/find.go#L474
-category: it
+category: iter
 subCategory: find
 signatures:
   - "func SamplesBy[T any, I ~func(func(T) bool)](collection I, count int, randomIntGenerator func(int) int) I"
 playUrl: https://go.dev/play/p/fX2FEtixrVG
 variantHelpers:
-  - it#find#samplesby
+  - iter#find#samplesby
 similarHelpers:
   - core#slice#samplesby
-  - it#find#sample
-  - it#find#samples
-  - it#find#sampleby
+  - iter#find#sample
+  - iter#find#samples
+  - iter#find#sampleby
 position: 620
 ---
 

--- a/docs/data/it-seqtochannel.md
+++ b/docs/data/it-seqtochannel.md
@@ -2,17 +2,17 @@
 name: SeqToChannel
 slug: seqtochannel
 sourceRef: it/channel.go#L12
-category: it
+category: iter
 subCategory: channel
 signatures:
   - "func SeqToChannel[T any](bufferSize int, collection iter.Seq[T]) <-chan T"
   - "func SeqToChannel2[K, V any](bufferSize int, collection iter.Seq2[K, V]) <-chan Tuple2[K, V]"
 playUrl: "https://go.dev/play/p/id3jqJPffT6"
 variantHelpers:
-  - it#channel#seqtochannel
-  - it#channel#seqtochannel2
+  - iter#channel#seqtochannel
+  - iter#channel#seqtochannel2
 similarHelpers:
-  - it#channel#channeltoseq
+  - iter#channel#channeltoseq
 position: 0
 ---
 

--- a/docs/data/it-sequencestate.md
+++ b/docs/data/it-sequencestate.md
@@ -2,7 +2,7 @@
 name: Empty
 slug: sequencestate
 sourceRef: it/type_manipulation.go#L43
-category: it
+category: iter
 subCategory: type
 signatures:
   - "func Empty[T any]() iter.Seq[T]"
@@ -11,11 +11,11 @@ signatures:
   - "func CoalesceSeq[T any](v ...iter.Seq[T]) (iter.Seq[T], bool)"
   - "func CoalesceSeqOrEmpty[T any](v ...iter.Seq[T]) iter.Seq[T]"
 variantHelpers:
-  - it#type#empty
-  - it#type#isempty
-  - it#type#isnotempty
-  - it#type#coalesceseq
-  - it#type#coalesceseqorempty
+  - iter#type#empty
+  - iter#type#isempty
+  - iter#type#isnotempty
+  - iter#type#coalesceseq
+  - iter#type#coalesceseqorempty
 similarHelpers:
   - core#type#isempty
   - core#type#isnotempty

--- a/docs/data/it-shuffle.md
+++ b/docs/data/it-shuffle.md
@@ -2,16 +2,16 @@
 name: Shuffle
 slug: shuffle
 sourceRef: it/seq.go#L357
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Shuffle[T any, I ~func(func(T) bool)](collection I) I"
 playUrl: https://go.dev/play/p/3WOx-ukGvKK
 variantHelpers:
-  - it#sequence#shuffle
+  - iter#sequence#shuffle
 similarHelpers:
   - core#slice#shuffle
-  - it#sequence#reverse
+  - iter#sequence#reverse
 position: 130
 ---
 

--- a/docs/data/it-slice.md
+++ b/docs/data/it-slice.md
@@ -2,13 +2,13 @@
 name: Slice
 slug: slice
 sourceRef: it/seq.go#L680
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Slice[T any, I ~func(func(T) bool)](collection I, start, end int) I"
 playUrl: "https://go.dev/play/p/5WqJN9-zv" 
 variantHelpers:
-  - it#slice#drop
+  - iter#slice#drop
 similarHelpers:
   - core#slice#slice
   - core#slice#chunk

--- a/docs/data/it-sliding.md
+++ b/docs/data/it-sliding.md
@@ -2,13 +2,13 @@
 name: Sliding
 slug: sliding
 sourceRef: it/seq.go#L329
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Sliding[T any](collection iter.Seq[T], size, step int) iter.Seq[[]T]"
 playUrl: https://go.dev/play/p/mzhO4CZeiik
 variantHelpers:
-  - it#sequence#sliding
+  - iter#sequence#sliding
 similarHelpers:
   - core#slice#sliding
 position: 80

--- a/docs/data/it-some.md
+++ b/docs/data/it-some.md
@@ -2,17 +2,17 @@
 name: Some
 slug: some
 sourceRef: it/intersect.go#L52
-category: it
+category: iter
 subCategory: intersect
 signatures:
   - "func Some[T comparable](collection iter.Seq[T], subset ...T) bool"
 playUrl: "https://go.dev/play/p/KmX-fXictQl"
 variantHelpers:
-  - it#intersect#some
+  - iter#intersect#some
 similarHelpers:
   - core#slice#some
-  - it#intersect#every
-  - it#intersect#none
+  - iter#intersect#every
+  - iter#intersect#none
 position: 40
 ---
 

--- a/docs/data/it-someby.md
+++ b/docs/data/it-someby.md
@@ -2,13 +2,13 @@
 name: SomeBy
 slug: someby
 sourceRef: it/intersect.go#L56
-category: it
+category: iter
 subCategory: intersect
 signatures:
   - "func SomeBy[T any](collection iter.Seq[T], predicate func(item T) bool) bool"
 playUrl: https://go.dev/play/p/PDT6dWCl7Md
 variantHelpers:
-  - it#intersect#someby
+  - iter#intersect#someby
 similarHelpers:
   - core#slice#someby
 position: 670

--- a/docs/data/it-splice.md
+++ b/docs/data/it-splice.md
@@ -2,16 +2,16 @@
 name: Splice
 slug: splice
 sourceRef: it/seq.go#L744
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Splice[T any, I ~func(func(T) bool)](collection I, index int, elements ...T) I"
 variantHelpers:
-  - it#sequence#splice
+  - iter#sequence#splice
 similarHelpers:
-  - it#sequence#slice
-  - it#sequence#replace
-  - it#sequence#replaceall
+  - iter#sequence#slice
+  - iter#sequence#replace
+  - iter#sequence#replaceall
   - core#slice#splice
 position: 122
 ---

--- a/docs/data/it-subset.md
+++ b/docs/data/it-subset.md
@@ -2,16 +2,16 @@
 name: Subset
 slug: subset
 sourceRef: it/seq.go#L667
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Subset[T any, I ~func(func(T) bool)](collection I, offset, length int) I"
 variantHelpers:
-  - it#sequence#subset
+  - iter#sequence#subset
 similarHelpers:
-  - it#sequence#slice
-  - it#sequence#drop
-  - it#sequence#dropright
+  - iter#sequence#slice
+  - iter#sequence#drop
+  - iter#sequence#dropright
   - core#slice#slice
 position: 120
 ---

--- a/docs/data/it-sum.md
+++ b/docs/data/it-sum.md
@@ -2,15 +2,15 @@
 name: Sum / SumBy
 slug: sum
 sourceRef: it/math.go#L59
-category: it
+category: iter
 subCategory: math
 signatures:
   - "func Sum[T constraints.Float | constraints.Integer | constraints.Complex](collection iter.Seq[T]) T"
   - "func SumBy[T any, R constraints.Float | constraints.Integer | constraints.Complex](collection iter.Seq[T], iteratee func(item T) R) R"
 playUrl: "https://go.dev/play/p/nHbGFOEIeTa"
 variantHelpers:
-  - it#math#sum
-  - it#math#sumby
+  - iter#math#sum
+  - iter#math#sumby
 similarHelpers:
   - core#slice#sum
   - core#slice#sumby

--- a/docs/data/it-sumby.md
+++ b/docs/data/it-sumby.md
@@ -2,13 +2,13 @@
 name: SumBy
 slug: sumby
 sourceRef: it/math.go#L74
-category: it
+category: iter
 subCategory: math
 signatures:
   - "func SumBy[T any, R constraints.Float | constraints.Integer | constraints.Complex](collection iter.Seq[T], transform func(item T) R) R"
 playUrl: https://go.dev/play/p/ZNiqXNMu5QP
 variantHelpers:
-  - it#math#sumby
+  - iter#math#sumby
 similarHelpers:
   - core#slice#sumby
   - core#slice#sum

--- a/docs/data/it-take.md
+++ b/docs/data/it-take.md
@@ -2,12 +2,12 @@
 name: Take
 slug: take
 sourceRef: it/seq.go#L682
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Take[T any, I ~func(func(T) bool)](collection I, n int) I"
 variantHelpers:
-  - it#sequence#take
+  - iter#sequence#take
 similarHelpers:
   - core#slice#take
 position: 110

--- a/docs/data/it-takefilter.md
+++ b/docs/data/it-takefilter.md
@@ -2,15 +2,15 @@
 name: TakeFilter
 slug: takefilter
 sourceRef: it/seq.go#L725
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func TakeFilter[T any, I ~func(func(T) bool)](collection I, n int, predicate func(item T) bool) I"
   - "func TakeFilterI[T any, I ~func(func(T) bool)](collection I, n int, predicate func(item T, index int) bool) I"
 playUrl: https://go.dev/play/p/Db68Bhu4MCA
 variantHelpers:
-  - it#sequence#takefilter
-  - it#sequence#takefilteri
+  - iter#sequence#takefilter
+  - iter#sequence#takefilteri
 similarHelpers:
   - core#slice#takefilter
 position: 130

--- a/docs/data/it-takewhile.md
+++ b/docs/data/it-takewhile.md
@@ -2,12 +2,12 @@
 name: TakeWhile
 slug: takewhile
 sourceRef: it/seq.go#L706
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func TakeWhile[T any, I ~func(func(T) bool)](collection I, predicate func(item T) bool) I"
 variantHelpers:
-  - it#sequence#takewhile
+  - iter#sequence#takewhile
 similarHelpers:
   - core#slice#takewhile
 position: 120

--- a/docs/data/it-times.md
+++ b/docs/data/it-times.md
@@ -2,16 +2,16 @@
 name: Times
 slug: times
 sourceRef: it/seq.go#L202
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Times[T any](count int, callback func(index int) T) iter.Seq[T]"
 playUrl: https://go.dev/play/p/0W4IRzQuCEc
 variantHelpers:
-  - it#sequence#times
+  - iter#sequence#times
 similarHelpers:
   - core#slice#times
-  - it#math#range
+  - iter#math#range
 position: 70
 ---
 

--- a/docs/data/it-toanyseq.md
+++ b/docs/data/it-toanyseq.md
@@ -2,12 +2,12 @@
 name: ToAnySeq
 slug: toanyseq
 sourceRef: it/type_manipulation.go#L11
-category: it
+category: iter
 subCategory: type
 signatures:
   - "func ToAnySeq[T any](collection iter.Seq[T]) iter.Seq[any]"
 variantHelpers:
-  - it#type#fromanyseq
+  - iter#type#fromanyseq
 playUrl: "https://go.dev/play/p/ktE4IMXDMxv"
 similarHelpers:
   - core#type#toany

--- a/docs/data/it-toseqptr.md
+++ b/docs/data/it-toseqptr.md
@@ -2,7 +2,7 @@
 name: ToSeqPtr
 slug: toseqptr
 sourceRef: it/type_manipulation.go#L11
-category: it
+category: iter
 subCategory: type
 signatures:
   - "func ToSeqPtr[T any](collection iter.Seq[T]) iter.Seq[*T]"

--- a/docs/data/it-trim.md
+++ b/docs/data/it-trim.md
@@ -2,14 +2,14 @@
 name: Trim
 slug: trim
 sourceRef: it/seq.go#L778
-category: it
+category: iter
 subCategory: string
 signatures:
   - "func Trim[T comparable, I ~func(func(T) bool)](collection I, cutset ...T) I"
 playUrl: https://go.dev/play/p/k0VCcilk4V1
 variantHelpers:
-  - it#string#trimfirst
-  - it#string#trimlast
+  - iter#string#trimfirst
+  - iter#string#trimlast
 similarHelpers:
   - core#string#trim
 position: 262

--- a/docs/data/it-trimfirst.md
+++ b/docs/data/it-trimfirst.md
@@ -2,14 +2,14 @@
 name: TrimFirst
 slug: trimfirst
 sourceRef: it/seq.go#L778
-category: it
+category: iter
 subCategory: string
 signatures:
   - "func TrimFirst[T comparable, I ~func(func(T) bool)](collection I, cutset ...T) I"
 playUrl: https://go.dev/play/p/4D4Ke5C5MwH
 variantHelpers:
-  - it#string#trim
-  - it#string#trimlast
+  - iter#string#trim
+  - iter#string#trimlast
 similarHelpers: []
 position: 263
 ---

--- a/docs/data/it-trimlast.md
+++ b/docs/data/it-trimlast.md
@@ -2,14 +2,14 @@
 name: TrimLast
 slug: trimlast
 sourceRef: it/seq.go#L778
-category: it
+category: iter
 subCategory: string
 signatures:
   - "func TrimLast[T comparable, I ~func(func(T) bool)](collection I, cutset ...T) I"
 playUrl: https://go.dev/play/p/GQLhnaeW0gd
 variantHelpers:
-  - it#string#trim
-  - it#string#trimfirst
+  - iter#string#trim
+  - iter#string#trimfirst
 similarHelpers: []
 position: 264
 ---

--- a/docs/data/it-trimprefix.md
+++ b/docs/data/it-trimprefix.md
@@ -2,7 +2,7 @@
 name: TrimPrefix
 slug: trimprefix
 sourceRef: it/seq.go#L778
-category: it
+category: iter
 subCategory: string
 signatures:
   - "func TrimPrefix[T comparable, I ~func(func(T) bool)](collection I, prefix []T) I"

--- a/docs/data/it-trimsuffix.md
+++ b/docs/data/it-trimsuffix.md
@@ -2,7 +2,7 @@
 name: TrimSuffix
 slug: trimsuffix
 sourceRef: it/seq.go#L778
-category: it
+category: iter
 subCategory: string
 signatures:
   - "func TrimSuffix[T comparable, I ~func(func(T) bool)](collection I, suffix []T) I"

--- a/docs/data/it-union.md
+++ b/docs/data/it-union.md
@@ -2,16 +2,16 @@
 name: Union
 slug: union
 sourceRef: it/intersect.go#L136
-category: it
+category: iter
 subCategory: intersect
 signatures:
   - "func Union[T comparable, I ~func(func(T) bool)](lists ...I) I"
 playUrl: "https://go.dev/play/p/ImIoFNpSUUB"
 variantHelpers:
-  - it#intersect#union
+  - iter#intersect#union
 similarHelpers:
   - core#slice#union
-  - it#intersect#intersect
+  - iter#intersect#intersect
 position: 20
 ---
 

--- a/docs/data/it-uniq.md
+++ b/docs/data/it-uniq.md
@@ -2,16 +2,16 @@
 name: Uniq
 slug: uniq
 sourceRef: it/seq.go#L216
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Uniq[T comparable, I ~func(func(T) bool)](collection I) I"
 playUrl: https://go.dev/play/p/D-SenTW-ipj
 variantHelpers:
-  - it#sequence#uniq
+  - iter#sequence#uniq
 similarHelpers:
   - core#slice#uniq
-  - it#sequence#uniqby
+  - iter#sequence#uniqby
 position: 50
 ---
 

--- a/docs/data/it-uniqby.md
+++ b/docs/data/it-uniqby.md
@@ -2,13 +2,13 @@
 name: UniqBy
 slug: uniqby
 sourceRef: it/seq.go#L225
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func UniqBy[T any, U comparable, I ~func(func(T) bool)](collection I, transform func(item T) U) I"
 playUrl: https://go.dev/play/p/HKrt3AvwMTR
 variantHelpers:
-  - it#slice#uniq
+  - iter#slice#uniq
 similarHelpers:
   - core#slice#uniqby
   - core#slice#uniq

--- a/docs/data/it-uniqkeys.md
+++ b/docs/data/it-uniqkeys.md
@@ -2,13 +2,13 @@
 name: UniqKeys
 slug: uniqkeys
 sourceRef: it/map.go#L26
-category: it
+category: iter
 subCategory: map
 signatures:
   - "func UniqKeys[K comparable, V any](in ...map[K]V) iter.Seq[K]"
 playUrl: "https://go.dev/play/p/_NicwfgAHbO"
 variantHelpers:
-  - it#map#uniqkeys
+  - iter#map#uniqkeys
 similarHelpers:
   - core#slice#uniqkeys
 position: 800

--- a/docs/data/it-uniqvalues.md
+++ b/docs/data/it-uniqvalues.md
@@ -2,13 +2,13 @@
 name: UniqValues
 slug: uniqvalues
 sourceRef: it/map.go#L59
-category: it
+category: iter
 subCategory: map
 signatures:
   - "func UniqValues[K, V comparable](in ...map[K]V) iter.Seq[V]"
 playUrl: https://go.dev/play/p/QQv4zGrk-fF
 variantHelpers:
-  - it#map#uniqvalues
+  - iter#map#uniqvalues
 similarHelpers:
   - core#slice#uniqvalues
 position: 810

--- a/docs/data/it-values.md
+++ b/docs/data/it-values.md
@@ -2,17 +2,17 @@
 name: Values
 slug: values
 sourceRef: it/map.go#L44
-category: it
+category: iter
 subCategory: map
 signatures:
   - "func Values[K comparable, V any](in ...map[K]V) iter.Seq[V]"
 playUrl: https://go.dev/play/p/-WehUfGtC6C
 variantHelpers:
-  - it#map#values
+  - iter#map#values
 similarHelpers:
   - core#slice#values
-  - it#map#keys
-  - it#map#uniqvalues
+  - iter#map#keys
+  - iter#map#uniqvalues
 position: 10
 ---
 

--- a/docs/data/it-window.md
+++ b/docs/data/it-window.md
@@ -2,13 +2,13 @@
 name: Window
 slug: window
 sourceRef: it/seq.go#L318
-category: it
+category: iter
 subCategory: sequence
 signatures:
   - "func Window[T any](collection iter.Seq[T], size int) iter.Seq[[]T]"
 playUrl: https://go.dev/play/p/_1BzQYtKBhi
 variantHelpers:
-  - it#sequence#window
+  - iter#sequence#window
 similarHelpers:
   - core#slice#window
 position: 70

--- a/docs/data/it-without.md
+++ b/docs/data/it-without.md
@@ -2,16 +2,16 @@
 name: Without
 slug: without
 sourceRef: it/intersect.go#L155
-category: it
+category: iter
 subCategory: intersect
 signatures:
   - "func Without[T comparable, I ~func(func(T) bool)](collection I, exclude ...T) I"
 playUrl: "https://go.dev/play/p/LbN55AVBZ7h"
 variantHelpers:
-  - it#intersect#without
+  - iter#intersect#without
 similarHelpers:
   - core#slice#without
-  - it#intersect#intersect
+  - iter#intersect#intersect
 position: 50
 ---
 

--- a/docs/data/it-withoutby.md
+++ b/docs/data/it-withoutby.md
@@ -2,13 +2,13 @@
 name: WithoutBy
 slug: withoutby
 sourceRef: it/intersect.go#L159
-category: it
+category: iter
 subCategory: intersect
 signatures:
   - "func WithoutBy[T any, K comparable, I ~func(func(T) bool)](collection I, transform func(item T) K, exclude ...K) I"
 playUrl: "https://go.dev/play/p/Hm734hnLnLI"
 variantHelpers:
-  - it#intersect#withoutby
+  - iter#intersect#withoutby
 similarHelpers:
   - core#slice#withoutby
 position: 700

--- a/docs/data/it-withoutnth.md
+++ b/docs/data/it-withoutnth.md
@@ -2,13 +2,13 @@
 name: WithoutNth
 slug: withoutnth
 sourceRef: it/intersect.go#L167
-category: it
+category: iter
 subCategory: intersect
 signatures:
   - "func WithoutNth[T comparable, I ~func(func(T) bool)](collection I, nths ...int) I"
 playUrl: "https://go.dev/play/p/KGE7Lpsk18P"
 variantHelpers:
-  - it#intersect#withoutnth
+  - iter#intersect#withoutnth
 similarHelpers:
   - core#slice#withoutnth
 position: 710

--- a/docs/data/it-zipbyx.md
+++ b/docs/data/it-zipbyx.md
@@ -2,7 +2,7 @@
 name: ZipByX
 slug: zipbyx
 sourceRef: it/tuples.go#L295
-category: it
+category: iter
 subCategory: tuple
 signatures:
   - "func ZipBy2[T1, T2, R any](seq1 iter.Seq[T1], seq2 iter.Seq[T2], transform func(T1, T2) R) iter.Seq[R]"
@@ -15,10 +15,10 @@ signatures:
   - "func ZipBy9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R any](seq1 iter.Seq[T1], seq2 iter.Seq[T2], seq3 iter.Seq[T3], seq4 iter.Seq[T4], seq5 iter.Seq[T5], seq6 iter.Seq[T6], seq7 iter.Seq[T7], seq8 iter.Seq[T8], seq9 iter.Seq[T9], transform func(T1, T2, T3, T4, T5, T6, T7, T8, T9) R) iter.Seq[R]"
 playUrl: https://go.dev/play/p/y03uqMEAi1E
 variantHelpers:
-  - it#tuple#zipbyx
+  - iter#tuple#zipbyx
 similarHelpers:
   - core#tuple#zipbyx
-  - it#tuple#zipx
+  - iter#tuple#zipx
   - core#slice#map
 position: 10
 ---

--- a/docs/data/it-zipx.md
+++ b/docs/data/it-zipx.md
@@ -2,7 +2,7 @@
 name: ZipX
 slug: zipx
 sourceRef: it/tuples.go#L14
-category: it
+category: iter
 subCategory: tuple
 signatures:
   - "func Zip2[T1, T2 any](list1 iter.Seq[T1], list2 iter.Seq[T2]) iter.Seq[lo.Tuple2[T1, T2]]"
@@ -15,11 +15,11 @@ signatures:
   - "func Zip9[T1, T2, T3, T4, T5, T6, T7, T8, T9 any](list1 iter.Seq[T1], list2 iter.Seq[T2], list3 iter.Seq[T3], list4 iter.Seq[T4], list5 iter.Seq[T5], list6 iter.Seq[T6], list7 iter.Seq[T7], list8 iter.Seq[T8], list9 iter.Seq[T9]) iter.Seq[lo.Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]]"
 playUrl: "https://go.dev/play/p/U5nBWvR8eUZ"
 variantHelpers:
-  - it#tuple#zipx
+  - iter#tuple#zipx
 similarHelpers:
   - core#tuple#zipx
-  - it#tuple#crossjoinx
-  - it#tuple#zipbyx
+  - iter#tuple#crossjoinx
+  - iter#tuple#zipbyx
 position: 0
 ---
 

--- a/docs/data/mutable-filter.md
+++ b/docs/data/mutable-filter.md
@@ -10,7 +10,7 @@ similarHelpers:
   - core#slice#filterreject
   - core#slice#filtermap
   - parallel#slice#filter
-  - it#chunkstring
+  - iter#chunkstring
 variantHelpers:
   - "mutable#slice#filter"
   - "mutable#slice#filteri"

--- a/docs/data/simd-clamp.md
+++ b/docs/data/simd-clamp.md
@@ -2,10 +2,10 @@
 name: Clamp
 slug: clamp
 sourceRef: exp/simd/math_avx.go#L453
-category: exp
+category: experimental
 subCategory: simd
 similarHelpers:
-  - exp#simd#clamp
+  - experimental#simd#clamp
 position: 40
 signatures:
   - "func ClampInt8x16[T ~int8, Slice ~[]T](collection Slice, min, max T) Slice"

--- a/docs/data/simd-contains.md
+++ b/docs/data/simd-contains.md
@@ -2,10 +2,10 @@
 name: Contains
 slug: contains
 sourceRef: exp/simd/intersect_avx512.go#L9
-category: exp
+category: experimental
 subCategory: simd
 similarHelpers:
-  - exp#simd#contains
+  - experimental#simd#contains
 position: 0
 signatures:
   - "func ContainsInt8x16[T ~int8](collection []T, target T) bool"

--- a/docs/data/simd-max.md
+++ b/docs/data/simd-max.md
@@ -2,10 +2,10 @@
 name: Max
 slug: max
 sourceRef: exp/simd/math_avx.go#L1279
-category: exp
+category: experimental
 subCategory: simd
 similarHelpers:
-  - exp#simd#max
+  - experimental#simd#max
 position: 30
 signatures:
   - "func MaxInt8x16[T ~int8](collection []T) T"

--- a/docs/data/simd-mean.md
+++ b/docs/data/simd-mean.md
@@ -2,11 +2,11 @@
 name: Mean
 slug: mean
 sourceRef: exp/simd/math_avx.go#L352
-category: exp
+category: experimental
 subCategory: simd
 similarHelpers:
-  - exp#simd#mean
-  - exp#simd#meanby
+  - experimental#simd#mean
+  - experimental#simd#meanby
 position: 10
 signatures:
   - "func MeanInt8x16[T ~int8](collection []T) T"

--- a/docs/data/simd-meanby.md
+++ b/docs/data/simd-meanby.md
@@ -2,11 +2,11 @@
 name: MeanBy
 slug: meanby
 sourceRef: exp/simd/math.go#L1006
-category: exp
+category: experimental
 subCategory: simd
 similarHelpers:
-  - exp#simd#mean
-  - exp#simd#sumby
+  - experimental#simd#mean
+  - experimental#simd#sumby
 position: 30
 signatures:
   - "func MeanByInt8[T any, R ~int8](collection []T, iteratee func(item T) R) R"

--- a/docs/data/simd-min.md
+++ b/docs/data/simd-min.md
@@ -2,10 +2,10 @@
 name: Min
 slug: min
 sourceRef: exp/simd/math_avx.go#L833
-category: exp
+category: experimental
 subCategory: simd
 similarHelpers:
-  - exp#simd#min
+  - experimental#simd#min
 position: 20
 signatures:
   - "func MinInt8x16[T ~int8](collection []T) T"

--- a/docs/data/simd-sum.md
+++ b/docs/data/simd-sum.md
@@ -2,11 +2,11 @@
 name: Sum
 slug: sum
 sourceRef: exp/simd/math_avx.go#L14
-category: exp
+category: experimental
 subCategory: simd
 similarHelpers:
-  - exp#simd#sum
-  - exp#simd#sumby
+  - experimental#simd#sum
+  - experimental#simd#sumby
 position: 0
 signatures:
   - "func SumInt8x16[T ~int8](collection []T) T"

--- a/docs/data/simd-sumby.md
+++ b/docs/data/simd-sumby.md
@@ -2,11 +2,11 @@
 name: SumBy
 slug: sumby
 sourceRef: exp/simd/math.go#L841
-category: exp
+category: experimental
 subCategory: simd
 similarHelpers:
-  - exp#simd#sum
-  - exp#simd#meanby
+  - experimental#simd#sum
+  - experimental#simd#meanby
 position: 20
 signatures:
   - "func SumByInt8[T any, R ~int8](collection []T, iteratee func(item T) R) R"

--- a/docs/docs/experimental/simd.md
+++ b/docs/docs/experimental/simd.md
@@ -43,6 +43,6 @@ BenchmarkSumInt8/xlarge/AVX512-x64-4              10107534      118.1 ns/op
 import HelperList from '@site/plugins/helpers-pages/components/HelperList';
 
 <HelperList
-  category="exp"
+  category="experimental"
   subCategory="simd"
 />

--- a/docs/docs/iter/channel.md
+++ b/docs/docs/iter/channel.md
@@ -19,6 +19,6 @@ This page lists all operations on channels, available in the `it` lo sub-package
 import HelperList from '@site/plugins/helpers-pages/components/HelperList';
 
 <HelperList 
-  category="it"
+  category="iter"
   subCategory="channel"
 />

--- a/docs/docs/iter/find.md
+++ b/docs/docs/iter/find.md
@@ -19,6 +19,6 @@ This page lists all search helpers, available in the `it` lo sub-package.
 import HelperList from '@site/plugins/helpers-pages/components/HelperList';
 
 <HelperList 
-  category="it"
+  category="iter"
   subCategory="find"
 />

--- a/docs/docs/iter/intersect.md
+++ b/docs/docs/iter/intersect.md
@@ -19,6 +19,6 @@ This page lists all intersection helpers, available in the `it` lo sub-package.
 import HelperList from '@site/plugins/helpers-pages/components/HelperList';
 
 <HelperList 
-  category="it"
+  category="iter"
   subCategory="intersect"
 />

--- a/docs/docs/iter/map.md
+++ b/docs/docs/iter/map.md
@@ -19,6 +19,6 @@ This page lists all operations on maps, available in the `it` lo sub-package.
 import HelperList from '@site/plugins/helpers-pages/components/HelperList';
 
 <HelperList 
-  category="it"
+  category="iter"
   subCategory="map"
 />

--- a/docs/docs/iter/sequence.md
+++ b/docs/docs/iter/sequence.md
@@ -19,6 +19,6 @@ This page lists all operations on sequences, available in the `it` lo sub-packag
 import HelperList from '@site/plugins/helpers-pages/components/HelperList';
 
 <HelperList 
-  category="it"
+  category="iter"
   subCategory="sequence"
 />

--- a/docs/docs/iter/slice.md
+++ b/docs/docs/iter/slice.md
@@ -19,6 +19,6 @@ This page lists all operations on slice, available in the `it` lo sub-package.
 import HelperList from '@site/plugins/helpers-pages/components/HelperList';
 
 <HelperList 
-  category="it"
+  category="iter"
   subCategory="slice"
 />

--- a/docs/docs/iter/string.md
+++ b/docs/docs/iter/string.md
@@ -19,6 +19,6 @@ This page lists all operations on strings, available in the `it` lo sub-package.
 import HelperList from '@site/plugins/helpers-pages/components/HelperList';
 
 <HelperList 
-  category="it"
+  category="iter"
   subCategory="string"
 />

--- a/docs/docs/iter/tuple.md
+++ b/docs/docs/iter/tuple.md
@@ -19,6 +19,6 @@ This page lists all tuple operations, available in the `it` lo sub-package.
 import HelperList from '@site/plugins/helpers-pages/components/HelperList';
 
 <HelperList 
-  category="it"
+  category="iter"
   subCategory="tuple"
 />

--- a/docs/docs/iter/type.md
+++ b/docs/docs/iter/type.md
@@ -19,6 +19,6 @@ This page lists all type operations available in the `it` lo sub-package.
 import HelperList from '@site/plugins/helpers-pages/components/HelperList';
 
 <HelperList 
-  category="it"
+  category="iter"
   subCategory="type"
 />


### PR DESCRIPTION
Category identifiers "it" and "exp" in data files generated SimilarHelpers links to /docs/it/... and /docs/exp/..., but actual Docusaurus pages live at /docs/iter/... and /docs/experimental/.... Renamed category values across 188 files to align with URL paths.