### PR TITLE
add FilterRejectUnstable implementations

### DIFF
--- a/benchmark/core_slice_bench_test.go
+++ b/benchmark/core_slice_bench_test.go
@@ -663,6 +663,17 @@ func BenchmarkFilterReject(b *testing.B) {
 	}
 }
 
+func BenchmarkFilterRejectUnstable(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = lo.FilterRejectUnstable(ints, func(v, _ int) bool { return v%2 == 0 })
+			}
+		})
+	}
+}
+
 func BenchmarkCount(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)

--- a/benchmark/mutable_slice_bench_test.go
+++ b/benchmark/mutable_slice_bench_test.go
@@ -33,6 +33,28 @@ func BenchmarkMutableFilterI(b *testing.B) {
 	}
 }
 
+func BenchmarkMutableFilterRejectUnstable(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = mutable.FilterRejectUnstable(ints, func(v int) bool { return v%2 == 0 })
+			}
+		})
+	}
+}
+
+func BenchmarkMutableFilterRejectUnstableI(b *testing.B) {
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = mutable.FilterRejectUnstableI(ints, func(v, _ int) bool { return v%2 == 0 })
+			}
+		})
+	}
+}
+
 func BenchmarkMutableMap(b *testing.B) {
 	for _, n := range lengths {
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {

--- a/mutable/slice.go
+++ b/mutable/slice.go
@@ -37,6 +37,47 @@ func FilterI[T any, Slice ~[]T](collection Slice, predicate func(item T, index i
 	return collection[:j]
 }
 
+// FilterRejectUnstable partitions collection's underlying array by the elements that satisfy
+// predicate, and with the elements that don't, in unstable order, and returns two slices whose length is the
+// number of kept and rejected elements. Use FilterRejectUnstableI if you need the element's index.
+//
+// The caller's original slice variable still has its original content, but rejected elements are moved to the back
+// and accepted elements are moved to the head of the slice in unstable order.
+func FilterRejectUnstable[T any, Slice ~[]T](collection Slice, predicate func(T) bool) (kept, rejected Slice) {
+	rejectPos := len(collection)
+
+	for i := 0; i < rejectPos; {
+		if !predicate(collection[i]) {
+			rejectPos--
+			collection[i], collection[rejectPos] = collection[rejectPos], collection[i]
+
+			continue
+		}
+
+		i++
+	}
+	return collection[:rejectPos], collection[rejectPos:]
+}
+
+// FilterRejectUnstableI is like FilterRejectUnstable but passes the element's index to predicate as well.
+// See FilterRejectUnstable for the in-place semantics (the caller's original slice keeps its contents;
+// returned slices are sub-slices of the original slice).
+func FilterRejectUnstableI[T any, Slice ~[]T](collection Slice, predicate func(T, int) bool) (kept, rejected Slice) {
+	rejectPos := len(collection)
+
+	for i := 0; i < rejectPos; {
+		if !predicate(collection[i], i) {
+			rejectPos--
+			collection[i], collection[rejectPos] = collection[rejectPos], collection[i]
+
+			continue
+		}
+
+		i++
+	}
+	return collection[:rejectPos], collection[rejectPos:]
+}
+
 // Map applies transform to each element of collection in place. Use MapI if you need
 // the element's index.
 // Play: https://go.dev/play/p/0jY3Z0B7O_5

--- a/slice.go
+++ b/slice.go
@@ -987,6 +987,34 @@ func FilterReject[T any, Slice ~[]T](collection Slice, predicate func(T, int) bo
 	return kept, rejected
 }
 
+// FilterRejectUnstable mixes Filter and Reject, this method returns two slices, one for the elements of collection that
+// predicate returns true for and one for the elements that predicate does not return true for.
+//
+// Unstable implementation is 2 times more memory efficient than the original one,
+// but it returns rejected elements in reverse order due to implementation details.
+// Play: https://go.dev/play/p/EurlBKKDpdT
+func FilterRejectUnstable[T any, Slice ~[]T](collection Slice, predicate func(T, int) bool) (kept, rejected Slice) {
+	n := len(collection)
+	result := make(Slice, n)
+
+	keptEnd := 0
+	rejectEnd := n - 1
+
+	for i := 0; i < n; i++ {
+		if predicate(collection[i], i) {
+			result[keptEnd] = collection[i]
+			keptEnd++
+
+			continue
+		}
+
+		result[rejectEnd] = collection[i]
+		rejectEnd--
+	}
+
+	return result[:keptEnd], result[keptEnd:]
+}
+
 // Count counts the number of elements in the collection that equal value.
 // Play: https://go.dev/play/p/Y3FlK54yveC
 func Count[T comparable](collection []T, value T) int {

--- a/slice_test.go
+++ b/slice_test.go
@@ -2587,6 +2587,33 @@ func TestFilterReject(t *testing.T) {
 	is.IsType(b, allStrings, "type preserved")
 }
 
+func TestFilterRejectUnstable(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	left1, right1 := FilterReject([]int{1, 2, 3, 4}, func(x, _ int) bool {
+		return x%2 == 0
+	})
+
+	is.Equal([]int{2, 4}, left1)
+	is.Equal([]int{1, 3}, right1)
+
+	left2, right2 := FilterRejectUnstable([]string{"Smith", "foo", "Domin", "bar", "Olivia"}, func(x string, _ int) bool {
+		return len(x) > 3
+	})
+
+	is.Equal([]string{"Smith", "Domin", "Olivia"}, left2)
+	is.Equal([]string{"bar", "foo"}, right2)
+
+	type myStrings []string
+	allStrings := myStrings{"", "foo", "bar"}
+	a, b := FilterRejectUnstable(allStrings, func(x string, _ int) bool {
+		return len(x) > 0
+	})
+	is.IsType(a, allStrings, "type preserved")
+	is.IsType(b, allStrings, "type preserved")
+}
+
 func TestCount(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)


### PR DESCRIPTION
This PR adds a new `FilterRejectUnstable` function to both the `mutable` and `lo` packages. Benchmarks show that the mutable implementation is 7–10x faster than the original `lo.FilterReject` on my machine.

I understand that introducing an unstable version is a controversial choice, but I couldn’t come up with a similarly efficient stable implementation (at least not as clean as this one). The performance gain justifies this approach for me.

---

I first implemented only an in‑place version in the `mutable` package but then I realized that this approach could also be useful in the `lo` package. Although its speed is not much faster than the original `FilterReject`, it cuts memory usage in half compared to the original implementation, which makes it especially helpful for large collections.