### PR TITLE
Add a Join() function to the lo package

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Supported helpers for slices:
 - [TrimPrefix](#TrimPrefix)
 - [TrimRight](#TrimRight)
 - [TrimSuffix](#TrimSuffix)
+- [Join](#Join)
 
 Supported helpers for maps:
 
@@ -1653,6 +1654,18 @@ result := lo.TrimSuffix([]string{"hello", "world", "hello", "test"}, []string{"t
 ```
 
 [[play](https://go.dev/play/p/IjEUrV0iofq)]
+
+### Join
+Joins every collection item into a string, using the specified separator. If the separator is nil, it is considered as an empty string.
+
+```go
+result1 := lo.Join([]int{1, 2, 3, 4}, " - ")
+// "1 - 2 - 3 - 4"
+
+result2 := lo.Join([]string{"a", "b", "c", "d"}, 2)
+// "a2b2c2d"
+```
+[[play](https://go.dev/play/p/uEwlghJIHmN)]
 
 ### Keys
 

--- a/docs/data/core-join.md
+++ b/docs/data/core-join.md
@@ -1,0 +1,20 @@
+---
+name: Join
+slug: join
+sourceRed: slice.go#L1348
+category: core
+subCategory: slice
+playUrl: https://go.dev/play/p/uEwlghJIHmN
+signatures:
+ - "func Join[T any, Slice []T](collection Slice, separator any) string"
+---
+
+Joins every collection item into a string, using the specified separator. If the separator is nil, it is considered as an empty string.
+
+```go
+result1 := lo.Join([]int{1, 2, 3, 4}, " - "))
+// "1 - 2 - 3 - 4"
+
+result1 := lo.Join([]string{"a", "b", "c", "d"}, 2))
+// "a2b2c2d"
+```

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -273,6 +273,7 @@ Lo is built on a foundation of pragmatic engineering principles that balance pow
 - TrimPrefix: Remove prefix from string if present
 - TrimRight: Remove whitespace from end of string
 - TrimSuffix: Remove suffix from string if present
+- Join: Join elements using separator
 
 ### String
 - RandomString: Generate random string of specified length

--- a/lo_example_test.go
+++ b/lo_example_test.go
@@ -4149,3 +4149,14 @@ func ExampleIntersectBy() {
 	// Output:
 	// [0]
 }
+
+func ExampleJoin() {
+	result1 := Join([]int{1, 2, 3, 4}, " - ")
+	fmt.Printf("%v\n", result1)
+
+	result2 := Join([]string{"a", "b", "c", "d"}, 2)
+	fmt.Printf("%v", result2)
+	// Output:
+	// 1 - 2 - 3 - 4
+	// a2b2c2d
+}

--- a/slice.go
+++ b/slice.go
@@ -1,7 +1,9 @@
 package lo
 
 import (
+	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/samber/lo/internal/constraints"
 	"github.com/samber/lo/mutable"
@@ -1338,4 +1340,29 @@ func TrimSuffix[T comparable, Slice ~[]T](collection, suffix Slice) Slice {
 	}
 
 	return collection
+}
+
+// Join joins every collection item into a string, using the specified separator. If the separator
+// is nil, it is considered as an empty string.
+// Play: https://go.dev/play/p/uEwlghJIHmN
+func Join[T any, Slice ~[]T](collection Slice, separator any) string {
+	switch len(collection) {
+	case 0:
+		return ""
+	case 1:
+		return fmt.Sprint(collection[0])
+	}
+
+	if separator == nil {
+		separator = ""
+	}
+
+	var result strings.Builder
+
+	fmt.Fprint(&result, collection[0])
+	ForEach(collection[1:], func(item T, _ int) {
+		fmt.Fprintf(&result, "%v%v", separator, item)
+	})
+
+	return result.String()
 }

--- a/slice_test.go
+++ b/slice_test.go
@@ -3319,3 +3319,130 @@ func TestTrimSuffix(t *testing.T) {
 	actual = TrimSuffix([]string{"a", "b", "c", "d", "e", "f", "g"}, []string{})
 	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, actual)
 }
+
+func TestJoin(t *testing.T) {
+	t.Parallel()
+
+	t.Run("[]string input", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			input     []string
+			separator any
+			want      string
+		}{
+			{
+				name:      "empty array",
+				input:     []string{},
+				separator: ", ",
+				want:      "",
+			},
+			{
+				name:      "one element array",
+				input:     []string{"a"},
+				separator: ", ",
+				want:      "a",
+			},
+			{
+				name:      "multiple element array",
+				input:     []string{"a", "b", "c"},
+				separator: ", ",
+				want:      "a, b, c",
+			},
+			{
+				name:      "empty separator",
+				input:     []string{"a", "b", "c"},
+				separator: "",
+				want:      "abc",
+			},
+			{
+				name:      "nil separator",
+				input:     []string{"a", "b", "c"},
+				separator: nil,
+				want:      "abc",
+			},
+			{
+				name:      "int separator",
+				input:     []string{"a", "b", "c"},
+				separator: 2,
+				want:      "a2b2c",
+			},
+			{
+				name:      "nil input",
+				input:     nil,
+				separator: ", ",
+				want:      "",
+			},
+		}
+
+		for _, tt := range tests {
+			tt := tt // capture range variable
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				is := assert.New(t)
+
+				got := Join(tt.input, tt.separator)
+
+				is.Equal(tt.want, got)
+			})
+		}
+	})
+
+	t.Run("[]int input", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			input     []int
+			separator any
+			want      string
+		}{
+			{
+				name:      "empty array",
+				input:     []int{},
+				separator: ", ",
+				want:      "",
+			},
+			{
+				name:      "one element array",
+				input:     []int{1},
+				separator: ", ",
+				want:      "1",
+			},
+			{
+				name:      "multiple element array",
+				input:     []int{1, 2, 3},
+				separator: ", ",
+				want:      "1, 2, 3",
+			},
+			{
+				name:      "empty separator",
+				input:     []int{1, 2, 3},
+				separator: "",
+				want:      "123",
+			},
+			{
+				name:      "nil separator",
+				input:     []int{1, 2, 3},
+				separator: nil,
+				want:      "123",
+			},
+			{
+				name:      "int separator",
+				input:     []int{1, 2, 3},
+				separator: 2,
+				want:      "12223",
+			},
+		}
+
+		for _, tt := range tests {
+			tt := tt // capture range variable
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				is := assert.New(t)
+
+				got := Join(tt.input, tt.separator)
+
+				is.Equal(tt.want, got)
+			})
+		}
+	})
+
+}


### PR DESCRIPTION

## Describe your changes

I added a `Join()` function to the `lo` package.
It takes a collection and a separator (that can be any type) and returns a string that contains
every item, separated by the specified separator.

It uses `fmt` to convert list items and separator to string, and a `strings.Builder` to construct it.
I created an example on `pkg.go.dev` but because the import path is github.com/samber/lo, it will be available only if you accept the PR.

I wrote various tests in ./slice_test.go. Feel free to look at them if you want to verify, I tried to cover every case where my function could bug. 

## Checklist before requesting a review

- [X] 👓 I have performed a self-review of my code
- [X] 👶 This helper does not already exist
- [X] 🧪 This helper is tested
- [X] 🏎️ My code limits memory allocation and is fast
- [?] 🧞‍♂️ This helper is immutable and my tests prove it
- [?] ✍️ I implemented the parallel, iterator and mutable variants
- [X] 🔬 An example has been added to lo_example_test.go
- [X] ⛹️ An example has been created on https://go.dev/play and added in comments
- [X] 📖 My helper has been added to documentation
  - [X] in README.md
  - [X] in docs/data/*.md
  - [X] in docs/static/llms.txt

## Conventions

- Returning `(ok bool)` is often better than `(err error)`
- `panic(...)` must be limited
- Helpers should receive variadic arguments when relevent
- Add variants of your helper when relevant:
  - Variable number of arguments: `lo.Must0`, `lo.Must1`, `lo.Must2`, ...
  - Predicate with index: `lo.SliceToMap` vs `lo.SliceToMapI` 
  - With lazy callback: `lo.Ternary` vs `lo.TernaryF`
  - ...
