### PR TITLE
docs(concat): use lo.Concat in the core/concat example

### DIFF
--- a/docs/data/core-concat.md
+++ b/docs/data/core-concat.md
@@ -21,6 +21,6 @@ Returns a new slice containing all the elements in collections. Concat conserves
 ```go
 list1 := []int{0, 1}
 list2 := []int{2, 3, 4, 5}
-flat := lo.Flatten(list1, list2)
+concat := lo.Concat(list1, list2)
 // []int{0, 1, 2, 3, 4, 5}
 ```


### PR DESCRIPTION
The example on the Concat docs page was calling `lo.Flatten` by mistake. Swap it for the helper the page is actually documenting.

Closes #859.