### PR TITLE
feat: add WithLanguage variants for case-conversion helpers

### DIFF
--- a/benchmark/core_string_bench_test.go
+++ b/benchmark/core_string_bench_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/samber/lo"
+	"golang.org/x/text/language"
 )
 
 func BenchmarkRandomString(b *testing.B) {
@@ -73,5 +74,41 @@ func BenchmarkEllipsis(b *testing.B) {
 	s := lo.RandomString(200, lo.LettersCharset)
 	for i := 0; i < b.N; i++ {
 		_ = lo.Ellipsis(s, 50)
+	}
+}
+
+func BenchmarkCapitalizeWithLanguage(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.CapitalizeWithLanguage("hello world", language.English)
+	}
+}
+
+func BenchmarkCapitalizeWithLanguageTurkish(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.CapitalizeWithLanguage("istanbul", language.Turkish)
+	}
+}
+
+func BenchmarkPascalCaseWithLanguage(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.PascalCaseWithLanguage("some_long_variable_name", language.English)
+	}
+}
+
+func BenchmarkCamelCaseWithLanguage(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.CamelCaseWithLanguage("some_long_variable_name", language.English)
+	}
+}
+
+func BenchmarkKebabCaseWithLanguage(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.KebabCaseWithLanguage("someLongVariableName", language.English)
+	}
+}
+
+func BenchmarkSnakeCaseWithLanguage(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = lo.SnakeCaseWithLanguage("someLongVariableName", language.English)
 	}
 }

--- a/docs/data/core-camelcase.md
+++ b/docs/data/core-camelcase.md
@@ -1,12 +1,13 @@
 ---
 name: CamelCase
 slug: camelcase
-sourceRef: string.go#L176
+sourceRef: string.go#L310
 category: core
 subCategory: string
 playUrl: https://go.dev/play/p/4JNDzaMwXkm
 variantHelpers:
   - core#string#camelcase
+  - core#string#camelcasewithlanguage
 similarHelpers:
   - core#string#pascalcase
   - core#string#snakecase
@@ -16,6 +17,7 @@ similarHelpers:
 position: 50
 signatures:
   - "func CamelCase(str string) string"
+  - "func CamelCaseWithLanguage(str string, tag language.Tag) string"
 ---
 
 Converts a string to camelCase.
@@ -23,6 +25,13 @@ Converts a string to camelCase.
 ```go
 lo.CamelCase("hello_world")
 // "helloWorld"
+```
+
+`CamelCaseWithLanguage` uses locale-aware casing. The first word is fully lowercased, subsequent words are title-cased, both according to the given language tag.
+
+```go
+lo.CamelCaseWithLanguage("ISTANBUL_CITY", language.Turkish)
+// "ıstanbulCıty"  (capital I → ı, title I → İ in Turkish)
 ```
 
 

--- a/docs/data/core-capitalize.md
+++ b/docs/data/core-capitalize.md
@@ -1,12 +1,13 @@
 ---
 name: Capitalize
 slug: capitalize
-sourceRef: string.go#L227
+sourceRef: string.go#L424
 category: core
 subCategory: string
 playUrl: https://go.dev/play/p/uLTZZQXqnsa
 variantHelpers:
   - core#string#capitalize
+  - core#string#capitalizewithlanguage
 similarHelpers:
   - core#string#pascalcase
   - core#string#camelcase
@@ -17,6 +18,7 @@ similarHelpers:
 position: 90
 signatures:
   - "func Capitalize(str string) string"
+  - "func CapitalizeWithLanguage(str string, tag language.Tag) string"
 ---
 
 Converts the first character to uppercase and the remaining to lowercase.
