### PR TITLE
docs: add IsUniq and IsUniqBy documentation

### DIFF
--- a/docs/data/core-isuniq.md
+++ b/docs/data/core-isuniq.md
@@ -1,0 +1,28 @@
+---
+name: IsUniq
+slug: isuniq
+sourceRef: slice.go#L290
+category: core
+subCategory: slice
+playUrl: https://go.dev/play/p/fnnBKQrEOGH
+variantHelpers:
+  - core#slice#isuniq
+similarHelpers:
+  - core#slice#isuniqby
+  - core#slice#uniq
+position: 120
+signatures:
+  - "func IsUniq[T comparable, Slice ~[]T](collection Slice) bool"
+---
+
+Returns true if all elements in the slice are unique, false otherwise. Returns true for nil and empty slices.
+
+```go
+lo.IsUniq([]int{1, 2, 3})
+// true
+
+lo.IsUniq([]int{1, 2, 1})
+// false
+```
+
+

--- a/docs/data/core-isuniqby.md
+++ b/docs/data/core-isuniqby.md
@@ -1,0 +1,37 @@
+---
+name: IsUniqBy
+slug: isuniqby
+sourceRef: slice.go#L307
+category: core
+subCategory: slice
+playUrl: https://go.dev/play/p/YBxLRh2hsaE
+variantHelpers:
+  - core#slice#isuniqby
+similarHelpers:
+  - core#slice#isuniq
+  - core#slice#uniqby
+position: 130
+signatures:
+  - "func IsUniqBy[T any, U comparable, Slice ~[]T](collection Slice, iteratee func(item T) U) bool"
+---
+
+Returns true if all elements in the slice are unique based on a custom criterion. The `iteratee` is invoked for each element to generate the key by which uniqueness is computed. Returns true for nil and empty slices.
+
+```go
+type User struct {
+    ID  int
+    Name string
+}
+
+lo.IsUniqBy([]User{{ID: 1}, {ID: 2}, {ID: 3}}, func(u User) int {
+    return u.ID
+})
+// true
+
+lo.IsUniqBy([]User{{ID: 1}, {ID: 2}, {ID: 1}}, func(u User) int {
+    return u.ID
+})
+// false
+```
+
+

--- a/docs/data/core-uniq.md
+++ b/docs/data/core-uniq.md
@@ -9,6 +9,7 @@ variantHelpers:
   - core#slice#uniq
 similarHelpers:
   - core#slice#uniqby
+  - core#slice#isuniq
   - core#slice#uniqmap
   - core#slice#uniqkeys
   - core#slice#uniqvalues

--- a/docs/data/core-uniqby.md
+++ b/docs/data/core-uniqby.md
@@ -10,6 +10,7 @@ variantHelpers:
 similarHelpers:
   - core#slice#uniqbyerr
   - core#slice#uniq
+  - core#slice#isuniqby
   - core#slice#uniqmap
   - core#slice#partitionby
 position: 110


### PR DESCRIPTION
Split into two separate doc files following the existing pattern (cf `core-uniq.md` / `core-uniqby.md`).

- `docs/data/core-isuniq.md` - IsUniq with example
- `docs/data/core-isuniqby.md` - IsUniqBy with example
- Cross-references added to `core-uniq.md` and `core-uniqby.md` similarHelpers

Note: playground URLs are placeholder and need to be replaced with actual ones.