### PR TITLE
fix(docs): fix broken variantHelpers anchors and slice heading in iter docs

### DIFF
--- a/docs/data/it-countby.md
+++ b/docs/data/it-countby.md
@@ -8,7 +8,7 @@ signatures:
   - "func CountBy[T any](collection iter.Seq[T], predicate func(item T) bool) int"
 playUrl: https://go.dev/play/p/m6G0o3huCOG
 variantHelpers:
-  - iter#find#count
+  - iter#sequence#count
 similarHelpers:
   - core#slice#countby
   - core#slice#count

--- a/docs/data/it-dropbyindex.md
+++ b/docs/data/it-dropbyindex.md
@@ -8,7 +8,7 @@ signatures:
   - "func DropByIndex[T any, I ~func(func(T) bool)](collection I, indexes ...int) I"
 playUrl: https://go.dev/play/p/vPbrZYgiU4q
 variantHelpers:
-  - iter#slice#drop
+  - iter#sequence#drop
 similarHelpers:
   - core#slice#dropbyindex
   - core#slice#withoutnth

--- a/docs/data/it-repeat.md
+++ b/docs/data/it-repeat.md
@@ -8,7 +8,7 @@ signatures:
   - "func Repeat[T lo.Clonable[T]](count int, initial T) iter.Seq[T]"
 playUrl: https://go.dev/play/p/xs-aq0p_uDP
 variantHelpers:
-  - iter#slice#repeatby
+  - iter#sequence#repeatby
 similarHelpers:
   - core#slice#repeat
   - core#slice#repeatby

--- a/docs/data/it-sample.md
+++ b/docs/data/it-sample.md
@@ -12,8 +12,8 @@ variantHelpers:
 similarHelpers:
   - core#slice#sample
   - iter#find#samples
-  - iter#find#sampleBy
-  - iter#find#samplesBy
+  - iter#find#sampleby
+  - iter#find#samplesby
 position: 160
 ---
 

--- a/docs/data/it-slice.md
+++ b/docs/data/it-slice.md
@@ -8,7 +8,7 @@ signatures:
   - "func Slice[T any, I ~func(func(T) bool)](collection I, start, end int) I"
 playUrl: "https://go.dev/play/p/5WqJN9-zv" 
 variantHelpers:
-  - iter#slice#drop
+  - iter#sequence#slice
 similarHelpers:
   - core#slice#slice
   - core#slice#chunk

--- a/docs/data/it-uniqby.md
+++ b/docs/data/it-uniqby.md
@@ -8,7 +8,7 @@ signatures:
   - "func UniqBy[T any, U comparable, I ~func(func(T) bool)](collection I, transform func(item T) U) I"
 playUrl: https://go.dev/play/p/HKrt3AvwMTR
 variantHelpers:
-  - iter#slice#uniq
+  - iter#sequence#uniq
 similarHelpers:
   - core#slice#uniqby
   - core#slice#uniq

--- a/docs/docs/iter/slice.md
+++ b/docs/docs/iter/slice.md
@@ -12,7 +12,7 @@ Your feedback helps us improve!
 :::
 
 #
-## Iterator - Map helpers
+## Iterator - Slice helpers
 
 This page lists all operations on slice, available in the `it` lo sub-package.
 


### PR DESCRIPTION

## Describe your changes

...

## Checklist before requesting a review

- [ ] 👓 I have performed a self-review of my code
- [ ] 👶 This helper does not already exist
- [ ] 🧪 This helper is tested
- [ ] 🏎️ My code limits memory allocation and is fast
- [ ] 🧞‍♂️ This helper is immutable and my tests prove it
- [ ] ✍️ I implemented the parallel, iterator and mutable variants
- [ ] 🔬 An example has been added to lo_example_test.go
- [ ] ⛹️ An example has been created on https://go.dev/play and added in comments
- [ ] 📖 My helper has been added to documentation
  - [ ] in README.md
  - [ ] in docs/data/*.md
  - [ ] in docs/static/llms.txt

## Conventions

- Returning `(ok bool)` is often better than `(err error)`
- `panic(...)` must be limited
- Helpers should receive variadic arguments when relevent
- Add variants of your helper when relevant:
  - Variable number of arguments: `lo.Must0`, `lo.Must1`, `lo.Must2`, ...
  - Predicate with index: `lo.SliceToMap` vs `lo.SliceToMapI` 
  - With lazy callback: `lo.Ternary` vs `lo.TernaryF`
  - ...