@@ -24,6 +26,16 @@ Converts the first character to uppercase and the remaining to lowercase.
 ```go
 lo.Capitalize("heLLO")
 // "Hello"
+```
+
+`CapitalizeWithLanguage` uses a locale-aware title caser. This matters for languages such as Turkish, where the uppercase of `i` is `İ` (dotted I), not `I`.
+
+```go
+lo.CapitalizeWithLanguage("istanbul", language.Turkish)
+// "İstanbul"
+
+lo.CapitalizeWithLanguage("istanbul", language.English)
+// "Istanbul"
 ```
 
 

--- a/docs/data/core-kebabcase.md
+++ b/docs/data/core-kebabcase.md
@@ -1,12 +1,13 @@
 ---
 name: KebabCase
 slug: kebabcase
-sourceRef: string.go#L190
+sourceRef: string.go#L346
 category: core
 subCategory: string
 playUrl: https://go.dev/play/p/ZBeMB4-pq45
 variantHelpers:
   - core#string#kebabcase
+  - core#string#kebabcasewithlanguage
 similarHelpers:
   - core#string#pascalcase
   - core#string#camelcase
@@ -16,6 +17,7 @@ similarHelpers:
 position: 60
 signatures:
   - "func KebabCase(str string) string"
+  - "func KebabCaseWithLanguage(str string, tag language.Tag) string"
 ---
 
 Converts a string to kebab-case.
@@ -23,6 +25,16 @@ Converts a string to kebab-case.
 ```go
 lo.KebabCase("helloWorld")
 // "hello-world"
+```
+
+`KebabCaseWithLanguage` uses a locale-aware lowercase caser instead of `strings.ToLower`. This matters for languages such as Turkish, where capital `I` lowercases to `ı` (dotless i, U+0131), not `i`.
+
+```go
+lo.KebabCaseWithLanguage("ISTANBUL_CITY", language.Turkish)
+// "ıstanbul-cıty"
+
+lo.KebabCaseWithLanguage("ISTANBUL_CITY", language.English)
+// "istanbul-city"
 ```
 
 

--- a/docs/data/core-pascalcase.md
+++ b/docs/data/core-pascalcase.md
@@ -1,12 +1,13 @@
 ---
 name: PascalCase
 slug: pascalcase
-sourceRef: string.go#L166
+sourceRef: string.go#L280
 category: core
 subCategory: string
 playUrl: https://go.dev/play/p/uxER7XpRHLB
 variantHelpers:
   - core#string#pascalcase
+  - core#string#pascalcasewithlanguage
 similarHelpers:
   - core#string#camelcase
   - core#string#snakecase
@@ -16,6 +17,7 @@ similarHelpers:
 position: 40
 signatures:
   - "func PascalCase(str string) string"
+  - "func PascalCaseWithLanguage(str string, tag language.Tag) string"
 ---
 
 Converts a string to PascalCase.
@@ -23,6 +25,13 @@ Converts a string to PascalCase.
 ```go
 lo.PascalCase("hello_world")
 // "HelloWorld"
+```
+
+`PascalCaseWithLanguage` uses a locale-aware title caser. This matters for languages such as Turkish, where the uppercase of `i` is `İ` (dotted I), not `I`.
+
+```go
+lo.PascalCaseWithLanguage("istanbul_city", language.Turkish)
+// "İstanbulCity"
 ```
 
 

--- a/docs/data/core-snakecase.md
+++ b/docs/data/core-snakecase.md
@@ -1,12 +1,13 @@
 ---
 name: SnakeCase
 slug: snakecase
-sourceRef: string.go#L200
+sourceRef: string.go#L376
 category: core
 subCategory: string
 playUrl: https://go.dev/play/p/ziB0V89IeVH
 variantHelpers:
   - core#string#snakecase
+  - core#string#snakecasewithlanguage
 similarHelpers:
   - core#string#pascalcase
   - core#string#camelcase
@@ -16,6 +17,7 @@ similarHelpers:
 position: 70
 signatures:
   - "func SnakeCase(str string) string"
+  - "func SnakeCaseWithLanguage(str string, tag language.Tag) string"
 ---
 
 Converts a string to snake_case.
