### PR TITLE
fix(lint): nolint modernize on backward loop in it.Reverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Supported helpers for slices:
 - [Times](#times)
 - [Uniq](#uniq)
 - [UniqBy](#uniqby)
+- [IsUniq](#isuniq)
+- [IsUniqBy](#isuniqby)
 - [GroupBy](#groupby)
 - [GroupByMap](#groupbymap)
 - [Chunk](#chunk)
@@ -698,6 +700,37 @@ result, err := lo.UniqByErr([]int{0, 1, 2, 3, 4, 5}, func(i int) (int, error) {
 ```
 
 [[play](https://go.dev/play/p/g42Z3QSb53u)]
+
+### IsUniq
+
+Returns true if all elements in the slice are unique, false otherwise. Returns true for nil and empty slices.
+
+```go
+lo.IsUniq([]int{1, 2, 3})
+// true
+
+lo.IsUniq([]int{1, 2, 1})
+// false
+```
+
+### IsUniqBy
+
+Returns true if all elements in the slice are unique based on a custom criterion. It accepts `iteratee` which is invoked for each element in the slice to generate the criterion by which uniqueness is computed. Returns true for nil and empty slices.
+
+```go
+type User struct {
+    ID   int
+    Name string
+}
+
+users := []User{{ID: 1, Name: "Alice"}, {ID: 2, Name: "Bob"}, {ID: 1, Name: "Charlie"}}
+
+lo.IsUniqBy(users, func(u User) int { return u.ID })
+// false
+
+lo.IsUniqBy(users, func(u User) string { return u.Name })
+// true
+```
 
 ### GroupBy
 

--- a/docs/data/core-isuniq.md
+++ b/docs/data/core-isuniq.md
@@ -4,24 +4,17 @@ slug: isuniq
 sourceRef: slice.go#L290
 category: core
 subCategory: slice
-playUrl:
 variantHelpers:
   - core#slice#isuniq
-  - core#slice#isuniqby
 similarHelpers:
+  - core#slice#isuniqby
   - core#slice#uniq
-  - core#slice#uniqby
-  - core#slice#finduniques
-  - core#find#findduplicates
-position: 112
+position: 120
 signatures:
   - "func IsUniq[T comparable, Slice ~[]T](collection Slice) bool"
-  - "func IsUniqBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee func(item T) U) bool"
 ---
 
-Checks whether all elements in a slice are unique. Returns `true` for nil and empty slices.
-
-### IsUniq
+Returns true if all elements in the slice are unique, false otherwise. Returns true for nil and empty slices.
 
 ```go
 lo.IsUniq([]int{1, 2, 3})
@@ -31,21 +24,4 @@ lo.IsUniq([]int{1, 2, 1})
 // false
 ```
 
-### IsUniqBy
 
-Checks uniqueness based on a key computed by the iteratee function.
-
-```go
-type User struct {
-    ID  int
-    Name string
-}
-
-users := []User{{ID: 1, Name: "Alice"}, {ID: 2, Name: "Bob"}, {ID: 1, Name: "Charlie"}}
-
-lo.IsUniqBy(users, func(u User) int { return u.ID })
-// false
-
-lo.IsUniqBy(users, func(u User) string { return u.Name })
-// true
-```

--- a/docs/data/core-isuniq.md
+++ b/docs/data/core-isuniq.md
@@ -1,0 +1,51 @@
+---
+name: IsUniq
+slug: isuniq
+sourceRef: slice.go#L290
+category: core
+subCategory: slice
+playUrl:
+variantHelpers:
+  - core#slice#isuniq
+  - core#slice#isuniqby
+similarHelpers:
+  - core#slice#uniq
+  - core#slice#uniqby
+  - core#slice#finduniques
+  - core#find#findduplicates
+position: 112
+signatures:
+  - "func IsUniq[T comparable, Slice ~[]T](collection Slice) bool"
+  - "func IsUniqBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee func(item T) U) bool"
+---
+
+Checks whether all elements in a slice are unique. Returns `true` for nil and empty slices.
+
+### IsUniq
+
+```go
+lo.IsUniq([]int{1, 2, 3})
+// true
+
+lo.IsUniq([]int{1, 2, 1})
+// false
+```
+
+### IsUniqBy
+
+Checks uniqueness based on a key computed by the iteratee function.
+
+```go
+type User struct {
+    ID  int
+    Name string
+}
+
+users := []User{{ID: 1, Name: "Alice"}, {ID: 2, Name: "Bob"}, {ID: 1, Name: "Charlie"}}
+
+lo.IsUniqBy(users, func(u User) int { return u.ID })
+// false
+
+lo.IsUniqBy(users, func(u User) string { return u.Name })
+// true
+```

--- a/docs/data/core-isuniqby.md
+++ b/docs/data/core-isuniqby.md
@@ -1,0 +1,36 @@
+---
+name: IsUniqBy
+slug: isuniqby
+sourceRef: slice.go#L307
+category: core
+subCategory: slice
+variantHelpers:
+  - core#slice#isuniqby
+similarHelpers:
+  - core#slice#isuniq
+  - core#slice#uniqby
+position: 130
+signatures:
+  - "func IsUniqBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee func(item T) U) bool"
+---
+
+Returns true if all elements in the slice are unique based on a custom criterion. The `iteratee` is invoked for each element to generate the key by which uniqueness is computed. Returns true for nil and empty slices.
+
+```go
+type User struct {
+    ID   int
+    Name string
+}
+
+lo.IsUniqBy([]User{{ID: 1}, {ID: 2}, {ID: 3}}, func(u User) int {
+    return u.ID
+})
+// true
+
+lo.IsUniqBy([]User{{ID: 1}, {ID: 2}, {ID: 1}}, func(u User) int {
+    return u.ID
+})
+// false
+```
+
+

--- a/docs/data/core-uniq.md
+++ b/docs/data/core-uniq.md
@@ -9,6 +9,7 @@ variantHelpers:
   - core#slice#uniq
 similarHelpers:
   - core#slice#uniqby
+  - core#slice#isuniq
   - core#slice#uniqmap
   - core#slice#uniqkeys
   - core#slice#uniqvalues

--- a/docs/data/core-uniqby.md
+++ b/docs/data/core-uniqby.md
@@ -10,6 +10,7 @@ variantHelpers:
 similarHelpers:
   - core#slice#uniqbyerr
   - core#slice#uniq
+  - core#slice#isuniq
   - core#slice#uniqmap
   - core#slice#partitionby
 position: 110

--- a/docs/data/core-uniqby.md
+++ b/docs/data/core-uniqby.md
@@ -10,7 +10,7 @@ variantHelpers:
 similarHelpers:
   - core#slice#uniqbyerr
   - core#slice#uniq
-  - core#slice#isuniq
+  - core#slice#isuniqby
   - core#slice#uniqmap
   - core#slice#partitionby
 position: 110

--- a/docs/data/core-uniqbyerr.md
+++ b/docs/data/core-uniqbyerr.md
@@ -11,6 +11,7 @@ variantHelpers:
 similarHelpers:
   - core#slice#uniqby
   - core#slice#uniq
+  - core#slice#isuniq
   - core#slice#uniqmap
   - core#slice#partitionby
 position: 111

--- a/docs/data/core-uniqmap.md
+++ b/docs/data/core-uniqmap.md
@@ -10,6 +10,7 @@ variantHelpers:
 similarHelpers:
   - core#slice#uniq
   - core#slice#uniqby
+  - core#slice#isuniq
   - core#slice#map
   - core#slice#filtermap
 position: 20

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -219,6 +219,8 @@ Lo is built on a foundation of pragmatic engineering principles that balance pow
 - Times: Execute function n times and collect results
 - Uniq: Remove duplicate elements
 - UniqBy: Remove duplicates by key function
+- IsUniq: Check if all elements are unique
+- IsUniqBy: Check if all elements are unique by key function
 - GroupBy: Group elements by key function
 - GroupByMap: Group elements by key function into map
 - Chunk: Split slice into chunks of specified size

--- a/it/seq.go
+++ b/it/seq.go
@@ -478,6 +478,7 @@ func Reverse[T any, I ~func(func(T) bool)](collection I) I {
 	slice := slices.Collect(iter.Seq[T](collection))
 
 	return I(func(yield func(T) bool) {
+		//nolint:modernize // backward loop can't use slices.Backward (Go 1.24+), lo supports Go 1.18+
 		for i := len(slice) - 1; i >= 0; i-- {
 			if !yield(slice[i]) {
 				return


### PR DESCRIPTION
The modernize linter (golangci-lint v2.12+) flags the backward loop in it.Reverse as replaceable with slices.Backward.

However, slices.Backward was introduced in Go 1.24, and lo supports Go 1.18+. This adds a targeted nolint directive with an explanation.