### PR TITLE
refactor(it): move SeqToSeq2 from map.go to seq.go

### DIFF
--- a/docs/data/it-seqtoseq2.md
+++ b/docs/data/it-seqtoseq2.md
@@ -1,0 +1,26 @@
+---
+name: SeqToSeq2
+slug: seqtoseq2
+sourceRef: it/seq.go#L1167
+category: iter
+subCategory: sequence
+signatures:
+  - "func SeqToSeq2[T any](in iter.Seq[T]) iter.Seq2[int, T]"
+playUrl: https://go.dev/play/p/V5wL9xY8nQr
+variantHelpers:
+  - iter#sequence#seqtoseq2
+similarHelpers:
+  - iter#map#seq2keyseq
+  - iter#map#seq2valueseq
+position: 185
+---
+
+Converts a sequence into an indexed sequence of key-value pairs. The first element of `iter.Seq2` is the index (starting from 0, incrementing by 1 for each item).
+
+```go
+seq := slices.Values([]string{"foo", "bar", "baz"})
+for i, v := range it.SeqToSeq2(seq) {
+    fmt.Printf("%d:%s ", i, v)
+}
+// 0:foo 1:bar 2:baz
+```

--- a/docs/data/it-seqtoseq2.md
+++ b/docs/data/it-seqtoseq2.md
@@ -10,8 +10,8 @@ playUrl: https://go.dev/play/p/V5wL9xY8nQr
 variantHelpers:
   - iter#sequence#seqtoseq2
 similarHelpers:
-  - iter#map#seq2keyseq
-  - iter#map#seq2valueseq
+  - iter#map#seq2keytoseq
+  - iter#map#seq2valuetoseq
 position: 185
 ---
 

--- a/it/map.go
+++ b/it/map.go
@@ -232,20 +232,6 @@ func FilterValues[K comparable, V any](in map[K]V, predicate func(key K, value V
 	}
 }
 
-// SeqToSeq2 converts a sequence into a sequence of key-value pairs keyed by index.
-// Play: https://go.dev/play/p/V5wL9xY8nQr
-func SeqToSeq2[T any](in iter.Seq[T]) iter.Seq2[int, T] {
-	return func(yield func(int, T) bool) {
-		var i int
-		for item := range in {
-			if !yield(i, item) {
-				return
-			}
-			i++
-		}
-	}
-}
-
 // Seq2KeyToSeq converts a sequence of key-value pairs into a sequence of keys.
 // Play: https://go.dev/play/p/W6xM7zZ9oSt
 func Seq2KeyToSeq[K, V any](in iter.Seq2[K, V]) iter.Seq[K] {

--- a/it/map_example_test.go
+++ b/it/map_example_test.go
@@ -156,13 +156,6 @@ func ExampleFilterValues() {
 	// Output: [foo]
 }
 
-func ExampleSeqToSeq2() {
-	result := maps.Collect(SeqToSeq2(slices.Values([]string{"foo", "bar", "baz"})))
-
-	fmt.Printf("%v %v %v %v", len(result), result[0], result[1], result[2])
-	// Output: 3 foo bar baz
-}
-
 func ExampleSeq2KeyToSeq() {
 	result := slices.Collect(Seq2KeyToSeq(maps.All(map[string]int{
 		"foo": 1,

--- a/it/map_test.go
+++ b/it/map_test.go
@@ -265,17 +265,6 @@ func TestFilterValues(t *testing.T) {
 	is.Empty(slices.Collect(result2))
 }
 
-func TestSeqToSeq2(t *testing.T) {
-	t.Parallel()
-	is := assert.New(t)
-
-	r1 := maps.Collect(SeqToSeq2(values("foo", "bar")))
-	is.Equal(map[int]string{0: "foo", 1: "bar"}, r1)
-
-	r2 := maps.Collect(SeqToSeq2(values[string]()))
-	is.Empty(r2)
-}
-
 func TestSeq2KeyToSeq(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)

--- a/it/seq.go
+++ b/it/seq.go
@@ -1164,6 +1164,21 @@ func TrimSuffix[T comparable, I ~func(func(T) bool)](collection I, suffix []T) I
 	}
 }
 
+// SeqToSeq2 converts a sequence into a sequence of key-value pairs, where the first
+// element of iter.Seq2 is the index (starting from 0 and incrementing by 1 for each item).
+// Play: https://go.dev/play/p/V5wL9xY8nQr
+func SeqToSeq2[T any](in iter.Seq[T]) iter.Seq2[int, T] {
+	return func(yield func(int, T) bool) {
+		var i int
+		for item := range in {
+			if !yield(i, item) {
+				return
+			}
+			i++
+		}
+	}
+}
+
 // Buffer returns a sequence of slices, each containing up to size items read from the channel.
 // The last slice may be smaller if the channel closes before filling the buffer.
 // Play: https://go.dev/play/p/zDZdcCA20ut

--- a/it/seq_example_test.go
+++ b/it/seq_example_test.go
@@ -5,6 +5,7 @@ package it
 import (
 	"fmt"
 	"iter"
+	"maps"
 	"math"
 	"slices"
 	"strconv"
@@ -770,4 +771,11 @@ func ExampleTrimSuffix() {
 	// TrimSuffix with suffix {1,2}: [1 2 1 2 3]
 	// TrimSuffix with string suffix: [hello world]
 	// TrimSuffix with suffix {5,6} (not present): [1 2 1 2 3]
+}
+
+func ExampleSeqToSeq2() {
+	result := maps.Collect(SeqToSeq2(slices.Values([]string{"foo", "bar", "baz"})))
+
+	fmt.Printf("%v %v %v %v", len(result), result[0], result[1], result[2])
+	// Output: 3 foo bar baz
 }

--- a/it/seq_test.go
+++ b/it/seq_test.go
@@ -5,6 +5,7 @@ package it
 import (
 	"fmt"
 	"iter"
+	"maps"
 	"math"
 	"slices"
 	"strconv"
@@ -1819,4 +1820,15 @@ func TestBuffer(t *testing.T) {
 	// stop after first batch (early termination)
 	batches4 := slices.Collect(Take(Buffer(RangeFrom(1, 6), 2), 1))
 	is.Equal([][]int{{1, 2}}, batches4)
+}
+
+func TestSeqToSeq2(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	r1 := maps.Collect(SeqToSeq2(values("foo", "bar")))
+	is.Equal(map[int]string{0: "foo", 1: "bar"}, r1)
+
+	r2 := maps.Collect(SeqToSeq2(values[string]()))
+	is.Empty(r2)
 }


### PR DESCRIPTION
## Summary

- Moves `SeqToSeq2` from `it/map.go` to `it/seq.go` (correct file — it operates on sequences, not maps)
- Moves test and example from `map_test.go`/`map_example_test.go` to `seq_test.go`/`seq_example_test.go`
- Adds `maps` import to `seq_test.go` and `seq_example_test.go`
- Adds doc page `docs/data/it-seqtoseq2.md`
- Improves doc comment to clarify the index starts at 0 and increments by 1