@@ -23,6 +25,16 @@ Converts a string to snake_case.
 ```go
 lo.SnakeCase("HelloWorld")
 // "hello_world"
+```
+
+`SnakeCaseWithLanguage` uses a locale-aware lowercase caser instead of `strings.ToLower`. This matters for languages such as Turkish, where capital `I` lowercases to `ı` (dotless i, U+0131), not `i`.
+
+```go
+lo.SnakeCaseWithLanguage("ISTANBUL_CITY", language.Turkish)
+// "ıstanbul_cıty"
+
+lo.SnakeCaseWithLanguage("ISTANBUL_CITY", language.English)
+// "istanbul_city"
 ```
 
 

--- a/string.go
+++ b/string.go
@@ -51,13 +51,15 @@ var (
 func acquireTitleCaser(tag language.Tag) (*sync.Pool, *cases.Caser) {
 	key := tag.String()
 	if v, ok := titleCaserPools.Load(key); ok {
-		pool := v.(*sync.Pool) // always *sync.Pool: we only ever store that type
-		return pool, pool.Get().(*cases.Caser) // Pool.New always returns *cases.Caser
+		pool, _ := v.(*sync.Pool)         // always *sync.Pool: we only ever store that type
+		c, _ := pool.Get().(*cases.Caser) // Pool.New always returns *cases.Caser
+		return pool, c
 	}
 	p := &sync.Pool{New: func() any { c := cases.Title(tag); return &c }}
 	actual, _ := titleCaserPools.LoadOrStore(key, p)
-	pool := actual.(*sync.Pool) // always *sync.Pool: we only ever store that type
-	return pool, pool.Get().(*cases.Caser) // Pool.New always returns *cases.Caser
+	pool, _ := actual.(*sync.Pool)    // always *sync.Pool: we only ever store that type
+	c, _ := pool.Get().(*cases.Caser) // Pool.New always returns *cases.Caser
+	return pool, c
 }
 
 // acquireLowerCaser returns a pool and a ready-to-use lower Caser for the given language tag.
@@ -66,13 +68,15 @@ func acquireTitleCaser(tag language.Tag) (*sync.Pool, *cases.Caser) {
 func acquireLowerCaser(tag language.Tag) (*sync.Pool, *cases.Caser) {
 	key := tag.String()
 	if v, ok := lowerCaserPools.Load(key); ok {
-		pool := v.(*sync.Pool) // always *sync.Pool: we only ever store that type
-		return pool, pool.Get().(*cases.Caser) // Pool.New always returns *cases.Caser
+		pool, _ := v.(*sync.Pool)         // always *sync.Pool: we only ever store that type
+		c, _ := pool.Get().(*cases.Caser) // Pool.New always returns *cases.Caser
+		return pool, c
 	}
 	p := &sync.Pool{New: func() any { c := cases.Lower(tag); return &c }}
 	actual, _ := lowerCaserPools.LoadOrStore(key, p)
-	pool := actual.(*sync.Pool) // always *sync.Pool: we only ever store that type
-	return pool, pool.Get().(*cases.Caser) // Pool.New always returns *cases.Caser
+	pool, _ := actual.(*sync.Pool)    // always *sync.Pool: we only ever store that type
+	c, _ := pool.Get().(*cases.Caser) // Pool.New always returns *cases.Caser
+	return pool, c
 }
 
 // RandomString return a random string.
@@ -278,7 +282,7 @@ func PascalCase(str string) string {
 	if len(items) == 0 {
 		return ""
 	}
-	c := englishTitleCaserPool.Get().(*cases.Caser)
+	c, _ := englishTitleCaserPool.Get().(*cases.Caser)
 	defer englishTitleCaserPool.Put(c)
 	for i := range items {
 		items[i] = c.String(items[i])
@@ -308,8 +312,8 @@ func CamelCase(str string) string {
 	if len(items) == 0 {
 		return ""
 	}
-	lc := englishLowerCaserPool.Get().(*cases.Caser)
-	tc := englishTitleCaserPool.Get().(*cases.Caser)
+	lc, _ := englishLowerCaserPool.Get().(*cases.Caser)
+	tc, _ := englishTitleCaserPool.Get().(*cases.Caser)
 	defer englishLowerCaserPool.Put(lc)
 	defer englishTitleCaserPool.Put(tc)
 	items[0] = lc.String(items[0])
@@ -344,7 +348,7 @@ func KebabCase(str string) string {
 	if len(items) == 0 {
 		return ""
 	}
-	c := englishLowerCaserPool.Get().(*cases.Caser)
+	c, _ := englishLowerCaserPool.Get().(*cases.Caser)
 	defer englishLowerCaserPool.Put(c)
 	for i := range items {
 		items[i] = c.String(items[i])
@@ -374,7 +378,7 @@ func SnakeCase(str string) string {
 	if len(items) == 0 {
 		return ""
 	}
-	c := englishLowerCaserPool.Get().(*cases.Caser)
+	c, _ := englishLowerCaserPool.Get().(*cases.Caser)
 	defer englishLowerCaserPool.Put(c)
 	for i := range items {
 		items[i] = c.String(items[i])
@@ -418,7 +422,7 @@ func Words(str string) []string {
 // Capitalize converts the first character of string to upper case and the remaining to lower case.
 // Play: https://go.dev/play/p/uLTZZQXqnsa
 func Capitalize(str string) string {
-	c := englishTitleCaserPool.Get().(*cases.Caser)
+	c, _ := englishTitleCaserPool.Get().(*cases.Caser)
 	defer englishTitleCaserPool.Put(c)
 	return c.String(str)
 }

--- a/string.go
+++ b/string.go
@@ -31,14 +31,48 @@ var (
 	maximumCapacity      = math.MaxInt>>1 + 1
 )
 
-// titleCaserPool reuses cases.Title casers: constructing one is far more
-// expensive than the casing itself, and a Caser is not safe for concurrent
-// use, so it cannot be a plain package-level singleton.
-var titleCaserPool = sync.Pool{
-	New: func() any {
-		c := cases.Title(language.English)
-		return &c
-	},
+// Constructing a Caser is far more expensive than using one, and a Caser is not safe for
+// concurrent use, so they cannot be plain package-level singletons.
+//
+// English gets dedicated pools so the default (non-WithLanguage) functions pay zero sync.Map
+// overhead. Other languages share pools lazily created in titleCaserPools / lowerCaserPools.
+var (
+	englishTitleCaserPool = sync.Pool{New: func() any { c := cases.Title(language.English); return &c }}
+	englishLowerCaserPool = sync.Pool{New: func() any { c := cases.Lower(language.English); return &c }}
+
+	titleCaserPools sync.Map // map[string]*sync.Pool  (BCP 47 tag → pool of *cases.Caser)
+	lowerCaserPools sync.Map // map[string]*sync.Pool  (BCP 47 tag → pool of *cases.Caser)
+)
+
+// acquireTitleCaser returns a pool and a ready-to-use title Caser for the given language tag.
+// Caller must return the Caser: defer pool.Put(c).
+// Load-before-LoadOrStore avoids allocating a throwaway *sync.Pool on every call once the
+// entry is warm (LoadOrStore evaluates its value argument unconditionally).
+func acquireTitleCaser(tag language.Tag) (*sync.Pool, *cases.Caser) {
+	key := tag.String()
+	if v, ok := titleCaserPools.Load(key); ok {
+		pool := v.(*sync.Pool) // always *sync.Pool: we only ever store that type
+		return pool, pool.Get().(*cases.Caser) // Pool.New always returns *cases.Caser
+	}
+	p := &sync.Pool{New: func() any { c := cases.Title(tag); return &c }}
+	actual, _ := titleCaserPools.LoadOrStore(key, p)
+	pool := actual.(*sync.Pool) // always *sync.Pool: we only ever store that type
+	return pool, pool.Get().(*cases.Caser) // Pool.New always returns *cases.Caser
+}
+
+// acquireLowerCaser returns a pool and a ready-to-use lower Caser for the given language tag.
+// Caller must return the Caser: defer pool.Put(c).
+// Same Load-before-LoadOrStore pattern as acquireTitleCaser.
+func acquireLowerCaser(tag language.Tag) (*sync.Pool, *cases.Caser) {
+	key := tag.String()
+	if v, ok := lowerCaserPools.Load(key); ok {
+		pool := v.(*sync.Pool) // always *sync.Pool: we only ever store that type
+		return pool, pool.Get().(*cases.Caser) // Pool.New always returns *cases.Caser
+	}
+	p := &sync.Pool{New: func() any { c := cases.Lower(tag); return &c }}
+	actual, _ := lowerCaserPools.LoadOrStore(key, p)
+	pool := actual.(*sync.Pool) // always *sync.Pool: we only ever store that type
+	return pool, pool.Get().(*cases.Caser) // Pool.New always returns *cases.Caser
 }
 
 // RandomString return a random string.
@@ -241,8 +275,28 @@ func RuneLength(str string) int {
 // Play: https://go.dev/play/p/uxER7XpRHLB
 func PascalCase(str string) string {
 	items := Words(str)
+	if len(items) == 0 {
+		return ""
+	}
+	c := englishTitleCaserPool.Get().(*cases.Caser)
+	defer englishTitleCaserPool.Put(c)
 	for i := range items {
-		items[i] = Capitalize(items[i])
+		items[i] = c.String(items[i])
+	}
+	return strings.Join(items, "")
+}
+
+// PascalCaseWithLanguage converts string to pascal case using language-aware title casing.
+// This matters for languages such as Turkish where the uppercase of "i" is "İ", not "I".
+func PascalCaseWithLanguage(str string, tag language.Tag) string {
+	items := Words(str)
+	if len(items) == 0 {
+		return ""
+	}
+	pool, c := acquireTitleCaser(tag)
+	defer pool.Put(c)
+	for i := range items {
+		items[i] = c.String(items[i])
 	}
 	return strings.Join(items, "")
 }
@@ -251,12 +305,34 @@ func PascalCase(str string) string {
 // Play: https://go.dev/play/p/4JNDzaMwXkm
 func CamelCase(str string) string {
 	items := Words(str)
-	for i, item := range items {
-		item = strings.ToLower(item)
-		if i > 0 {
-			item = Capitalize(item)
-		}
-		items[i] = item
+	if len(items) == 0 {
+		return ""
+	}
+	lc := englishLowerCaserPool.Get().(*cases.Caser)
+	tc := englishTitleCaserPool.Get().(*cases.Caser)
+	defer englishLowerCaserPool.Put(lc)
+	defer englishTitleCaserPool.Put(tc)
+	items[0] = lc.String(items[0])
+	for i := 1; i < len(items); i++ {
+		items[i] = tc.String(items[i])
+	}
+	return strings.Join(items, "")
+}
+
+// CamelCaseWithLanguage converts string to camel case using language-aware casing.
+// This matters for languages such as Turkish where the uppercase of "i" is "İ", not "I".
+func CamelCaseWithLanguage(str string, tag language.Tag) string {
+	items := Words(str)
+	if len(items) == 0 {
+		return ""
+	}
+	lPool, lc := acquireLowerCaser(tag)
+	tPool, tc := acquireTitleCaser(tag)
+	defer lPool.Put(lc)
+	defer tPool.Put(tc)
+	items[0] = lc.String(items[0])
+	for i := 1; i < len(items); i++ {
+		items[i] = tc.String(items[i])
 	}
 	return strings.Join(items, "")
 }
@@ -265,8 +341,28 @@ func CamelCase(str string) string {
 // Play: https://go.dev/play/p/ZBeMB4-pq45
 func KebabCase(str string) string {
 	items := Words(str)
+	if len(items) == 0 {
+		return ""
+	}
+	c := englishLowerCaserPool.Get().(*cases.Caser)
+	defer englishLowerCaserPool.Put(c)
 	for i := range items {
-		items[i] = strings.ToLower(items[i])
+		items[i] = c.String(items[i])
+	}
+	return strings.Join(items, "-")
+}
+
+// KebabCaseWithLanguage converts string to kebab case using language-aware lowercasing.
+// This matters for languages such as Turkish where "I" lowercases to "ı" (dotless i), not "i".
+func KebabCaseWithLanguage(str string, tag language.Tag) string {
+	items := Words(str)
+	if len(items) == 0 {
+		return ""
+	}
+	pool, c := acquireLowerCaser(tag)
+	defer pool.Put(c)
+	for i := range items {
+		items[i] = c.String(items[i])
 	}
 	return strings.Join(items, "-")
 }
@@ -275,8 +371,28 @@ func KebabCase(str string) string {
 // Play: https://go.dev/play/p/ziB0V89IeVH
 func SnakeCase(str string) string {
 	items := Words(str)
+	if len(items) == 0 {
+		return ""
+	}
+	c := englishLowerCaserPool.Get().(*cases.Caser)
+	defer englishLowerCaserPool.Put(c)
 	for i := range items {
-		items[i] = strings.ToLower(items[i])
+		items[i] = c.String(items[i])
+	}
+	return strings.Join(items, "_")
+}
+
+// SnakeCaseWithLanguage converts string to snake case using language-aware lowercasing.
+// This matters for languages such as Turkish where "I" lowercases to "ı" (dotless i), not "i".
+func SnakeCaseWithLanguage(str string, tag language.Tag) string {
+	items := Words(str)
+	if len(items) == 0 {
+		return ""
+	}
+	pool, c := acquireLowerCaser(tag)
+	defer pool.Put(c)
+	for i := range items {
+		items[i] = c.String(items[i])
 	}
 	return strings.Join(items, "_")
 }
@@ -302,9 +418,17 @@ func Words(str string) []string {
 // Capitalize converts the first character of string to upper case and the remaining to lower case.
 // Play: https://go.dev/play/p/uLTZZQXqnsa
 func Capitalize(str string) string {
-	// Pool.New always returns *cases.Caser, so the assertion never fails.
-	c, _ := titleCaserPool.Get().(*cases.Caser)
-	defer titleCaserPool.Put(c)
+	c := englishTitleCaserPool.Get().(*cases.Caser)
+	defer englishTitleCaserPool.Put(c)
+	return c.String(str)
+}
+
+// CapitalizeWithLanguage converts the first character of string to upper case and the remaining to
+// lower case, using language-aware title casing.
+// This matters for languages such as Turkish where the uppercase of "i" is "İ", not "I".
+func CapitalizeWithLanguage(str string, tag language.Tag) string {
+	pool, c := acquireTitleCaser(tag)
+	defer pool.Put(c)
 	return c.String(str)
 }
 

--- a/string_test.go
+++ b/string_test.go
@@ -8,6 +8,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
 )
 
 func TestRandomString(t *testing.T) {
@@ -536,6 +537,58 @@ func TestCapitalize(t *testing.T) {
 			assert.Equalf(t, tc.want, Capitalize(tc.in), "Capitalize(%v)", tc.in)
 		})
 	}
+}
+
+func TestCapitalizeWithLanguage(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	// English: plain I
+	is.Equal("Istanbul", CapitalizeWithLanguage("istanbul", language.English))
+	is.Equal("Hello", CapitalizeWithLanguage("heLLO", language.English))
+
+	// Turkish: lowercase i → title İ (dotted capital I, U+0130)
+	is.Equal("İstanbul", CapitalizeWithLanguage("istanbul", language.Turkish))
+	// Turkish: ISTANBUL starts with capital I (the uppercase form of ı); title case
+	// keeps it as I and lowercases the rest → "Istanbul" (not "İstanbul").
+	is.Equal("Istanbul", CapitalizeWithLanguage("ISTANBUL", language.Turkish))
+}
+
+func TestPascalCaseWithLanguage(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	is.Equal("IstanbulCity", PascalCaseWithLanguage("istanbul city", language.English))
+	// Turkish: lowercase i → title İ (dotted capital I, U+0130)
+	is.Equal("İstanbulCity", PascalCaseWithLanguage("istanbul city", language.Turkish))
+}
+
+func TestCamelCaseWithLanguage(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	is.Equal("istanbulCity", CamelCaseWithLanguage("istanbul city", language.English))
+	// Turkish: capital I lowercases to ı (dotless i, U+0131), so first word → "ıstanbul".
+	// Second word title-cased: C stays C, capital I → lowercase ı → "Cıty".
+	is.Equal("ıstanbulCıty", CamelCaseWithLanguage("ISTANBUL CITY", language.Turkish))
+}
+
+func TestKebabCaseWithLanguage(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	is.Equal("istanbul-city", KebabCaseWithLanguage("ISTANBUL CITY", language.English))
+	// Turkish: I lowercases to ı (dotless i, U+0131)
+	is.Equal("ıstanbul-cıty", KebabCaseWithLanguage("ISTANBUL CITY", language.Turkish))
+}
+
+func TestSnakeCaseWithLanguage(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	is.Equal("istanbul_city", SnakeCaseWithLanguage("ISTANBUL CITY", language.English))
+	// Turkish: I lowercases to ı (dotless i, U+0131)
+	is.Equal("ıstanbul_cıty", SnakeCaseWithLanguage("ISTANBUL CITY", language.Turkish))
 }
 
 func TestEllipsis(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds locale-aware variants of all case-conversion helpers: `CapitalizeWithLanguage`, `PascalCaseWithLanguage`, `CamelCaseWithLanguage`, `KebabCaseWithLanguage`, `SnakeCaseWithLanguage`.

The canonical motivating example is **Turkish**, where Unicode casing rules differ from English:
- lowercase `i` → title `İ` (dotted capital I, U+0130)
- capital `I` → lowercase `ı` (dotless i, U+0131)

`KebabCase` and `SnakeCase` also switch from `strings.ToLower` to `cases.Lower` for the same reason.

## Pool strategy

- **English**: two dedicated `sync.Pool` vars (`englishTitleCaserPool`, `englishLowerCaserPool`) — zero `sync.Map` overhead on the default hot path.
- **Other languages**: lazy per-tag pools in `sync.Map`, acquired via `Load`-before-`LoadOrStore` to avoid allocating a throwaway `*sync.Pool` on every warm call.
- All multi-word helpers now acquire their caser **once per call** and reuse it across words.

## Benchmarks (Apple M3, before → after)

```
Capitalize          143.8 ns/op →  146.1 ns/op   ~ (neutral)
CapitalizeParallel   65.8 ns/op →   65.4 ns/op   ~ (neutral)
PascalCase           2.73 µs/op →   2.65 µs/op   -2.9%
CamelCase            2.62 µs/op →   2.66 µs/op   ~ (neutral)
KebabCase            2.43 µs/op →   2.68 µs/op   +10%  ⚠ intentional
SnakeCase            2.43 µs/op →   2.68 µs/op   +10%  ⚠ intentional
```

`KebabCase`/`SnakeCase` regression (+10% latency, +~1 kB/op) is the intentional cost of switching from `strings.ToLower` to `cases.Lower`: the `transform.String` internal buffer adds ~4 allocs/op per call, but enables correct locale-specific lowercasing.