### PR TITLE
fix: clamp Substring negative offset by rune length, not byte length

### DIFF
--- a/string.go
+++ b/string.go
@@ -148,8 +148,8 @@ func substring[T ~string](str T, offset int, length uint) T {
 		// Otherwise proceed to trimming by length
 		fallthrough
 
-	// Zero offset or offset less than minus string length - start from beginning
-	case offset < -len(str), offset == 0:
+	// Zero offset or offset less than minus string length (in runes) - start from beginning
+	case offset < -utf8.RuneCountInString(string(str)), offset == 0:
 		// Count length runes from the start
 		for i := range str {
 			if length == 0 {

--- a/string_test.go
+++ b/string_test.go
@@ -97,6 +97,12 @@ func TestSubstring(t *testing.T) {
 	str29 := Substring("🏠🐶🐱"[1:], 0, 2)
 	str30 := Substring("привет", 6, math.MaxUint)
 	str31 := Substring("привет", 6+1, math.MaxUint)
+	// Negative offset beyond the rune length clamps to the start of the string,
+	// even for multibyte strings whose byte length exceeds their rune length.
+	str32 := Substring("héllo", -6, 2)
+	str33 := Substring("héllo", -6, 1)
+	str34 := Substring("日本語", -4, 1)
+	str35 := Substring("日本語", -5, 2)
 
 	is.Empty(str0)
 	is.Empty(str1)
@@ -130,6 +136,10 @@ func TestSubstring(t *testing.T) {
 	is.Equal("��", str29)
 	is.Empty(str30)
 	is.Empty(str31)
+	is.Equal("hé", str32)
+	is.Equal("h", str33)
+	is.Equal("日", str34)
+	is.Equal("日本", str35)
 }
 
 func BenchmarkSubstring(b *testing.B) {


### PR DESCRIPTION
## What

`Substring` is documented and tested with rune (character) semantics, but the internal `substring` helper compares a negative offset against `len(str)`, which is the **byte** length:

```go
case offset < -len(str), offset == 0:
```

For an ASCII string byte length and rune length are equal, so this is fine. For a multibyte string the byte length is larger, so offsets in the band `-byteLen < offset <= -runeLen` fail this case, fall through to the count-from-the-end branch, walk `-offset` runes backwards, overshoot the start of the string and return a wrong or empty result.

The existing test `Substring("hello", -10, 2) == "he"` already pins the intended behaviour: a negative offset more negative than the length clamps to the start and takes `length` runes. Multibyte strings just were not covered.

## Repro

```go
lo.Substring("héllo", -6, 2) // got "h",  want "hé"
lo.Substring("héllo", -6, 1) // got "",   want "h"
lo.Substring("日本語", -4, 1)  // got "",   want "日"
lo.Substring("日本語", -5, 2)  // got "",   want "日本"
```

## Fix

Compare against `utf8.RuneCountInString(string(str))` instead of `len(str)`. `utf8` is already imported and the `fallthrough` from the positive-offset case is unaffected (a fallthrough ignores the case expression).

Added four assertions to `TestSubstring` covering the multibyte negative-offset band. `go test ./...` is green, `gofmt`/`go vet` clean.