### PR TITLE
perf(string): reuse cases.Title caser via sync.Pool in Capitalize

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -1050,7 +1050,7 @@ func CountValues[T comparable](collection []T) map[T]int {
 // Is equivalent to chaining lo.Map and lo.CountValues.
 // Play: https://go.dev/play/p/2U0dG1SnOmS
 func CountValuesBy[T any, U comparable](collection []T, transform func(item T) U) map[U]int {
-	result := make(map[U]int)
+	result := make(map[U]int, len(collection))
 
 	for i := range collection {
 		result[transform(collection[i])]++

--- a/string.go
+++ b/string.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"regexp"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 
@@ -29,6 +30,16 @@ var (
 	splitNumberLetterReg = regexp.MustCompile(`([0-9])([a-zA-Z])`)
 	maximumCapacity      = math.MaxInt>>1 + 1
 )
+
+// titleCaserPool reuses cases.Title casers: constructing one is far more
+// expensive than the casing itself, and a Caser is not safe for concurrent
+// use, so it cannot be a plain package-level singleton.
+var titleCaserPool = sync.Pool{
+	New: func() any {
+		c := cases.Title(language.English)
+		return &c
+	},
+}
 
 // RandomString return a random string.
 // Play: https://go.dev/play/p/rRseOQVVum4
@@ -291,7 +302,9 @@ func Words(str string) []string {
 // Capitalize converts the first character of string to upper case and the remaining to lower case.
 // Play: https://go.dev/play/p/uLTZZQXqnsa
 func Capitalize(str string) string {
-	return cases.Title(language.English).String(str)
+	c := titleCaserPool.Get().(*cases.Caser) //nolint:forcetypeassert
+	defer titleCaserPool.Put(c)
+	return c.String(str)
 }
 
 // Ellipsis trims and truncates a string to a specified length in runes and appends an ellipsis

--- a/string.go
+++ b/string.go
@@ -302,7 +302,8 @@ func Words(str string) []string {
 // Capitalize converts the first character of string to upper case and the remaining to lower case.
 // Play: https://go.dev/play/p/uLTZZQXqnsa
 func Capitalize(str string) string {
-	c := titleCaserPool.Get().(*cases.Caser) //nolint:forcetypeassert
+	// Pool.New always returns *cases.Caser, so the assertion never fails.
+	c, _ := titleCaserPool.Get().(*cases.Caser)
 	defer titleCaserPool.Put(c)
 	return c.String(str)
 }


### PR DESCRIPTION
## Summary

`Capitalize` was calling `cases.Title(language.English)` on every invocation, which constructs a new `Caser` transformer each time. Building the transformer costs more than the actual casing operation.

A `Caser` is not safe for concurrent use, so a plain `var` singleton is not an option — `sync.Pool` is the right fit: it reuses objects across calls while keeping each goroutine working on its own instance.

## Benchstat

```
goos: darwin
goarch: arm64
pkg: github.com/samber/lo/benchmark
cpu: Apple M3

              │    before    │              after              │
              │   sec/op     │   sec/op      vs base          │
Capitalize      255.7ns ± 1%   153.9ns ± 2%  -39.80% (p=0.000 n=10)

              │    before    │              after              │
              │    B/op      │    B/op       vs base          │
Capitalize      448.0 ± 0%     272.0 ± 0%    -39.29% (p=0.000 n=10)

              │    before    │              after              │
              │  allocs/op   │  allocs/op    vs base          │
Capitalize      4.000 ± 0%     2.000 ± 0%    -50.00% (p=0.000 n=10)
```

- **-39.8%** temps (255 → 154 ns/op)
- **-39.3%** mémoire (448 → 272 B/op)
- **-50.0%** allocations (4 → 2 allocs/op)