### PR TITLE
Add mutable Reject

### DIFF
--- a/benchmark/mutable_slice_bench_test.go
+++ b/benchmark/mutable_slice_bench_test.go
@@ -33,6 +33,32 @@ func BenchmarkMutableFilterI(b *testing.B) {
 	}
 }
 
+func BenchmarkMutableReject(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			src := genSliceInt(n)
+			for i := 0; i < b.N; i++ {
+				cp := make([]int, len(src))
+				copy(cp, src)
+				_ = mutable.Reject(cp, func(x int) bool { return x%2 == 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkMutableRejectI(b *testing.B) {
+	for _, n := range lengths {
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			src := genSliceInt(n)
+			for i := 0; i < b.N; i++ {
+				cp := make([]int, len(src))
+				copy(cp, src)
+				_ = mutable.RejectI(cp, func(x, _ int) bool { return x%2 == 0 })
+			}
+		})
+	}
+}
+
 func BenchmarkMutableMap(b *testing.B) {
 	for _, n := range lengths {
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {

--- a/mutable/slice.go
+++ b/mutable/slice.go
@@ -37,6 +37,41 @@ func FilterI[T any, Slice ~[]T](collection Slice, predicate func(item T, index i
 	return collection[:j]
 }
 
+// Reject overwrites collection's underlying array with the elements that don't satisfy
+// predicate, in their original order, and returns a slice header whose length is the
+// number kept. Use RejectI if you need the element's index.
+//
+// The caller's original slice variable still has its original length: only the returned
+// slice has the new shorter length. Anything past that point in the original array is
+// leftover from before the call (often duplicates of the last kept element). Either
+// assign the result back, or re-slice with the returned length, if you want to discard
+// the leftover.
+func Reject[T any, Slice ~[]T](collection Slice, predicate func(T) bool) Slice {
+	j := 0
+	for i := range collection {
+		if !predicate(collection[i]) {
+			collection[j] = collection[i]
+			j++
+		}
+	}
+	return collection[:j]
+}
+
+// RejectI is like Reject but passes the element's index to predicate as well.
+// See Reject for the in-place semantics (the caller's original slice keeps its length;
+// only the returned slice has the new shorter length).
+func RejectI[T any, Slice ~[]T](collection Slice, predicate func(T, int) bool) Slice {
+	j := 0
+	for i := range collection {
+		if !predicate(collection[i], i) {
+			collection[j] = collection[i]
+			j++
+		}
+	}
+	return collection[:j]
+
+}
+
 // Map applies transform to each element of collection in place. Use MapI if you need
 // the element's index.
 // Play: https://go.dev/play/p/0jY3Z0B7O_5

--- a/mutable/slice_test.go
+++ b/mutable/slice_test.go
@@ -39,6 +39,39 @@ func TestFilterI(t *testing.T) {
 	is.Equal([]int{2, 4}, r1)
 }
 
+func TestReject(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	input1 := []int{1, 2, 3, 4}
+	r1 := Reject(input1, func(x int) bool {
+		return x%2 == 0
+	})
+
+	is.Equal([]int{1, 3, 3, 4}, input1)
+	is.Equal([]int{1, 3}, r1)
+
+	input2 := []string{"", "foo", "", "bar", ""}
+	r2 := Reject(input2, func(x string) bool {
+		return len(x) > 0
+	})
+
+	is.Equal([]string{"", "", "", "bar", ""}, input2)
+	is.Equal([]string{"", "", ""}, r2)
+}
+
+func TestRejectI(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	r1 := RejectI([]int{1, 2, 3, 4}, func(x, i int) bool {
+		is.Equal(i, x-1)
+		return x%2 == 0
+	})
+
+	is.Equal([]int{1, 3}, r1)
+}
+
 func TestMap(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)


### PR DESCRIPTION
This PR adds `mutable.Reject` that uses the same algorithm as `mutable.Filter`, but the predicate return is reversed