### PR TITLE
docs(concat): example uses lo.Concat, not lo.Flatten

### DIFF
--- a/docs/data/core-concat.md
+++ b/docs/data/core-concat.md
@@ -21,6 +21,6 @@ Returns a new slice containing all the elements in collections. Concat conserves
 ```go
 list1 := []int{0, 1}
 list2 := []int{2, 3, 4, 5}
-flat := lo.Flatten(list1, list2)
+combined := lo.Concat(list1, list2)
 // []int{0, 1, 2, 3, 4, 5}
 ```


### PR DESCRIPTION
Closes #859.

The Concat doc page on lo.samber.dev was showing a `lo.Flatten(list1, list2)` call under the Concat heading, which is what the screenshot in the issue caught. Fix the example to actually use `lo.Concat`.

No source change, both helpers already exist.