### PR TITLE
fix: ChunkString returns empty slice for empty input (fixes #788)

### DIFF
--- a/string.go
+++ b/string.go
@@ -201,6 +201,10 @@ func ChunkString[T ~string](str T, size int) []T {
 		panic("lo.ChunkString: size must be greater than 0")
 	}
 
+	if len(str) == 0 {
+		return []T{}
+	}
+
 	if size >= len(str) {
 		return []T{str}
 	}

--- a/string_test.go
+++ b/string_test.go
@@ -51,7 +51,7 @@ func TestChunkString(t *testing.T) {
 	is.Equal([]string{"123456"}, result4)
 
 	result5 := ChunkString("", 2)
-	is.Equal([]string{""}, result5) // @TODO: should be [] - see https://github.com/samber/lo/issues/788
+	is.Equal([]string{}, result5)
 
 	result6 := ChunkString("明1好休2林森", 2)
 	is.Equal([]string{"明1", "好休", "2林", "森"}, result6)


### PR DESCRIPTION
## Summary

`ChunkString("", n)` was returning `[""]` (a one-element slice containing an empty string) instead of `[]` (an empty slice). This was inconsistent with `Chunk([]rune{}, n)` which correctly returns an empty slice.

## Root Cause

The early-return guard `if size >= len(str) { return []T{str} }` always fires when `str` is empty because any positive `size` satisfies `size >= 0`. So it returned `[]T{""}` instead of an empty slice.

## Fix

Add an explicit early-return for the empty-string case before the size check:

```go
if len(str) == 0 {
    return []T{}
}
```

## Test

Updated the existing test case (which already carried a `// @TODO: should be []` comment referencing #788) to assert the correct behavior.

```go
// Before
ChunkString("", 2) // => [""]

// After  
ChunkString("", 2) // => []
```

Full test suite passes with no regressions.

Fixes #788