### PR TITLE
docs: keep sourceRef line numbers in sync via gopls symbols

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -60,6 +60,16 @@ position: 0
   - Cross-references to helpers that users might want to consider as alternatives
 - **position**: Position in the list (0, 10, 20, 30...). Order must follow the order in source code. Helpers are grouped by category+sub-category and displayed on a page. Position number is reset for each page.
 
+## Keeping sourceRef in Sync
+
+The `sourceRef` field (format `file.go#L123`) points to a specific line number in the Go source. Any change to a `.go` file (adding, removing, or reordering functions) shifts line numbers for everything below the change in that file, which can make existing `sourceRef` values stale — not just for the function being edited, but for every other documented helper in the same file.
+
+Whenever Go source code is modified:
+
+1. Run `gopls symbols <file>` for every changed `.go` file to list all symbols (functions/methods/types) with their current line numbers.
+2. Cross-reference each symbol against the `sourceRef` fields in `docs/data/*.md` files that document helpers from that file.
+3. Update any `sourceRef` whose line number no longer matches.
+
 ## Content Structure
 
 After the frontmatter, include:

--- a/docs/data/core-assign.md
+++ b/docs/data/core-assign.md
@@ -1,7 +1,7 @@
 ---
 name: Assign
 slug: assign
-sourceRef: map.go#L234
+sourceRef: map.go#L270
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/VhwfJOyxf5o

--- a/docs/data/core-associate.md
+++ b/docs/data/core-associate.md
@@ -1,7 +1,7 @@
 ---
 name: Associate
 slug: associate
-sourceRef: slice.go#L389
+sourceRef: slice.go#L673
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/WHa2CfMO3Lr

--- a/docs/data/core-attempt.md
+++ b/docs/data/core-attempt.md
@@ -1,7 +1,7 @@
 ---
 name: Attempt
 slug: attempt
-sourceRef: retry.go#L153
+sourceRef: retry.go#L155
 category: core
 subCategory: retry
 playUrl: https://go.dev/play/p/3ggJZ2ZKcMj

--- a/docs/data/core-attemptwhile.md
+++ b/docs/data/core-attemptwhile.md
@@ -1,7 +1,7 @@
 ---
 name: AttemptWhile
 slug: attemptwhile
-sourceRef: retry.go#L198
+sourceRef: retry.go#L200
 category: core
 subCategory: retry
 playUrl: https://go.dev/play/p/1VS7HxlYMOG

--- a/docs/data/core-attemptwhilewithdelay.md
+++ b/docs/data/core-attemptwhilewithdelay.md
@@ -1,7 +1,7 @@
 ---
 name: AttemptWhileWithDelay
 slug: attemptwhilewithdelay
-sourceRef: retry.go#L223
+sourceRef: retry.go#L225
 category: core
 subCategory: retry
 playUrl: https://go.dev/play/p/mhufUjJfLEF

--- a/docs/data/core-attemptwithdelay.md
+++ b/docs/data/core-attemptwithdelay.md
@@ -1,7 +1,7 @@
 ---
 name: AttemptWithDelay
 slug: attemptwithdelay
-sourceRef: retry.go#L172
+sourceRef: retry.go#L174
 category: core
 subCategory: retry
 playUrl: https://go.dev/play/p/tVs6CygC7m1

--- a/docs/data/core-buffer.md
+++ b/docs/data/core-buffer.md
@@ -1,7 +1,7 @@
 ---
 name: Buffer
 slug: buffer
-sourceRef: channel.go#L214
+sourceRef: channel.go#L209
 category: core
 subCategory: channel
 signatures:

--- a/docs/data/core-bufferwithtimeout.md
+++ b/docs/data/core-bufferwithtimeout.md
@@ -1,7 +1,7 @@
 ---
 name: BufferWithTimeout
 slug: bufferwithtimeout
-sourceRef: channel.go#L214
+sourceRef: channel.go#L251
 category: core
 subCategory: channel
 signatures:

--- a/docs/data/core-channeltoslice.md
+++ b/docs/data/core-channeltoslice.md
@@ -1,7 +1,7 @@
 ---
 name: ChannelToSlice
 slug: channeltoslice
-sourceRef: channel.go#L18
+sourceRef: channel.go#L177
 category: core
 subCategory: channel
 signatures:

--- a/docs/data/core-chunk.md
+++ b/docs/data/core-chunk.md
@@ -1,7 +1,7 @@
 ---
 name: Chunk
 slug: chunk
-sourceRef: slice.go#L209
+sourceRef: slice.go#L388
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/kEMkFbdu85g

--- a/docs/data/core-chunkentries.md
+++ b/docs/data/core-chunkentries.md
@@ -1,7 +1,7 @@
 ---
 name: ChunkEntries
 slug: chunkentries
-sourceRef: map.go#L253
+sourceRef: map.go#L289
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/X_YQL6mmoD-

--- a/docs/data/core-chunkstring.md
+++ b/docs/data/core-chunkstring.md
@@ -1,7 +1,7 @@
 ---
 name: ChunkString
 slug: chunkstring
-sourceRef: string.go#L130
+sourceRef: string.go#L248
 category: core
 subCategory: string
 playUrl: https://go.dev/play/p/__FLTuJVz54

--- a/docs/data/core-clamp.md
+++ b/docs/data/core-clamp.md
@@ -1,7 +1,7 @@
 ---
 name: Clamp
 slug: clamp
-sourceRef: math.go#L59
+sourceRef: math.go#L71
 category: core
 subCategory: math
 playUrl: https://go.dev/play/p/RU4lJNC2hlI

--- a/docs/data/core-clone.md
+++ b/docs/data/core-clone.md
@@ -1,7 +1,7 @@
 ---
 name: Clone
 slug: clone
-sourceRef: slice.go#L741
+sourceRef: slice.go#L1132
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/66LJ2wAF0rN

--- a/docs/data/core-coalesce.md
+++ b/docs/data/core-coalesce.md
@@ -1,7 +1,7 @@
 ---
 name: Coalesce
 slug: coalesce
-sourceRef: type_manipulation.go#L153
+sourceRef: type_manipulation.go#L161
 category: core
 subCategory: type
 signatures:

--- a/docs/data/core-coalescemap.md
+++ b/docs/data/core-coalescemap.md
@@ -1,7 +1,7 @@
 ---
 name: CoalesceMap
 slug: coalescemap
-sourceRef: type_manipulation.go#L196
+sourceRef: type_manipulation.go#L204
 category: core
 subCategory: type
 signatures:

--- a/docs/data/core-coalescemaporempty.md
+++ b/docs/data/core-coalescemaporempty.md
@@ -1,7 +1,7 @@
 ---
 name: CoalesceMapOrEmpty
 slug: coalescemaporempty
-sourceRef: type_manipulation.go#L207
+sourceRef: type_manipulation.go#L215
 category: core
 subCategory: type
 signatures:

--- a/docs/data/core-coalesceorempty.md
+++ b/docs/data/core-coalesceorempty.md
@@ -1,7 +1,7 @@
 ---
 name: CoalesceOrEmpty
 slug: coalesceorempty
-sourceRef: type_manipulation.go#L167
+sourceRef: type_manipulation.go#L175
 category: core
 subCategory: type
 signatures:

--- a/docs/data/core-coalesceslice.md
+++ b/docs/data/core-coalesceslice.md
@@ -1,7 +1,7 @@
 ---
 name: CoalesceSlice
 slug: coalesceslice
-sourceRef: type_manipulation.go#L174
+sourceRef: type_manipulation.go#L182
 category: core
 subCategory: type
 signatures:

--- a/docs/data/core-coalescesliceorempty.md
+++ b/docs/data/core-coalescesliceorempty.md
@@ -1,7 +1,7 @@
 ---
 name: CoalesceSliceOrEmpty
 slug: coalescesliceorempty
-sourceRef: type_manipulation.go#L185
+sourceRef: type_manipulation.go#L193
 category: core
 subCategory: type
 signatures:

--- a/docs/data/core-compact.md
+++ b/docs/data/core-compact.md
@@ -1,7 +1,7 @@
 ---
 name: Compact
 slug: compact
-sourceRef: slice.go#L706
+sourceRef: slice.go#L1147
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/tXiy-iK6PAc

--- a/docs/data/core-concat.md
+++ b/docs/data/core-concat.md
@@ -1,7 +1,7 @@
 ---
 name: Concat
 slug: concat
-sourceRef: slice.go#L282
+sourceRef: slice.go#L488
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/Ux2UuR2xpRK

--- a/docs/data/core-count.md
+++ b/docs/data/core-count.md
@@ -1,7 +1,7 @@
 ---
 name: Count
 slug: count
-sourceRef: slice.go#L582
+sourceRef: slice.go#L992
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/Y3FlK54yveC

--- a/docs/data/core-countby.md
+++ b/docs/data/core-countby.md
@@ -1,7 +1,7 @@
 ---
 name: CountBy
 slug: countby
-sourceRef: slice.go#L849
+sourceRef: slice.go#L1006
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/5GMQP5vNT4q

--- a/docs/data/core-countbyerr.md
+++ b/docs/data/core-countbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: CountByErr
 slug: countbyerr
-sourceRef: slice.go#L863
+sourceRef: slice.go#L1021
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-countvalues.md
+++ b/docs/data/core-countvalues.md
@@ -1,7 +1,7 @@
 ---
 name: CountValues
 slug: countvalues
-sourceRef: slice.go#L610
+sourceRef: slice.go#L1039
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/-p-PyLT4dfy

--- a/docs/data/core-countvaluesby.md
+++ b/docs/data/core-countvaluesby.md
@@ -1,7 +1,7 @@
 ---
 name: CountValuesBy
 slug: countvaluesby
-sourceRef: slice.go#L623
+sourceRef: slice.go#L1052
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/2U0dG1SnOmS

--- a/docs/data/core-crossjoinbyerrx.md
+++ b/docs/data/core-crossjoinbyerrx.md
@@ -1,7 +1,7 @@
 ---
 name: CrossJoinByErrX
 slug: crossjoinbyerrx
-sourceRef: tuples.go#L1320
+sourceRef: tuples.go#L1615
 category: core
 subCategory: tuple
 signatures:

--- a/docs/data/core-crossjoinbyx.md
+++ b/docs/data/core-crossjoinbyx.md
@@ -1,7 +1,7 @@
 ---
 name: CrossJoinByX
 slug: crossjoinbyx
-sourceRef: tuples.go#L956
+sourceRef: tuples.go#L1383
 category: core
 subCategory: tuple
 signatures:

--- a/docs/data/core-crossjoinx.md
+++ b/docs/data/core-crossjoinx.md
@@ -1,7 +1,7 @@
 ---
 name: CrossJoinX
 slug: crossjoinx
-sourceRef: tuples.go#L891
+sourceRef: tuples.go#L1318
 category: core
 subCategory: tuple
 signatures:

--- a/docs/data/core-cut.md
+++ b/docs/data/core-cut.md
@@ -1,7 +1,7 @@
 ---
 name: Cut
 slug: cut
-sourceRef: slice.go#L774
+sourceRef: slice.go#L1222
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/GiL3qhpIP3f

--- a/docs/data/core-cutprefix.md
+++ b/docs/data/core-cutprefix.md
@@ -1,7 +1,7 @@
 ---
 name: CutPrefix
 slug: cutprefix
-sourceRef: slice.go#L800
+sourceRef: slice.go#L1248
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/P1scQj53aFa

--- a/docs/data/core-cutsuffix.md
+++ b/docs/data/core-cutsuffix.md
@@ -1,7 +1,7 @@
 ---
 name: CutSuffix
 slug: cutsuffix
-sourceRef: slice.go#L821
+sourceRef: slice.go#L1259
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/7FKfBFvPTaT

--- a/docs/data/core-difference.md
+++ b/docs/data/core-difference.md
@@ -1,7 +1,7 @@
 ---
 name: Difference
 slug: difference
-sourceRef: intersect.go#L124
+sourceRef: intersect.go#L210
 category: core
 subCategory: intersect
 playUrl: https://go.dev/play/p/pKE-JgzqRpz

--- a/docs/data/core-dispatchingstrategy.md
+++ b/docs/data/core-dispatchingstrategy.md
@@ -1,7 +1,7 @@
 ---
 name: DispatchingStrategy
 slug: dispatchingstrategy
-sourceRef: channel.go#L78
+sourceRef: channel.go#L12
 category: core
 subCategory: channel
 signatures:

--- a/docs/data/core-drop.md
+++ b/docs/data/core-drop.md
@@ -1,7 +1,7 @@
 ---
 name: Drop
 slug: drop
-sourceRef: slice.go#L441
+sourceRef: slice.go#L755
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/JswS7vXRJP2

--- a/docs/data/core-dropbyindex.md
+++ b/docs/data/core-dropbyindex.md
@@ -1,7 +1,7 @@
 ---
 name: DropByIndex
 slug: dropbyindex
-sourceRef: slice.go#L501
+sourceRef: slice.go#L856
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/bPIH4npZRxS

--- a/docs/data/core-dropright.md
+++ b/docs/data/core-dropright.md
@@ -1,7 +1,7 @@
 ---
 name: DropRight
 slug: dropright
-sourceRef: slice.go#L457
+sourceRef: slice.go#L771
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/GG0nXkSJJa3

--- a/docs/data/core-droprightwhile.md
+++ b/docs/data/core-droprightwhile.md
@@ -1,7 +1,7 @@
 ---
 name: DropRightWhile
 slug: droprightwhile
-sourceRef: slice.go#L486
+sourceRef: slice.go#L800
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/HBh8pHl-ZZz

--- a/docs/data/core-dropwhile.md
+++ b/docs/data/core-dropwhile.md
@@ -1,7 +1,7 @@
 ---
 name: DropWhile
 slug: dropwhile
-sourceRef: slice.go#L472
+sourceRef: slice.go#L786
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/b_PYomVQLGy

--- a/docs/data/core-durationx.md
+++ b/docs/data/core-durationx.md
@@ -1,7 +1,7 @@
 ---
 name: DurationX
 slug: durationx
-sourceRef: time.go#L7
+sourceRef: time.go#L9
 category: core
 subCategory: time
 signatures:

--- a/docs/data/core-earliest.md
+++ b/docs/data/core-earliest.md
@@ -1,7 +1,7 @@
 ---
 name: Earliest
 slug: earliest
-sourceRef: find.go#L363
+sourceRef: find.go#L519
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/pRyy0c6hsBs

--- a/docs/data/core-earliestby.md
+++ b/docs/data/core-earliestby.md
@@ -1,7 +1,7 @@
 ---
 name: EarliestBy
 slug: earliestby
-sourceRef: find.go#L462
+sourceRef: find.go#L542
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/0XvCF6vuLXC

--- a/docs/data/core-earliestbyerr.md
+++ b/docs/data/core-earliestbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: EarliestByErr
 slug: earliestbyerr
-sourceRef: find.go#L484
+sourceRef: find.go#L568
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/zJUBUj7ANvq

--- a/docs/data/core-elementsmatch.md
+++ b/docs/data/core-elementsmatch.md
@@ -1,7 +1,7 @@
 ---
 name: ElementsMatch
 slug: elementsmatch
-sourceRef: intersect.go#L247
+sourceRef: intersect.go#L385
 category: core
 subCategory: intersect
 playUrl: https://go.dev/play/p/XWSEM4Ic_t0

--- a/docs/data/core-elementsmatchby.md
+++ b/docs/data/core-elementsmatchby.md
@@ -1,7 +1,7 @@
 ---
 name: ElementsMatchBy
 slug: elementsmatchby
-sourceRef: intersect.go#L255
+sourceRef: intersect.go#L393
 category: core
 subCategory: intersect
 playUrl: https://go.dev/play/p/XWSEM4Ic_t0

--- a/docs/data/core-ellipsis.md
+++ b/docs/data/core-ellipsis.md
@@ -1,7 +1,7 @@
 ---
 name: Ellipsis
 slug: ellipsis
-sourceRef: string.go#L235
+sourceRef: string.go#L443
 category: core
 subCategory: string
 playUrl: https://go.dev/play/p/qE93rgqe1TW

--- a/docs/data/core-empty.md
+++ b/docs/data/core-empty.md
@@ -1,7 +1,7 @@
 ---
 name: Empty
 slug: empty
-sourceRef: type_manipulation.go#L132
+sourceRef: type_manipulation.go#L140
 category: core
 subCategory: type
 signatures:

--- a/docs/data/core-entries.md
+++ b/docs/data/core-entries.md
@@ -1,7 +1,7 @@
 ---
 name: Entries
 slug: entries
-sourceRef: map.go#L179
+sourceRef: map.go#L215
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/_t4Xe34-Nl5

--- a/docs/data/core-everyby.md
+++ b/docs/data/core-everyby.md
@@ -1,7 +1,7 @@
 ---
 name: EveryBy
 slug: everyby
-sourceRef: intersect.go#L41
+sourceRef: intersect.go#L47
 category: core
 subCategory: intersect
 playUrl: https://go.dev/play/p/dn1-vhHsq9x

--- a/docs/data/core-fanin.md
+++ b/docs/data/core-fanin.md
@@ -1,7 +1,7 @@
 ---
 name: FanIn
 slug: fanin
-sourceRef: channel.go#L18
+sourceRef: channel.go#L260
 category: core
 subCategory: channel
 signatures:

--- a/docs/data/core-fanout.md
+++ b/docs/data/core-fanout.md
@@ -1,7 +1,7 @@
 ---
 name: FanOut
 slug: fanout
-sourceRef: channel.go#L18
+sourceRef: channel.go#L287
 category: core
 subCategory: channel
 signatures:

--- a/docs/data/core-fill.md
+++ b/docs/data/core-fill.md
@@ -1,7 +1,7 @@
 ---
 name: Fill
 slug: fill
-sourceRef: slice.go#L338
+sourceRef: slice.go#L589
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/VwR34GzqEub

--- a/docs/data/core-filterkeys.md
+++ b/docs/data/core-filterkeys.md
@@ -1,7 +1,7 @@
 ---
 name: FilterKeys
 slug: filterkeys
-sourceRef: map.go#L350
+sourceRef: map.go#L467
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/OFlKXlPrBAe

--- a/docs/data/core-filterkeyserr.md
+++ b/docs/data/core-filterkeyserr.md
@@ -1,7 +1,7 @@
 ---
 name: FilterKeysErr
 slug: filterkeyserr
-sourceRef: map.go#L498
+sourceRef: map.go#L500
 category: core
 subCategory: map
 signatures:

--- a/docs/data/core-filtermap.md
+++ b/docs/data/core-filtermap.md
@@ -1,7 +1,7 @@
 ---
 name: FilterMap
 slug: filtermap
-sourceRef: slice.go#L58
+sourceRef: slice.go#L94
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/CgHYNUpOd1I

--- a/docs/data/core-filtermaptosliceerr.md
+++ b/docs/data/core-filtermaptosliceerr.md
@@ -1,7 +1,7 @@
 ---
 name: FilterMapToSliceErr
 slug: filtermaptosliceerr
-sourceRef: map.go#L443
+sourceRef: map.go#L448
 category: core
 subCategory: map
 signatures:

--- a/docs/data/core-filterreject.md
+++ b/docs/data/core-filterreject.md
@@ -1,7 +1,7 @@
 ---
 name: FilterReject
 slug: filterreject
-sourceRef: slice.go#L565
+sourceRef: slice.go#L975
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/lHSEGSznJjB

--- a/docs/data/core-filterslicetomap.md
+++ b/docs/data/core-filterslicetomap.md
@@ -1,7 +1,7 @@
 ---
 name: FilterSliceToMap
 slug: filterslicetomap
-sourceRef: slice.go#L414
+sourceRef: slice.go#L717
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/eurMiQEqey2

--- a/docs/data/core-filtervalues.md
+++ b/docs/data/core-filtervalues.md
@@ -1,7 +1,7 @@
 ---
 name: FilterValues
 slug: filtervalues
-sourceRef: map.go#L365
+sourceRef: map.go#L482
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/YVD5r_h-LX-

--- a/docs/data/core-filtervalueserr.md
+++ b/docs/data/core-filtervalueserr.md
@@ -1,7 +1,7 @@
 ---
 name: FilterValuesErr
 slug: filtervalueserr
-sourceRef: map.go#L519
+sourceRef: map.go#L522
 category: core
 subCategory: map
 signatures:

--- a/docs/data/core-findduplicates.md
+++ b/docs/data/core-findduplicates.md
@@ -1,7 +1,7 @@
 ---
 name: FindDuplicates
 slug: findduplicates
-sourceRef: find.go#L207
+sourceRef: find.go#L238
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/muFgL_XBwoP

--- a/docs/data/core-findduplicatesby.md
+++ b/docs/data/core-findduplicatesby.md
@@ -1,7 +1,7 @@
 ---
 name: FindDuplicatesBy
 slug: findduplicatesby
-sourceRef: find.go#L234
+sourceRef: find.go#L270
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/LKdYdNHuGJG

--- a/docs/data/core-findduplicatesbyerr.md
+++ b/docs/data/core-findduplicatesbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: FindDuplicatesByErr
 slug: findduplicatesbyerr
-sourceRef: find.go#L296
+sourceRef: find.go#L307
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/HiVILQqdFP0

--- a/docs/data/core-finderr.md
+++ b/docs/data/core-finderr.md
@@ -1,7 +1,7 @@
 ---
 name: FindErr
 slug: finderr
-sourceRef: find.go#L83
+sourceRef: find.go#L88
 category: core
 subCategory: find
 signatures:

--- a/docs/data/core-findindexof.md
+++ b/docs/data/core-findindexof.md
@@ -1,7 +1,7 @@
 ---
 name: FindIndexOf
 slug: findindexof
-sourceRef: find.go#L87
+sourceRef: find.go#L107
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/XWSEM4Ic_t0

--- a/docs/data/core-findkey.md
+++ b/docs/data/core-findkey.md
@@ -1,7 +1,7 @@
 ---
 name: FindKey
 slug: findkey
-sourceRef: find.go#L128
+sourceRef: find.go#L148
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/Bg0w1VDPYXx

--- a/docs/data/core-findkeyby.md
+++ b/docs/data/core-findkeyby.md
@@ -1,7 +1,7 @@
 ---
 name: FindKeyBy
 slug: findkeyby
-sourceRef: find.go#L140
+sourceRef: find.go#L160
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/9IbiPElcyo8

--- a/docs/data/core-findlastindexof.md
+++ b/docs/data/core-findlastindexof.md
@@ -1,7 +1,7 @@
 ---
 name: FindLastIndexOf
 slug: findlastindexof
-sourceRef: find.go#L101
+sourceRef: find.go#L121
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/2VhPMiQvX-D

--- a/docs/data/core-findorelse.md
+++ b/docs/data/core-findorelse.md
@@ -1,7 +1,7 @@
 ---
 name: FindOrElse
 slug: findorelse
-sourceRef: find.go#L116
+sourceRef: find.go#L136
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/Eo7W0lvKTky

--- a/docs/data/core-finduniques.md
+++ b/docs/data/core-finduniques.md
@@ -1,7 +1,7 @@
 ---
 name: FindUniques
 slug: finduniques
-sourceRef: find.go#L152
+sourceRef: find.go#L173
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/NV5vMK_2Z_n

--- a/docs/data/core-finduniquesby.md
+++ b/docs/data/core-finduniquesby.md
@@ -1,7 +1,7 @@
 ---
 name: FindUniquesBy
 slug: finduniquesby
-sourceRef: find.go#L178
+sourceRef: find.go#L204
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/2vmxCs4kW_m

--- a/docs/data/core-first.md
+++ b/docs/data/core-first.md
@@ -1,7 +1,7 @@
 ---
 name: First
 slug: first
-sourceRef: find.go#L554
+sourceRef: find.go#L857
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/94lu5X6_cbf

--- a/docs/data/core-firstor.md
+++ b/docs/data/core-firstor.md
@@ -1,7 +1,7 @@
 ---
 name: FirstOr
 slug: firstor
-sourceRef: find.go#L574
+sourceRef: find.go#L877
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/x9CxQyRFXeZ

--- a/docs/data/core-firstorempty.md
+++ b/docs/data/core-firstorempty.md
@@ -1,7 +1,7 @@
 ---
 name: FirstOrEmpty
 slug: firstorempty
-sourceRef: find.go#L567
+sourceRef: find.go#L870
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/i200n9wgrDA

--- a/docs/data/core-flatmap.md
+++ b/docs/data/core-flatmap.md
@@ -1,7 +1,7 @@
 ---
 name: FlatMap
 slug: flatmap
-sourceRef: slice.go#L74
+sourceRef: slice.go#L110
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/pFCF5WVB225

--- a/docs/data/core-flatmaperr.md
+++ b/docs/data/core-flatmaperr.md
@@ -1,7 +1,7 @@
 ---
 name: FlatMapErr
 slug: flatmaperr
-sourceRef: slice.go#L99
+sourceRef: slice.go#L124
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-flatten.md
+++ b/docs/data/core-flatten.md
@@ -1,7 +1,7 @@
 ---
 name: Flatten
 slug: flatten
-sourceRef: slice.go#L266
+sourceRef: slice.go#L471
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/rbp9ORaMpjw

--- a/docs/data/core-foreach.md
+++ b/docs/data/core-foreach.md
@@ -1,7 +1,7 @@
 ---
 name: ForEach
 slug: foreach
-sourceRef: slice.go#L107
+sourceRef: slice.go#L192
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/oofyiUPRf8t

--- a/docs/data/core-foreachwhile.md
+++ b/docs/data/core-foreachwhile.md
@@ -1,7 +1,7 @@
 ---
 name: ForEachWhile
 slug: foreachwhile
-sourceRef: slice.go#L116
+sourceRef: slice.go#L201
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-fromanyslice.md
+++ b/docs/data/core-fromanyslice.md
@@ -1,7 +1,7 @@
 ---
 name: FromAnySlice
 slug: fromanyslice
-sourceRef: type_manipulation.go#L118
+sourceRef: type_manipulation.go#L126
 category: core
 subCategory: type
 signatures:

--- a/docs/data/core-fromentries.md
+++ b/docs/data/core-fromentries.md
@@ -1,7 +1,7 @@
 ---
 name: FromEntries
 slug: fromentries
-sourceRef: map.go#L201
+sourceRef: map.go#L237
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/oIr5KHFGCEN

--- a/docs/data/core-frompairs.md
+++ b/docs/data/core-frompairs.md
@@ -1,7 +1,7 @@
 ---
 name: FromPairs
 slug: frompairs
-sourceRef: map.go#L214
+sourceRef: map.go#L250
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/oIr5KHFGCEN

--- a/docs/data/core-generator.md
+++ b/docs/data/core-generator.md
@@ -1,7 +1,7 @@
 ---
 name: Generator
 slug: generator
-sourceRef: channel.go#L18
+sourceRef: channel.go#L191
 category: core
 subCategory: channel
 signatures:

--- a/docs/data/core-groupby.md
+++ b/docs/data/core-groupby.md
@@ -1,7 +1,7 @@
 ---
 name: GroupBy
 slug: groupby
-sourceRef: slice.go#L180
+sourceRef: slice.go#L324
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/XnQBd_v6brd

--- a/docs/data/core-groupbyerr.md
+++ b/docs/data/core-groupbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: GroupByErr
 slug: groupbyerr
-sourceRef: slice.go#L279
+sourceRef: slice.go#L339
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/BzKPcY3AdX2

--- a/docs/data/core-groupbymap.md
+++ b/docs/data/core-groupbymap.md
@@ -1,7 +1,7 @@
 ---
 name: GroupByMap
 slug: groupbymap
-sourceRef: slice.go#L194
+sourceRef: slice.go#L356
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/iMeruQ3_W80

--- a/docs/data/core-groupbymaperr.md
+++ b/docs/data/core-groupbymaperr.md
@@ -1,7 +1,7 @@
 ---
 name: GroupByMapErr
 slug: groupbymaperr
-sourceRef: slice.go#L311
+sourceRef: slice.go#L370
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-hasprefix.md
+++ b/docs/data/core-hasprefix.md
@@ -1,7 +1,7 @@
 ---
 name: HasPrefix
 slug: hasprefix
-sourceRef: find.go#L41
+sourceRef: find.go#L40
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/SrljzVDpMQM

--- a/docs/data/core-hassuffix.md
+++ b/docs/data/core-hassuffix.md
@@ -1,7 +1,7 @@
 ---
 name: HasSuffix
 slug: hassuffix
-sourceRef: find.go#L57
+sourceRef: find.go#L56
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/bJeLetQNAON

--- a/docs/data/core-if.md
+++ b/docs/data/core-if.md
@@ -1,7 +1,7 @@
 ---
 name: If/Else
 slug: if-else
-sourceRef: condition.go#L31
+sourceRef: condition.go#L33
 category: core
 subCategory: condition
 playUrl: https://go.dev/play/p/WSw3ApMxhyW

--- a/docs/data/core-indexof.md
+++ b/docs/data/core-indexof.md
@@ -1,7 +1,7 @@
 ---
 name: IndexOf
 slug: indexof
-sourceRef: find.go#L14
+sourceRef: find.go#L13
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/Eo7W0lvKTky

--- a/docs/data/core-interleave.md
+++ b/docs/data/core-interleave.md
@@ -1,7 +1,7 @@
 ---
 name: Interleave
 slug: interleave
-sourceRef: slice.go#L282
+sourceRef: slice.go#L533
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/KOVtGUt-tdI

--- a/docs/data/core-intersect.md
+++ b/docs/data/core-intersect.md
@@ -1,7 +1,7 @@
 ---
 name: Intersect
 slug: intersect
-sourceRef: intersect.go#L103
+sourceRef: intersect.go#L119
 category: core
 subCategory: intersect
 playUrl: https://go.dev/play/p/uuElL9X9e58

--- a/docs/data/core-intersectby.md
+++ b/docs/data/core-intersectby.md
@@ -1,7 +1,7 @@
 ---
 name: IntersectBy
 slug: intersectby
-sourceRef: intersect.go#L174
+sourceRef: intersect.go#L162
 category: core
 subCategory: intersect
 playUrl: https://go.dev/play/p/uWF8y2-zmtf

--- a/docs/data/core-invert.md
+++ b/docs/data/core-invert.md
@@ -1,7 +1,7 @@
 ---
 name: Invert
 slug: invert
-sourceRef: map.go#L222
+sourceRef: map.go#L258
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/rFQ4rak6iA1

--- a/docs/data/core-isempty.md
+++ b/docs/data/core-isempty.md
@@ -1,7 +1,7 @@
 ---
 name: IsEmpty
 slug: isempty
-sourceRef: type_manipulation.go#L139
+sourceRef: type_manipulation.go#L147
 category: core
 subCategory: type
 signatures:

--- a/docs/data/core-isnotempty.md
+++ b/docs/data/core-isnotempty.md
@@ -1,7 +1,7 @@
 ---
 name: IsNotEmpty
 slug: isnotempty
-sourceRef: type_manipulation.go#L146
+sourceRef: type_manipulation.go#L154
 category: core
 subCategory: type
 signatures:

--- a/docs/data/core-issorted.md
+++ b/docs/data/core-issorted.md
@@ -1,7 +1,7 @@
 ---
 name: IsSorted
 slug: issorted
-sourceRef: slice.go#L722
+sourceRef: slice.go#L1163
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/mc3qR-t4mcx

--- a/docs/data/core-issortedby.md
+++ b/docs/data/core-issortedby.md
@@ -1,7 +1,7 @@
 ---
 name: IsSortedBy
 slug: issortedby
-sourceRef: slice.go#L733
+sourceRef: slice.go#L1174
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/wiG6XyBBu49

--- a/docs/data/core-keyby.md
+++ b/docs/data/core-keyby.md
@@ -1,7 +1,7 @@
 ---
 name: KeyBy
 slug: keyby
-sourceRef: slice.go#L374
+sourceRef: slice.go#L641
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/ccUiUL_Lnel

--- a/docs/data/core-keybyerr.md
+++ b/docs/data/core-keybyerr.md
@@ -1,7 +1,7 @@
 ---
 name: KeyByErr
 slug: keybyerr
-sourceRef: slice.go#L576
+sourceRef: slice.go#L655
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-keyify.md
+++ b/docs/data/core-keyify.md
@@ -1,7 +1,7 @@
 ---
 name: Keyify
 slug: keyify
-sourceRef: slice.go#L429
+sourceRef: slice.go#L743
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/_d5lXdzfw32

--- a/docs/data/core-last.md
+++ b/docs/data/core-last.md
@@ -1,7 +1,7 @@
 ---
 name: Last
 slug: last
-sourceRef: find.go#L585
+sourceRef: find.go#L888
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/ul45Z0y2EFO

--- a/docs/data/core-lastindexof.md
+++ b/docs/data/core-lastindexof.md
@@ -1,7 +1,7 @@
 ---
 name: LastIndexOf
 slug: lastindexof
-sourceRef: find.go#L27
+sourceRef: find.go#L26
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/Eo7W0lvKTky

--- a/docs/data/core-lastor.md
+++ b/docs/data/core-lastor.md
@@ -1,7 +1,7 @@
 ---
 name: LastOr
 slug: lastor
-sourceRef: find.go#L605
+sourceRef: find.go#L908
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/ul45Z0y2EFO

--- a/docs/data/core-lastorempty.md
+++ b/docs/data/core-lastorempty.md
@@ -1,7 +1,7 @@
 ---
 name: LastOrEmpty
 slug: lastorempty
-sourceRef: find.go#L598
+sourceRef: find.go#L901
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/ul45Z0y2EFO

--- a/docs/data/core-latest.md
+++ b/docs/data/core-latest.md
@@ -1,7 +1,7 @@
 ---
 name: Latest
 slug: latest
-sourceRef: find.go#L508
+sourceRef: find.go#L778
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/dBfdf5s8s-Y

--- a/docs/data/core-latestby.md
+++ b/docs/data/core-latestby.md
@@ -1,7 +1,7 @@
 ---
 name: LatestBy
 slug: latestby
-sourceRef: find.go#L530
+sourceRef: find.go#L801
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/p1HA8XumaMU

--- a/docs/data/core-latestbyerr.md
+++ b/docs/data/core-latestbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: LatestByErr
 slug: latestbyerr
-sourceRef: find.go#L737
+sourceRef: find.go#L827
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/WpBUptwnxuG

--- a/docs/data/core-map.md
+++ b/docs/data/core-map.md
@@ -1,7 +1,7 @@
 ---
 name: Map
 slug: map
-sourceRef: slice.go#L26
+sourceRef: slice.go#L45
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/OkPcYAhBo0D

--- a/docs/data/core-mapentries.md
+++ b/docs/data/core-mapentries.md
@@ -1,7 +1,7 @@
 ---
 name: MapEntries
 slug: mapentries
-sourceRef: map.go#L336
+sourceRef: map.go#L370
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/VuvNQzxKimT

--- a/docs/data/core-mapentrieserr.md
+++ b/docs/data/core-mapentrieserr.md
@@ -1,7 +1,7 @@
 ---
 name: MapEntriesErr
 slug: mapentrieserr
-sourceRef: map.go#L351
+sourceRef: map.go#L383
 category: core
 subCategory: map
 signatures:

--- a/docs/data/core-maperr.md
+++ b/docs/data/core-maperr.md
@@ -1,7 +1,7 @@
 ---
 name: MapErr
 slug: maperr
-sourceRef: slice.go#L36
+sourceRef: slice.go#L57
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-mapkeys.md
+++ b/docs/data/core-mapkeys.md
@@ -1,7 +1,7 @@
 ---
 name: MapKeys
 slug: mapkeys
-sourceRef: map.go#L283
+sourceRef: map.go#L314
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/9_4WPIqOetJ

--- a/docs/data/core-mapkeyserr.md
+++ b/docs/data/core-mapkeyserr.md
@@ -1,7 +1,7 @@
 ---
 name: MapKeysErr
 slug: mapkeyserr
-sourceRef: map.go#L293
+sourceRef: map.go#L326
 category: core
 subCategory: map
 signatures:

--- a/docs/data/core-maptoslice.md
+++ b/docs/data/core-maptoslice.md
@@ -1,7 +1,7 @@
 ---
 name: MapToSlice
 slug: maptoslice
-sourceRef: map.go#L367
+sourceRef: map.go#L399
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/4f5hbHyMf5h

--- a/docs/data/core-maptosliceerr.md
+++ b/docs/data/core-maptosliceerr.md
@@ -1,7 +1,7 @@
 ---
 name: MapToSliceErr
 slug: maptosliceerr
-sourceRef: map.go#L379
+sourceRef: map.go#L411
 category: core
 subCategory: map
 signatures:

--- a/docs/data/core-mapvalues.md
+++ b/docs/data/core-mapvalues.md
@@ -1,7 +1,7 @@
 ---
 name: MapValues
 slug: mapvalues
-sourceRef: map.go#L310
+sourceRef: map.go#L342
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/T_8xAfvcf0W

--- a/docs/data/core-mapvalueserr.md
+++ b/docs/data/core-mapvalueserr.md
@@ -1,7 +1,7 @@
 ---
 name: MapValuesErr
 slug: mapvalueserr
-sourceRef: map.go#L322
+sourceRef: map.go#L354
 category: core
 subCategory: map
 signatures:

--- a/docs/data/core-max.md
+++ b/docs/data/core-max.md
@@ -1,7 +1,7 @@
 ---
 name: Max
 slug: max
-sourceRef: find.go#L410
+sourceRef: find.go#L599
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/wYvG8gRRFw-

--- a/docs/data/core-maxby.md
+++ b/docs/data/core-maxby.md
@@ -1,7 +1,7 @@
 ---
 name: MaxBy
 slug: maxby
-sourceRef: find.go#L507
+sourceRef: find.go#L654
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/PJCc-ThrwX1

--- a/docs/data/core-maxbyerr.md
+++ b/docs/data/core-maxbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: MaxByErr
 slug: maxbyerr
-sourceRef: find.go#L528
+sourceRef: find.go#L683
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/s-63-6_9zqM

--- a/docs/data/core-maxindex.md
+++ b/docs/data/core-maxindex.md
@@ -1,7 +1,7 @@
 ---
 name: MaxIndex
 slug: maxindex
-sourceRef: find.go#L432
+sourceRef: find.go#L622
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/RFkB4Mzb1qt

--- a/docs/data/core-maxindexby.md
+++ b/docs/data/core-maxindexby.md
@@ -1,7 +1,7 @@
 ---
 name: MaxIndexBy
 slug: maxindexby
-sourceRef: find.go#L566
+sourceRef: find.go#L715
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/5yd4W7pe2QJ

--- a/docs/data/core-maxindexbyerr.md
+++ b/docs/data/core-maxindexbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: MaxIndexByErr
 slug: maxindexbyerr
-sourceRef: find.go#L591
+sourceRef: find.go#L746
 category: core
 subCategory: find
 variantHelpers:

--- a/docs/data/core-mean.md
+++ b/docs/data/core-mean.md
@@ -1,7 +1,7 @@
 ---
 name: Mean
 slug: mean
-sourceRef: math.go#L126
+sourceRef: math.go#L152
 category: core
 subCategory: math
 playUrl: https://go.dev/play/p/tPURSuteUsP

--- a/docs/data/core-meanby.md
+++ b/docs/data/core-meanby.md
@@ -1,7 +1,7 @@
 ---
 name: MeanBy
 slug: meanby
-sourceRef: math.go#L161
+sourceRef: math.go#L163
 category: core
 subCategory: math
 playUrl: https://go.dev/play/p/j7TsVwBOZ7P

--- a/docs/data/core-meanbyerr.md
+++ b/docs/data/core-meanbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: MeanByErr
 slug: meanbyerr
-sourceRef: math.go#L172
+sourceRef: math.go#L175
 category: core
 subCategory: math
 variantHelpers:

--- a/docs/data/core-min.md
+++ b/docs/data/core-min.md
@@ -1,7 +1,7 @@
 ---
 name: Min
 slug: min
-sourceRef: find.go#L265
+sourceRef: find.go#L352
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/fJFLwpY8eMN

--- a/docs/data/core-minby.md
+++ b/docs/data/core-minby.md
@@ -1,7 +1,7 @@
 ---
 name: MinBy
 slug: minby
-sourceRef: find.go#L329
+sourceRef: find.go#L403
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/-B1PsrHVnfx

--- a/docs/data/core-minbyerr.md
+++ b/docs/data/core-minbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: MinByErr
 slug: minbyerr
-sourceRef: find.go#L349
+sourceRef: find.go#L428
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/nvDYGS8q895

--- a/docs/data/core-minindex.md
+++ b/docs/data/core-minindex.md
@@ -1,7 +1,7 @@
 ---
 name: MinIndex
 slug: minindex
-sourceRef: find.go#L287
+sourceRef: find.go#L375
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/RxAidik4p50

--- a/docs/data/core-minindexby.md
+++ b/docs/data/core-minindexby.md
@@ -1,7 +1,7 @@
 ---
 name: MinIndexBy
 slug: minindexby
-sourceRef: find.go#L337
+sourceRef: find.go#L457
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/zwwPRqWhnUY

--- a/docs/data/core-minindexbyerr.md
+++ b/docs/data/core-minindexbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: MinIndexByErr
 slug: minindexbyerr
-sourceRef: find.go#L404
+sourceRef: find.go#L486
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/MUqi_NvTKM1

--- a/docs/data/core-mode.md
+++ b/docs/data/core-mode.md
@@ -1,7 +1,7 @@
 ---
 name: Mode
 slug: mode
-sourceRef: math.go#L149
+sourceRef: math.go#L191
 category: core
 subCategory: math
 playUrl: https://go.dev/play/p/PbiviqnV5zX

--- a/docs/data/core-newdebounce.md
+++ b/docs/data/core-newdebounce.md
@@ -1,7 +1,7 @@
 ---
 name: NewDebounce
 slug: newdebounce
-sourceRef: retry.go#L54
+sourceRef: retry.go#L56
 category: core
 subCategory: concurrency
 playUrl: https://go.dev/play/p/_IPY7ROzbMk

--- a/docs/data/core-newdebounceby.md
+++ b/docs/data/core-newdebounceby.md
@@ -1,7 +1,7 @@
 ---
 name: NewDebounceBy
 slug: newdebounceby
-sourceRef: retry.go#L137
+sourceRef: retry.go#L139
 category: core
 subCategory: concurrency
 playUrl: https://go.dev/play/p/Izk7GEzZm2Q

--- a/docs/data/core-newthrottle.md
+++ b/docs/data/core-newthrottle.md
@@ -1,7 +1,7 @@
 ---
 name: NewThrottle
 slug: newthrottle
-sourceRef: retry.go#L349
+sourceRef: retry.go#L347
 category: core
 subCategory: concurrency
 playUrl: https://go.dev/play/p/qQn3fm8Z7jS

--- a/docs/data/core-newthrottleby.md
+++ b/docs/data/core-newthrottleby.md
@@ -1,7 +1,7 @@
 ---
 name: NewThrottleBy
 slug: newthrottleby
-sourceRef: retry.go#L371
+sourceRef: retry.go#L369
 category: core
 subCategory: concurrency
 playUrl: https://go.dev/play/p/0Wv6oX7dHdC

--- a/docs/data/core-newthrottlebywithcount.md
+++ b/docs/data/core-newthrottlebywithcount.md
@@ -1,7 +1,7 @@
 ---
 name: NewThrottleByWithCount
 slug: newthrottlebywithcount
-sourceRef: retry.go#L377
+sourceRef: retry.go#L375
 category: core
 subCategory: concurrency
 playUrl: https://go.dev/play/p/vQk3ECH7_EW

--- a/docs/data/core-newthrottlewithcount.md
+++ b/docs/data/core-newthrottlewithcount.md
@@ -1,7 +1,7 @@
 ---
 name: NewThrottleWithCount
 slug: newthrottlewithcount
-sourceRef: retry.go#L355
+sourceRef: retry.go#L353
 category: core
 subCategory: concurrency
 playUrl: https://go.dev/play/p/w5nc0MgWtjC

--- a/docs/data/core-newtransaction.md
+++ b/docs/data/core-newtransaction.md
@@ -1,7 +1,7 @@
 ---
 name: NewTransaction
 slug: newtransaction
-sourceRef: retry.go#L253
+sourceRef: retry.go#L255
 category: core
 subCategory: concurrency
 playUrl: https://go.dev/play/p/7B2o52wEQbj

--- a/docs/data/core-none.md
+++ b/docs/data/core-none.md
@@ -1,7 +1,7 @@
 ---
 name: None
 slug: none
-sourceRef: intersect.go#L79
+sourceRef: intersect.go#L90
 category: core
 subCategory: intersect
 playUrl: https://go.dev/play/p/fye7JsmxzPV

--- a/docs/data/core-noneby.md
+++ b/docs/data/core-noneby.md
@@ -1,7 +1,7 @@
 ---
 name: NoneBy
 slug: noneby
-sourceRef: intersect.go#L91
+sourceRef: intersect.go#L107
 category: core
 subCategory: intersect
 playUrl: https://go.dev/play/p/O64WZ32H58S

--- a/docs/data/core-nth.md
+++ b/docs/data/core-nth.md
@@ -1,7 +1,7 @@
 ---
 name: Nth
 slug: nth
-sourceRef: find.go#L617
+sourceRef: find.go#L920
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/mNFI9-kIZZ5

--- a/docs/data/core-nthor.md
+++ b/docs/data/core-nthor.md
@@ -1,7 +1,7 @@
 ---
 name: NthOr
 slug: nthor
-sourceRef: find.go#L635
+sourceRef: find.go#L943
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/njKcNhBBVsF

--- a/docs/data/core-nthorempty.md
+++ b/docs/data/core-nthorempty.md
@@ -1,7 +1,7 @@
 ---
 name: NthOrEmpty
 slug: nthorempty
-sourceRef: find.go#L647
+sourceRef: find.go#L955
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/sHoh88KWt6B

--- a/docs/data/core-omitbykeys.md
+++ b/docs/data/core-omitbykeys.md
@@ -1,7 +1,7 @@
 ---
 name: OmitByKeys
 slug: omitbykeys
-sourceRef: map.go#L154
+sourceRef: map.go#L187
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/t1QjCrs-ysk

--- a/docs/data/core-omitbyvalues.md
+++ b/docs/data/core-omitbyvalues.md
@@ -1,7 +1,7 @@
 ---
 name: OmitByValues
 slug: omitbyvalues
-sourceRef: map.go#L167
+sourceRef: map.go#L200
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/9UYZi-hrs8j

--- a/docs/data/core-partitionby.md
+++ b/docs/data/core-partitionby.md
@@ -1,7 +1,7 @@
 ---
 name: PartitionBy
 slug: partitionby
-sourceRef: slice.go#L240
+sourceRef: slice.go#L419
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/NfQ_nGjkgXW

--- a/docs/data/core-partitionbyerr.md
+++ b/docs/data/core-partitionbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: PartitionByErr
 slug: partitionbyerr
-sourceRef: slice.go#L385
+sourceRef: slice.go#L446
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-pickbykeys.md
+++ b/docs/data/core-pickbykeys.md
@@ -1,7 +1,7 @@
 ---
 name: PickByKeys
 slug: pickbykeys
-sourceRef: map.go#L118
+sourceRef: map.go#L133
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/R1imbuci9qU

--- a/docs/data/core-pickbyvalues.md
+++ b/docs/data/core-pickbyvalues.md
@@ -1,7 +1,7 @@
 ---
 name: PickByValues
 slug: pickbyvalues
-sourceRef: map.go#L130
+sourceRef: map.go#L145
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/-_PPkSbO1Kc

--- a/docs/data/core-product.md
+++ b/docs/data/core-product.md
@@ -1,7 +1,7 @@
 ---
 name: Product
 slug: product
-sourceRef: math.go#L90
+sourceRef: math.go#L117
 category: core
 subCategory: math
 playUrl: https://go.dev/play/p/2_kjM_smtAH

--- a/docs/data/core-productby.md
+++ b/docs/data/core-productby.md
@@ -1,7 +1,7 @@
 ---
 name: ProductBy
 slug: productby
-sourceRef: math.go#L125
+sourceRef: math.go#L127
 category: core
 subCategory: math
 playUrl: https://go.dev/play/p/wadzrWr9Aer

--- a/docs/data/core-productbyerr.md
+++ b/docs/data/core-productbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: ProductByErr
 slug: productbyerr
-sourceRef: math.go#L134
+sourceRef: math.go#L138
 category: core
 subCategory: math
 variantHelpers:

--- a/docs/data/core-randomstring.md
+++ b/docs/data/core-randomstring.md
@@ -1,7 +1,7 @@
 ---
 name: RandomString
 slug: randomstring
-sourceRef: string.go#L35
+sourceRef: string.go#L84
 category: core
 subCategory: string
 playUrl: https://go.dev/play/p/rRseOQVVum4

--- a/docs/data/core-range.md
+++ b/docs/data/core-range.md
@@ -1,7 +1,7 @@
 ---
 name: Range
 slug: range
-sourceRef: math.go#L9
+sourceRef: math.go#L11
 category: core
 subCategory: math
 playUrl: https://go.dev/play/p/rho00R0WuHs

--- a/docs/data/core-rangefrom.md
+++ b/docs/data/core-rangefrom.md
@@ -1,7 +1,7 @@
 ---
 name: RangeFrom
 slug: rangefrom
-sourceRef: math.go#L21
+sourceRef: math.go#L23
 category: core
 subCategory: math
 playUrl: https://go.dev/play/p/0r6VimXAi9H

--- a/docs/data/core-rangewithsteps.md
+++ b/docs/data/core-rangewithsteps.md
@@ -1,7 +1,7 @@
 ---
 name: RangeWithSteps
 slug: rangewithsteps
-sourceRef: math.go#L34
+sourceRef: math.go#L36
 category: core
 subCategory: math
 playUrl: https://go.dev/play/p/0r6VimXAi9H

--- a/docs/data/core-reduce.md
+++ b/docs/data/core-reduce.md
@@ -1,7 +1,7 @@
 ---
 name: Reduce
 slug: reduce
-sourceRef: slice.go#L87
+sourceRef: slice.go#L141
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/CgHYNUpOd1I

--- a/docs/data/core-reduceerr.md
+++ b/docs/data/core-reduceerr.md
@@ -1,7 +1,7 @@
 ---
 name: ReduceErr
 slug: reduceerr
-sourceRef: slice.go#L128
+sourceRef: slice.go#L152
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-reduceright.md
+++ b/docs/data/core-reduceright.md
@@ -1,7 +1,7 @@
 ---
 name: ReduceRight
 slug: reduceright
-sourceRef: slice.go#L97
+sourceRef: slice.go#L167
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/Fq3W70l7wXF

--- a/docs/data/core-reducerighterr.md
+++ b/docs/data/core-reducerighterr.md
@@ -1,7 +1,7 @@
 ---
 name: ReduceRightErr
 slug: reducerighterr
-sourceRef: slice.go#L153
+sourceRef: slice.go#L177
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-reject.md
+++ b/docs/data/core-reject.md
@@ -1,7 +1,7 @@
 ---
 name: Reject
 slug: reject
-sourceRef: slice.go#L532
+sourceRef: slice.go#L923
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/pFCF5WVB225

--- a/docs/data/core-rejecterr.md
+++ b/docs/data/core-rejecterr.md
@@ -1,7 +1,7 @@
 ---
 name: RejectErr
 slug: rejecterr
-sourceRef: slice.go#L897
+sourceRef: slice.go#L938
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-rejectmap.md
+++ b/docs/data/core-rejectmap.md
@@ -1,7 +1,7 @@
 ---
 name: RejectMap
 slug: rejectmap
-sourceRef: slice.go#L550
+sourceRef: slice.go#L960
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/bmXhtuM2OMq

--- a/docs/data/core-repeat.md
+++ b/docs/data/core-repeat.md
@@ -1,7 +1,7 @@
 ---
 name: Repeat
 slug: repeat
-sourceRef: slice.go#L362
+sourceRef: slice.go#L601
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/g3uHXbmc3b6

--- a/docs/data/core-repeatby.md
+++ b/docs/data/core-repeatby.md
@@ -1,7 +1,7 @@
 ---
 name: RepeatBy
 slug: repeatby
-sourceRef: slice.go#L362
+sourceRef: slice.go#L613
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/ozZLCtX_hNU

--- a/docs/data/core-repeatbyerr.md
+++ b/docs/data/core-repeatbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: RepeatByErr
 slug: repeatbyerr
-sourceRef: slice.go#L564
+sourceRef: slice.go#L625
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-replace.md
+++ b/docs/data/core-replace.md
@@ -1,7 +1,7 @@
 ---
 name: Replace
 slug: replace
-sourceRef: slice.go#L684
+sourceRef: slice.go#L1110
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/XfPzmf9gql6

--- a/docs/data/core-replaceall.md
+++ b/docs/data/core-replaceall.md
@@ -1,7 +1,7 @@
 ---
 name: ReplaceAll
 slug: replaceall
-sourceRef: slice.go#L700
+sourceRef: slice.go#L1126
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/a9xZFUHfYcV

--- a/docs/data/core-reverse.md
+++ b/docs/data/core-reverse.md
@@ -1,7 +1,7 @@
 ---
 name: Reverse
 slug: reverse
-sourceRef: slice.go#L331
+sourceRef: slice.go#L582
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/iv2e9jslfBM

--- a/docs/data/core-runelength.md
+++ b/docs/data/core-runelength.md
@@ -1,7 +1,7 @@
 ---
 name: RuneLength
 slug: runelength
-sourceRef: string.go#L160
+sourceRef: string.go#L274
 category: core
 subCategory: string
 playUrl: https://go.dev/play/p/BXT52mBk0zO

--- a/docs/data/core-sample.md
+++ b/docs/data/core-sample.md
@@ -1,7 +1,7 @@
 ---
 name: Sample
 slug: sample
-sourceRef: find.go#L662
+sourceRef: find.go#L966
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/vCcSJbh5s6l

--- a/docs/data/core-sampleby.md
+++ b/docs/data/core-sampleby.md
@@ -1,7 +1,7 @@
 ---
 name: SampleBy
 slug: sampleby
-sourceRef: find.go#L669
+sourceRef: find.go#L972
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/HDmKmMgq0XN

--- a/docs/data/core-samples.md
+++ b/docs/data/core-samples.md
@@ -1,7 +1,7 @@
 ---
 name: Samples
 slug: samples
-sourceRef: find.go#L679
+sourceRef: find.go#L982
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/QYRD8aufD0C

--- a/docs/data/core-samplesby.md
+++ b/docs/data/core-samplesby.md
@@ -1,7 +1,7 @@
 ---
 name: SamplesBy
 slug: samplesby
-sourceRef: find.go#L686
+sourceRef: find.go#L988
 category: core
 subCategory: find
 playUrl: https://go.dev/play/p/Dy9bGDhD_Gw

--- a/docs/data/core-shuffle.md
+++ b/docs/data/core-shuffle.md
@@ -1,7 +1,7 @@
 ---
 name: Shuffle
 slug: shuffle
-sourceRef: slice.go#L322
+sourceRef: slice.go#L573
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/whgrQWwOy-j

--- a/docs/data/core-slice.md
+++ b/docs/data/core-slice.md
@@ -1,7 +1,7 @@
 ---
 name: Slice
 slug: slice
-sourceRef: slice.go#L658
+sourceRef: slice.go#L1087
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/8XWYhfMMA1h

--- a/docs/data/core-slicetochannel.md
+++ b/docs/data/core-slicetochannel.md
@@ -1,7 +1,7 @@
 ---
 name: SliceToChannel
 slug: slicetochannel
-sourceRef: channel.go#L18
+sourceRef: channel.go#L161
 category: core
 subCategory: channel
 signatures:

--- a/docs/data/core-slicetomap.md
+++ b/docs/data/core-slicetomap.md
@@ -1,7 +1,7 @@
 ---
 name: SliceToMap
 slug: slicetomap
-sourceRef: slice.go#L405
+sourceRef: slice.go#L699
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/WHa2CfMO3Lr

--- a/docs/data/core-sliding.md
+++ b/docs/data/core-sliding.md
@@ -1,7 +1,7 @@
 ---
 name: Sliding
 slug: sliding
-sourceRef: slice.go#L313
+sourceRef: slice.go#L506
 category: core
 subCategory: slice
 variantHelpers:

--- a/docs/data/core-some.md
+++ b/docs/data/core-some.md
@@ -1,7 +1,7 @@
 ---
 name: Some
 slug: some
-sourceRef: intersect.go#L54
+sourceRef: intersect.go#L60
 category: core
 subCategory: intersect
 playUrl: https://go.dev/play/p/Lj4ceFkeT9V

--- a/docs/data/core-someby.md
+++ b/docs/data/core-someby.md
@@ -1,7 +1,7 @@
 ---
 name: SomeBy
 slug: someby
-sourceRef: intersect.go#L67
+sourceRef: intersect.go#L78
 category: core
 subCategory: intersect
 playUrl: https://go.dev/play/p/DXF-TORBudx

--- a/docs/data/core-splice.md
+++ b/docs/data/core-splice.md
@@ -1,7 +1,7 @@
 ---
 name: Splice
 slug: splice
-sourceRef: slice.go#L748
+sourceRef: slice.go#L1196
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/G5_GhkeSUBA

--- a/docs/data/core-subset.md
+++ b/docs/data/core-subset.md
@@ -1,7 +1,7 @@
 ---
 name: Subset
 slug: subset
-sourceRef: slice.go#L635
+sourceRef: slice.go#L1064
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/tOQu1GhFcog

--- a/docs/data/core-substring.md
+++ b/docs/data/core-substring.md
@@ -1,7 +1,7 @@
 ---
 name: Substring
 slug: substring
-sourceRef: string.go#L105
+sourceRef: string.go#L158
 category: core
 subCategory: string
 playUrl: https://go.dev/play/p/emzCC9zBjHu

--- a/docs/data/core-sum.md
+++ b/docs/data/core-sum.md
@@ -1,7 +1,7 @@
 ---
 name: Sum
 slug: sum
-sourceRef: math.go#L70
+sourceRef: math.go#L82
 category: core
 subCategory: math
 playUrl: https://go.dev/play/p/upfeJVqs4Bt

--- a/docs/data/core-sumby.md
+++ b/docs/data/core-sumby.md
@@ -1,7 +1,7 @@
 ---
 name: SumBy
 slug: sumby
-sourceRef: math.go#L80
+sourceRef: math.go#L92
 category: core
 subCategory: math
 playUrl: https://go.dev/play/p/Dz_a_7jN_ca

--- a/docs/data/core-sumbyerr.md
+++ b/docs/data/core-sumbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: SumByErr
 slug: sumbyerr
-sourceRef: math.go#L102
+sourceRef: math.go#L103
 category: core
 subCategory: math
 variantHelpers:

--- a/docs/data/core-switch.md
+++ b/docs/data/core-switch.md
@@ -1,7 +1,7 @@
 ---
 name: Switch
 slug: switch
-sourceRef: condition.go#L101
+sourceRef: condition.go#L105
 category: core
 subCategory: condition
 playUrl: https://go.dev/play/p/TGbKUMAeRUd

--- a/docs/data/core-take.md
+++ b/docs/data/core-take.md
@@ -1,7 +1,7 @@
 ---
 name: Take
 slug: take
-sourceRef: slice.go#L587
+sourceRef: slice.go#L813
 category: core
 subCategory: slice
 variantHelpers:

--- a/docs/data/core-takefilter.md
+++ b/docs/data/core-takefilter.md
@@ -1,7 +1,7 @@
 ---
 name: TakeFilter
 slug: takefilter
-sourceRef: slice.go#L643
+sourceRef: slice.go#L896
 category: core
 subCategory: slice
 variantHelpers:

--- a/docs/data/core-takewhile.md
+++ b/docs/data/core-takewhile.md
@@ -1,7 +1,7 @@
 ---
 name: TakeWhile
 slug: takewhile
-sourceRef: slice.go#L605
+sourceRef: slice.go#L840
 category: core
 subCategory: slice
 variantHelpers:

--- a/docs/data/core-times.md
+++ b/docs/data/core-times.md
@@ -1,7 +1,7 @@
 ---
 name: Times
 slug: times
-sourceRef: slice.go#L127
+sourceRef: slice.go#L212
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/vgQj3Glr6lT

--- a/docs/data/core-toanyslice.md
+++ b/docs/data/core-toanyslice.md
@@ -1,7 +1,7 @@
 ---
 name: ToAnySlice
 slug: toanyslice
-sourceRef: type_manipulation.go#L107
+sourceRef: type_manipulation.go#L115
 category: core
 subCategory: type
 signatures:

--- a/docs/data/core-topairs.md
+++ b/docs/data/core-topairs.md
@@ -1,7 +1,7 @@
 ---
 name: ToPairs
 slug: topairs
-sourceRef: map.go#L195
+sourceRef: map.go#L231
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/3Dhgx46gawJ

--- a/docs/data/core-trim.md
+++ b/docs/data/core-trim.md
@@ -1,7 +1,7 @@
 ---
 name: Trim
 slug: trim
-sourceRef: slice.go#L842
+sourceRef: slice.go#L1268
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/LZLfLj5C8Lg

--- a/docs/data/core-trimleft.md
+++ b/docs/data/core-trimleft.md
@@ -1,7 +1,7 @@
 ---
 name: TrimLeft
 slug: trimleft
-sourceRef: slice.go#L847
+sourceRef: slice.go#L1295
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/fJK-AhROy9w

--- a/docs/data/core-trimprefix.md
+++ b/docs/data/core-trimprefix.md
@@ -1,7 +1,7 @@
 ---
 name: TrimPrefix
 slug: trimprefix
-sourceRef: slice.go#L858
+sourceRef: slice.go#L1306
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/8O2RoWYzi8J

--- a/docs/data/core-trimright.md
+++ b/docs/data/core-trimright.md
@@ -1,7 +1,7 @@
 ---
 name: TrimRight
 slug: trimright
-sourceRef: slice.go#L873
+sourceRef: slice.go#L1320
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/9V_N8sRyyiZ

--- a/docs/data/core-trimsuffix.md
+++ b/docs/data/core-trimsuffix.md
@@ -1,7 +1,7 @@
 ---
 name: TrimSuffix
 slug: trimsuffix
-sourceRef: slice.go#L884
+sourceRef: slice.go#L1331
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/IjEUrV0iofq

--- a/docs/data/core-union.md
+++ b/docs/data/core-union.md
@@ -1,7 +1,7 @@
 ---
 name: Union
 slug: union
-sourceRef: intersect.go#L157
+sourceRef: intersect.go#L235
 category: core
 subCategory: intersect
 playUrl: https://go.dev/play/p/-hsqZNTH0ej

--- a/docs/data/core-uniq.md
+++ b/docs/data/core-uniq.md
@@ -1,7 +1,7 @@
 ---
 name: Uniq
 slug: uniq
-sourceRef: slice.go#L140
+sourceRef: slice.go#L225
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/DTzbeXZ6iEN

--- a/docs/data/core-uniqby.md
+++ b/docs/data/core-uniqby.md
@@ -1,7 +1,7 @@
 ---
 name: UniqBy
 slug: uniqby
-sourceRef: slice.go#L160
+sourceRef: slice.go#L245
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/g42Z3QSb53u

--- a/docs/data/core-uniqbyerr.md
+++ b/docs/data/core-uniqbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: UniqByErr
 slug: uniqbyerr
-sourceRef: slice.go#L240
+sourceRef: slice.go#L267
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-uniqmap.md
+++ b/docs/data/core-uniqmap.md
@@ -1,7 +1,7 @@
 ---
 name: UniqMap
 slug: uniqmap
-sourceRef: slice.go#L38
+sourceRef: slice.go#L73
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/fygzLBhvUdB

--- a/docs/data/core-unzipbyerrx.md
+++ b/docs/data/core-unzipbyerrx.md
@@ -1,7 +1,7 @@
 ---
 name: UnzipByErrX
 slug: unzipbyerrx
-sourceRef: tuples.go#L1024
+sourceRef: tuples.go#L1101
 category: core
 subCategory: tuple
 signatures:

--- a/docs/data/core-unzipbyx.md
+++ b/docs/data/core-unzipbyx.md
@@ -1,7 +1,7 @@
 ---
 name: UnzipByX
 slug: unzipbyx
-sourceRef: tuples.go#L698
+sourceRef: tuples.go#L908
 category: core
 subCategory: tuple
 signatures:

--- a/docs/data/core-unzipx.md
+++ b/docs/data/core-unzipx.md
@@ -1,7 +1,7 @@
 ---
 name: UnzipX
 slug: unzipx
-sourceRef: tuples.go#L514
+sourceRef: tuples.go#L724
 category: core
 subCategory: tuple
 signatures:

--- a/docs/data/core-valueor.md
+++ b/docs/data/core-valueor.md
@@ -1,7 +1,7 @@
 ---
 name: ValueOr
 slug: valueor
-sourceRef: map.go#L97
+sourceRef: map.go#L96
 category: core
 subCategory: map
 playUrl: https://go.dev/play/p/bAq9mHErB4V

--- a/docs/data/core-window.md
+++ b/docs/data/core-window.md
@@ -1,7 +1,7 @@
 ---
 name: Window
 slug: window
-sourceRef: slice.go#L289
+sourceRef: slice.go#L495
 category: core
 subCategory: slice
 variantHelpers:

--- a/docs/data/core-without.md
+++ b/docs/data/core-without.md
@@ -1,7 +1,7 @@
 ---
 name: Without
 slug: without
-sourceRef: intersect.go#L181
+sourceRef: intersect.go#L313
 category: core
 subCategory: intersect
 playUrl: https://go.dev/play/p/PcAVtYJsEsS

--- a/docs/data/core-withoutby.md
+++ b/docs/data/core-withoutby.md
@@ -1,7 +1,7 @@
 ---
 name: WithoutBy
 slug: withoutby
-sourceRef: intersect.go#L273
+sourceRef: intersect.go#L328
 category: core
 subCategory: intersect
 playUrl: https://go.dev/play/p/VgWJOF01NbJ

--- a/docs/data/core-withoutbyerr.md
+++ b/docs/data/core-withoutbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: WithoutByErr
 slug: withoutbyerr
-sourceRef: intersect.go#L287
+sourceRef: intersect.go#L342
 category: core
 subCategory: intersect
 signatures:

--- a/docs/data/core-withoutempty.md
+++ b/docs/data/core-withoutempty.md
@@ -1,7 +1,7 @@
 ---
 name: WithoutEmpty
 slug: withoutempty
-sourceRef: intersect.go#L218
+sourceRef: intersect.go#L362
 category: core
 subCategory: intersect
 playUrl: https://go.dev/play/p/iZvYJWuniJm

--- a/docs/data/core-withoutnth.md
+++ b/docs/data/core-withoutnth.md
@@ -1,7 +1,7 @@
 ---
 name: WithoutNth
 slug: withoutnth
-sourceRef: intersect.go#L223
+sourceRef: intersect.go#L368
 category: core
 subCategory: intersect
 playUrl: https://go.dev/play/p/AIro-_UtL9c

--- a/docs/data/core-words.md
+++ b/docs/data/core-words.md
@@ -1,7 +1,7 @@
 ---
 name: Words
 slug: words
-sourceRef: string.go#L210
+sourceRef: string.go#L406
 category: core
 subCategory: string
 playUrl: https://go.dev/play/p/-f3VIQqiaVw

--- a/docs/data/core-zipbyerrx.md
+++ b/docs/data/core-zipbyerrx.md
@@ -1,7 +1,7 @@
 ---
 name: ZipByErrX
 slug: zipbyerrx
-sourceRef: tuples.go#L444
+sourceRef: tuples.go#L521
 category: core
 subCategory: tuple
 signatures:

--- a/docs/data/core-zipbyx.md
+++ b/docs/data/core-zipbyx.md
@@ -1,7 +1,7 @@
 ---
 name: ZipByX
 slug: zipbyx
-sourceRef: tuples.go#L335
+sourceRef: tuples.go#L341
 category: core
 subCategory: tuple
 signatures:

--- a/docs/data/it-assign.md
+++ b/docs/data/it-assign.md
@@ -1,7 +1,7 @@
 ---
 name: Assign
 slug: assign
-sourceRef: it/map.go#L122
+sourceRef: it/map.go#L140
 category: iter
 subCategory: map
 signatures:

--- a/docs/data/it-associate.md
+++ b/docs/data/it-associate.md
@@ -1,7 +1,7 @@
 ---
 name: Associate
 slug: associate
-sourceRef: it/seq.go#L412
+sourceRef: it/seq.go#L539
 category: iter
 subCategory: map
 signatures:

--- a/docs/data/it-buffer.md
+++ b/docs/data/it-buffer.md
@@ -1,7 +1,7 @@
 ---
 name: Buffer
 slug: buffer
-sourceRef: it/seq.go#L1162
+sourceRef: it/seq.go#L1185
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-channelseq.md
+++ b/docs/data/it-channelseq.md
@@ -1,7 +1,7 @@
 ---
 name: ChannelToSeq
 slug: channeltoseq
-sourceRef: it/channel.go#L39
+sourceRef: it/channel.go#L45
 category: iter
 subCategory: channel
 signatures:

--- a/docs/data/it-channeltoseq.md
+++ b/docs/data/it-channeltoseq.md
@@ -1,7 +1,7 @@
 ---
 name: SeqToChannel2
 slug: channeltoseq
-sourceRef: it/channel.go#L26
+sourceRef: it/channel.go#L29
 category: iter
 subCategory: channel
 signatures:

--- a/docs/data/it-chunk.md
+++ b/docs/data/it-chunk.md
@@ -1,7 +1,7 @@
 ---
 name: Chunk
 slug: chunk
-sourceRef: it/seq.go#L264
+sourceRef: it/seq.go#L290
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-chunkentries.md
+++ b/docs/data/it-chunkentries.md
@@ -1,7 +1,7 @@
 ---
 name: ChunkEntries
 slug: chunkentries
-sourceRef: it/map.go#L138
+sourceRef: it/map.go#L157
 category: iter
 subCategory: map
 signatures:

--- a/docs/data/it-chunkstring.md
+++ b/docs/data/it-chunkstring.md
@@ -1,7 +1,7 @@
 ---
 name: ChunkString
 slug: chunkstring
-sourceRef: it/string.go#L130
+sourceRef: it/string.go#L13
 category: iter
 subCategory: string
 playUrl: "https://go.dev/play/p/Bcc5ixTQQoQ"

--- a/docs/data/it-coalesceseq.md
+++ b/docs/data/it-coalesceseq.md
@@ -1,7 +1,7 @@
 ---
 name: CoalesceSeq
 slug: coalesceseq
-sourceRef: it/type_manipulation.go#L65
+sourceRef: it/type_manipulation.go#L74
 category: iter
 subCategory: type
 signatures:

--- a/docs/data/it-coalesceseqorempty.md
+++ b/docs/data/it-coalesceseqorempty.md
@@ -1,7 +1,7 @@
 ---
 name: CoalesceSeqOrEmpty
 slug: coalesceseqorempty
-sourceRef: it/type_manipulation.go#L76
+sourceRef: it/type_manipulation.go#L86
 category: iter
 subCategory: type
 signatures:

--- a/docs/data/it-compact.md
+++ b/docs/data/it-compact.md
@@ -1,7 +1,7 @@
 ---
 name: Compact
 slug: compact
-sourceRef: it/seq.go#L699
+sourceRef: it/seq.go#L933
 category: iter
 subCategory: slice
 signatures:

--- a/docs/data/it-concat.md
+++ b/docs/data/it-concat.md
@@ -1,7 +1,7 @@
 ---
 name: Concat
 slug: concat
-sourceRef: it/seq.go#L358
+sourceRef: it/seq.go#L431
 category: iter
 subCategory: sequence
 playUrl: https://go.dev/play/p/Fa0u7xT2JOR

--- a/docs/data/it-contains.md
+++ b/docs/data/it-contains.md
@@ -1,7 +1,7 @@
 ---
 name: Contains
 slug: contains
-sourceRef: it/intersect.go#L13
+sourceRef: it/intersect.go#L14
 category: iter
 subCategory: intersect
 signatures:

--- a/docs/data/it-containsby.md
+++ b/docs/data/it-containsby.md
@@ -1,7 +1,7 @@
 ---
 name: ContainsBy
 slug: containsby
-sourceRef: it/intersect.go#L17
+sourceRef: it/intersect.go#L20
 category: iter
 subCategory: intersect
 signatures:

--- a/docs/data/it-count.md
+++ b/docs/data/it-count.md
@@ -1,7 +1,7 @@
 ---
 name: Count / CountBy
 slug: count
-sourceRef: it/seq.go#L630
+sourceRef: it/seq.go#L834
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-countby.md
+++ b/docs/data/it-countby.md
@@ -1,7 +1,7 @@
 ---
 name: CountBy
 slug: countby
-sourceRef: it/seq.go#L325
+sourceRef: it/seq.go#L841
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-countvalues.md
+++ b/docs/data/it-countvalues.md
@@ -1,7 +1,7 @@
 ---
 name: CountValues
 slug: countvalues
-sourceRef: it/seq.go#L720
+sourceRef: it/seq.go#L856
 category: iter
 subCategory: slice
 signatures:

--- a/docs/data/it-countvaluesby.md
+++ b/docs/data/it-countvaluesby.md
@@ -1,7 +1,7 @@
 ---
 name: CountValuesBy
 slug: countvaluesby
-sourceRef: it/seq.go#L720
+sourceRef: it/seq.go#L864
 category: iter
 subCategory: slice
 signatures:

--- a/docs/data/it-crossjoinbyx.md
+++ b/docs/data/it-crossjoinbyx.md
@@ -1,7 +1,7 @@
 ---
 name: CrossJoinByX
 slug: crossjoinbyx
-sourceRef: it/tuples.go#L439
+sourceRef: it/tuples.go#L428
 category: iter
 subCategory: tuple
 signatures:

--- a/docs/data/it-crossjoinx.md
+++ b/docs/data/it-crossjoinx.md
@@ -1,7 +1,7 @@
 ---
 name: CrossJoinX
 slug: crossjoinx
-sourceRef: it/tuples.go#L370
+sourceRef: it/tuples.go#L363
 category: iter
 subCategory: tuple
 signatures:

--- a/docs/data/it-cutprefix.md
+++ b/docs/data/it-cutprefix.md
@@ -1,7 +1,7 @@
 ---
 name: CutPrefix
 slug: cutprefix
-sourceRef: it/seq.go#L778
+sourceRef: it/seq.go#L1004
 category: iter
 subCategory: string
 signatures:

--- a/docs/data/it-cutsuffix.md
+++ b/docs/data/it-cutsuffix.md
@@ -1,7 +1,7 @@
 ---
 name: CutSuffix
 slug: cutsuffix
-sourceRef: it/seq.go#L778
+sourceRef: it/seq.go#L1059
 category: iter
 subCategory: string
 signatures:

--- a/docs/data/it-drain.md
+++ b/docs/data/it-drain.md
@@ -1,7 +1,7 @@
 ---
 name: Drain
 slug: drain
-sourceRef: it/seq.go#L26
+sourceRef: it/seq.go#L27
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-drop.md
+++ b/docs/data/it-drop.md
@@ -1,7 +1,7 @@
 ---
 name: Drop
 slug: drop
-sourceRef: it/seq.go#L498
+sourceRef: it/seq.go#L628
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-dropbyindex.md
+++ b/docs/data/it-dropbyindex.md
@@ -1,7 +1,7 @@
 ---
 name: DropByIndex
 slug: dropbyindex
-sourceRef: it/seq.go#L581
+sourceRef: it/seq.go#L745
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-droplast.md
+++ b/docs/data/it-droplast.md
@@ -1,7 +1,7 @@
 ---
 name: DropLast
 slug: droplast
-sourceRef: it/seq.go#L512
+sourceRef: it/seq.go#L643
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-droplastwhile.md
+++ b/docs/data/it-droplastwhile.md
@@ -1,7 +1,7 @@
 ---
 name: DropLastWhile
 slug: droplastwhile
-sourceRef: it/seq.go#L180
+sourceRef: it/seq.go#L687
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-dropslice.md
+++ b/docs/data/it-dropslice.md
@@ -1,7 +1,7 @@
 ---
 name: DropLast
 slug: dropslice
-sourceRef: it/seq.go#L510
+sourceRef: it/seq.go#L643
 category: iter
 subCategory: slice
 signatures:

--- a/docs/data/it-dropwhile.md
+++ b/docs/data/it-dropwhile.md
@@ -1,7 +1,7 @@
 ---
 name: DropWhile
 slug: dropwhile
-sourceRef: it/seq.go#L180
+sourceRef: it/seq.go#L671
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-earliest.md
+++ b/docs/data/it-earliest.md
@@ -1,7 +1,7 @@
 ---
 name: Earliest
 slug: earliest
-sourceRef: it/find.go#L278
+sourceRef: it/find.go#L296
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-earliestby.md
+++ b/docs/data/it-earliestby.md
@@ -1,7 +1,7 @@
 ---
 name: EarliestBy
 slug: earliestby
-sourceRef: it/find.go#L285
+sourceRef: it/find.go#L304
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-elementsmatch.md
+++ b/docs/data/it-elementsmatch.md
@@ -1,7 +1,7 @@
 ---
 name: ElementsMatch
 slug: elementsmatch
-sourceRef: it/intersect.go#L174
+sourceRef: it/intersect.go#L264
 category: iter
 subCategory: intersect
 signatures:

--- a/docs/data/it-elementsmatchby.md
+++ b/docs/data/it-elementsmatchby.md
@@ -1,7 +1,7 @@
 ---
 name: ElementsMatchBy
 slug: elementsmatchby
-sourceRef: it/intersect.go#L183
+sourceRef: it/intersect.go#L274
 category: iter
 subCategory: intersect
 signatures:

--- a/docs/data/it-empty.md
+++ b/docs/data/it-empty.md
@@ -1,7 +1,7 @@
 ---
 name: Empty
 slug: empty
-sourceRef: it/type_manipulation.go#L44
+sourceRef: it/type_manipulation.go#L50
 category: iter
 subCategory: type
 signatures:

--- a/docs/data/it-entries.md
+++ b/docs/data/it-entries.md
@@ -1,7 +1,7 @@
 ---
 name: Entries
 slug: entries
-sourceRef: it/map.go#L77
+sourceRef: it/map.go#L90
 category: iter
 subCategory: map
 signatures:

--- a/docs/data/it-every.md
+++ b/docs/data/it-every.md
@@ -1,7 +1,7 @@
 ---
 name: Every
 slug: every
-sourceRef: it/intersect.go#L25
+sourceRef: it/intersect.go#L33
 category: iter
 subCategory: intersect
 signatures:

--- a/docs/data/it-everyby.md
+++ b/docs/data/it-everyby.md
@@ -1,7 +1,7 @@
 ---
 name: EveryBy
 slug: everyby
-sourceRef: it/intersect.go#L43
+sourceRef: it/intersect.go#L53
 category: iter
 subCategory: intersect
 signatures:

--- a/docs/data/it-fill.md
+++ b/docs/data/it-fill.md
@@ -1,7 +1,7 @@
 ---
 name: Fill
 slug: fill
-sourceRef: it/seq.go#L26
+sourceRef: it/seq.go#L492
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-filter.md
+++ b/docs/data/it-filter.md
@@ -1,7 +1,7 @@
 ---
 name: Filter
 slug: filter
-sourceRef: it/seq.go#L33
+sourceRef: it/seq.go#L34
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-filterkeys.md
+++ b/docs/data/it-filterkeys.md
@@ -1,7 +1,7 @@
 ---
 name: FilterKeys
 slug: filterkeys
-sourceRef: it/map.go#L238
+sourceRef: it/map.go#L212
 category: iter
 subCategory: map
 signatures:

--- a/docs/data/it-filtermap.md
+++ b/docs/data/it-filtermap.md
@@ -1,7 +1,7 @@
 ---
 name: FilterMap
 slug: filtermap
-sourceRef: it/seq.go#L86
+sourceRef: it/seq.go#L94
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-filtermaptoseq.md
+++ b/docs/data/it-filtermaptoseq.md
@@ -1,7 +1,7 @@
 ---
 name: FilterMapToSeq
 slug: filtermaptoseq
-sourceRef: it/map.go#L178
+sourceRef: it/map.go#L199
 category: iter
 subCategory: map
 signatures:

--- a/docs/data/it-filtervalues.md
+++ b/docs/data/it-filtervalues.md
@@ -1,7 +1,7 @@
 ---
 name: FilterValues
 slug: filtervalues
-sourceRef: it/map.go#L253
+sourceRef: it/map.go#L225
 category: iter
 subCategory: map
 signatures:

--- a/docs/data/it-find.md
+++ b/docs/data/it-find.md
@@ -1,7 +1,7 @@
 ---
 name: Find
 slug: find
-sourceRef: it/find.go#L105
+sourceRef: it/find.go#L103
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-findduplicates.md
+++ b/docs/data/it-findduplicates.md
@@ -1,7 +1,7 @@
 ---
 name: FindDuplicates
 slug: findduplicates
-sourceRef: it/find.go#L196
+sourceRef: it/find.go#L205
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-findduplicatesby.md
+++ b/docs/data/it-findduplicatesby.md
@@ -1,7 +1,7 @@
 ---
 name: FindDuplicatesBy
 slug: findduplicatesby
-sourceRef: it/find.go#L200
+sourceRef: it/find.go#L215
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-findindexof.md
+++ b/docs/data/it-findindexof.md
@@ -1,7 +1,7 @@
 ---
 name: FindIndexOf
 slug: findindexof
-sourceRef: it/find.go#L112
+sourceRef: it/find.go#L117
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-findlastindexof.md
+++ b/docs/data/it-findlastindexof.md
@@ -1,7 +1,7 @@
 ---
 name: FindLastIndexOf
 slug: findlastindexof
-sourceRef: it/find.go#L127
+sourceRef: it/find.go#L133
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-findorelse.md
+++ b/docs/data/it-findorelse.md
@@ -1,7 +1,7 @@
 ---
 name: FindOrElse
 slug: findorelse
-sourceRef: it/find.go#L147
+sourceRef: it/find.go#L154
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-finduniques.md
+++ b/docs/data/it-finduniques.md
@@ -1,7 +1,7 @@
 ---
 name: FindUniques
 slug: finduniques
-sourceRef: it/find.go#L159
+sourceRef: it/find.go#L167
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-finduniquesby.md
+++ b/docs/data/it-finduniquesby.md
@@ -1,7 +1,7 @@
 ---
 name: FindUniquesBy
 slug: finduniquesby
-sourceRef: it/find.go#L163
+sourceRef: it/find.go#L177
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-first.md
+++ b/docs/data/it-first.md
@@ -1,7 +1,7 @@
 ---
 name: First
 slug: first
-sourceRef: it/find.go#L362
+sourceRef: it/find.go#L385
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-firstor.md
+++ b/docs/data/it-firstor.md
@@ -1,7 +1,7 @@
 ---
 name: FirstOr
 slug: firstor
-sourceRef: it/find.go#L377
+sourceRef: it/find.go#L404
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-firstorempty.md
+++ b/docs/data/it-firstorempty.md
@@ -1,7 +1,7 @@
 ---
 name: FirstOrEmpty
 slug: firstorempty
-sourceRef: it/find.go#L370
+sourceRef: it/find.go#L396
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-flatmap.md
+++ b/docs/data/it-flatmap.md
@@ -1,7 +1,7 @@
 ---
 name: FlatMap
 slug: flatmap
-sourceRef: it/seq.go#L109
+sourceRef: it/seq.go#L120
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-flatten.md
+++ b/docs/data/it-flatten.md
@@ -1,7 +1,7 @@
 ---
 name: Flatten
 slug: flatten
-sourceRef: it/seq.go#L26
+sourceRef: it/seq.go#L417
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-foreach.md
+++ b/docs/data/it-foreach.md
@@ -1,7 +1,7 @@
 ---
 name: ForEach
 slug: foreach
-sourceRef: it/seq.go#L166
+sourceRef: it/seq.go#L183
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-foreachwhile.md
+++ b/docs/data/it-foreachwhile.md
@@ -1,7 +1,7 @@
 ---
 name: ForEachWhile
 slug: foreachwhile
-sourceRef: it/seq.go#L180
+sourceRef: it/seq.go#L202
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-fromanyseq.md
+++ b/docs/data/it-fromanyseq.md
@@ -1,7 +1,7 @@
 ---
 name: FromAnySeq
 slug: fromanyseq
-sourceRef: it/type_manipulation.go#L11
+sourceRef: it/type_manipulation.go#L39
 category: iter
 subCategory: type
 signatures:

--- a/docs/data/it-fromentries.md
+++ b/docs/data/it-fromentries.md
@@ -1,7 +1,7 @@
 ---
 name: FromEntries
 slug: fromentries
-sourceRef: it/map.go#L96
+sourceRef: it/map.go#L111
 category: iter
 subCategory: map
 signatures:

--- a/docs/data/it-frompairs.md
+++ b/docs/data/it-frompairs.md
@@ -1,7 +1,7 @@
 ---
 name: FromPairs
 slug: frompairs
-sourceRef: it/map.go#L104
+sourceRef: it/map.go#L122
 category: iter
 subCategory: map
 signatures:

--- a/docs/data/it-fromseqptr.md
+++ b/docs/data/it-fromseqptr.md
@@ -1,7 +1,7 @@
 ---
 name: FromSeqPtr
 slug: fromseqptr
-sourceRef: it/type_manipulation.go#L11
+sourceRef: it/type_manipulation.go#L20
 category: iter
 subCategory: type
 signatures:

--- a/docs/data/it-fromseqptror.md
+++ b/docs/data/it-fromseqptror.md
@@ -1,7 +1,7 @@
 ---
 name: FromSeqPtrOr
 slug: fromseqptror
-sourceRef: it/type_manipulation.go#L11
+sourceRef: it/type_manipulation.go#L26
 category: iter
 subCategory: type
 signatures:

--- a/docs/data/it-groupby.md
+++ b/docs/data/it-groupby.md
@@ -1,7 +1,7 @@
 ---
 name: GroupBy
 slug: groupby
-sourceRef: it/seq.go#L244
+sourceRef: it/seq.go#L268
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-hasprefix.md
+++ b/docs/data/it-hasprefix.md
@@ -1,7 +1,7 @@
 ---
 name: HasPrefix
 slug: hasprefix
-sourceRef: it/find.go#L49
+sourceRef: it/find.go#L51
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-hassuffix.md
+++ b/docs/data/it-hassuffix.md
@@ -1,7 +1,7 @@
 ---
 name: HasSuffix
 slug: hassuffix
-sourceRef: it/find.go#L71
+sourceRef: it/find.go#L74
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-interleave.md
+++ b/docs/data/it-interleave.md
@@ -1,7 +1,7 @@
 ---
 name: Interleave
 slug: interleave
-sourceRef: it/seq.go#L26
+sourceRef: it/seq.go#L438
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-intersect.md
+++ b/docs/data/it-intersect.md
@@ -1,7 +1,7 @@
 ---
 name: Intersect
 slug: intersect
-sourceRef: it/intersect.go#L78
+sourceRef: it/intersect.go#L123
 category: iter
 subCategory: intersect
 signatures:

--- a/docs/data/it-intersectby.md
+++ b/docs/data/it-intersectby.md
@@ -1,7 +1,7 @@
 ---
 name: IntersectBy
 slug: intersectby
-sourceRef: it/intersect.go#L78
+sourceRef: it/intersect.go#L169
 category: iter
 subCategory: intersect
 signatures:

--- a/docs/data/it-invert.md
+++ b/docs/data/it-invert.md
@@ -1,7 +1,7 @@
 ---
 name: Invert
 slug: invert
-sourceRef: it/map.go#L111
+sourceRef: it/map.go#L128
 category: iter
 subCategory: map
 signatures:

--- a/docs/data/it-isempty.md
+++ b/docs/data/it-isempty.md
@@ -1,7 +1,7 @@
 ---
 name: IsEmpty
 slug: isempty
-sourceRef: it/type_manipulation.go#L50
+sourceRef: it/type_manipulation.go#L57
 category: iter
 subCategory: type
 signatures:

--- a/docs/data/it-isnotempty.md
+++ b/docs/data/it-isnotempty.md
@@ -1,7 +1,7 @@
 ---
 name: IsNotEmpty
 slug: isnotempty
-sourceRef: it/type_manipulation.go#L59
+sourceRef: it/type_manipulation.go#L67
 category: iter
 subCategory: condition
 signatures:

--- a/docs/data/it-issorted.md
+++ b/docs/data/it-issorted.md
@@ -1,7 +1,7 @@
 ---
 name: IsSorted
 slug: issorted
-sourceRef: it/seq.go#L720
+sourceRef: it/seq.go#L940
 category: iter
 subCategory: slice
 signatures:

--- a/docs/data/it-issortedby.md
+++ b/docs/data/it-issortedby.md
@@ -1,7 +1,7 @@
 ---
 name: IsSortedBy
 slug: issortedby
-sourceRef: it/seq.go#L720
+sourceRef: it/seq.go#L947
 category: iter
 subCategory: slice
 signatures:

--- a/docs/data/it-keyby.md
+++ b/docs/data/it-keyby.md
@@ -1,7 +1,7 @@
 ---
 name: KeyBy
 slug: keyby
-sourceRef: it/seq.go#L398
+sourceRef: it/seq.go#L523
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-keyify.md
+++ b/docs/data/it-keyify.md
@@ -1,7 +1,7 @@
 ---
 name: Keyify
 slug: keyify
-sourceRef: it/seq.go#L720
+sourceRef: it/seq.go#L616
 category: iter
 subCategory: slice
 signatures:

--- a/docs/data/it-keys.md
+++ b/docs/data/it-keys.md
@@ -1,7 +1,7 @@
 ---
 name: Keys
 slug: keys
-sourceRef: it/map.go#L11
+sourceRef: it/map.go#L12
 category: iter
 subCategory: map
 signatures:

--- a/docs/data/it-last.md
+++ b/docs/data/it-last.md
@@ -1,7 +1,7 @@
 ---
 name: Last
 slug: last
-sourceRef: it/find.go#L389
+sourceRef: it/find.go#L415
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-lastindexof.md
+++ b/docs/data/it-lastindexof.md
@@ -1,7 +1,7 @@
 ---
 name: LastIndexOf
 slug: lastindexof
-sourceRef: it/find.go#L34
+sourceRef: it/find.go#L35
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-lastor.md
+++ b/docs/data/it-lastor.md
@@ -1,7 +1,7 @@
 ---
 name: LastOr
 slug: lastor
-sourceRef: it/find.go#L407
+sourceRef: it/find.go#L437
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-lastorempty.md
+++ b/docs/data/it-lastorempty.md
@@ -1,7 +1,7 @@
 ---
 name: LastOrEmpty
 slug: lastorempty
-sourceRef: it/find.go#L400
+sourceRef: it/find.go#L429
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-latest.md
+++ b/docs/data/it-latest.md
@@ -1,7 +1,7 @@
 ---
 name: Latest
 slug: latest
-sourceRef: it/find.go#L346
+sourceRef: it/find.go#L370
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-latestby.md
+++ b/docs/data/it-latestby.md
@@ -1,7 +1,7 @@
 ---
 name: LatestBy
 slug: latestby
-sourceRef: it/find.go#L353
+sourceRef: it/find.go#L378
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-map.md
+++ b/docs/data/it-map.md
@@ -1,7 +1,7 @@
 ---
 name: Map
 slug: map
-sourceRef: it/seq.go#L51
+sourceRef: it/seq.go#L54
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-maptoseq.md
+++ b/docs/data/it-maptoseq.md
@@ -1,7 +1,7 @@
 ---
 name: MapToSeq
 slug: maptoseq
-sourceRef: it/map.go#L164
+sourceRef: it/map.go#L184
 category: iter
 subCategory: map
 signatures:

--- a/docs/data/it-max.md
+++ b/docs/data/it-max.md
@@ -1,7 +1,7 @@
 ---
 name: Max
 slug: max
-sourceRef: it/find.go#L295
+sourceRef: it/find.go#L312
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-maxby.md
+++ b/docs/data/it-maxby.md
@@ -1,7 +1,7 @@
 ---
 name: MaxBy
 slug: maxby
-sourceRef: it/find.go#L310
+sourceRef: it/find.go#L329
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-maxindex.md
+++ b/docs/data/it-maxindex.md
@@ -1,7 +1,7 @@
 ---
 name: MaxIndex
 slug: maxindex
-sourceRef: it/find.go#L299
+sourceRef: it/find.go#L320
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-maxindexby.md
+++ b/docs/data/it-maxindexby.md
@@ -1,7 +1,7 @@
 ---
 name: MaxIndexBy
 slug: maxindexby
-sourceRef: it/find.go#L326
+sourceRef: it/find.go#L350
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-mean.md
+++ b/docs/data/it-mean.md
@@ -1,7 +1,7 @@
 ---
 name: Mean / MeanBy
 slug: mean
-sourceRef: it/math.go#L80
+sourceRef: it/math.go#L108
 category: iter
 subCategory: math
 signatures:

--- a/docs/data/it-meanby.md
+++ b/docs/data/it-meanby.md
@@ -1,7 +1,7 @@
 ---
 name: MeanBy
 slug: meanby
-sourceRef: it/math.go#L106
+sourceRef: it/math.go#L115
 category: iter
 subCategory: math
 signatures:

--- a/docs/data/it-min.md
+++ b/docs/data/it-min.md
@@ -1,7 +1,7 @@
 ---
 name: Min
 slug: min
-sourceRef: it/find.go#L227
+sourceRef: it/find.go#L238
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-minby.md
+++ b/docs/data/it-minby.md
@@ -1,7 +1,7 @@
 ---
 name: MinBy
 slug: minby
-sourceRef: it/find.go#L242
+sourceRef: it/find.go#L255
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-minindex.md
+++ b/docs/data/it-minindex.md
@@ -1,7 +1,7 @@
 ---
 name: MinIndex
 slug: minindex
-sourceRef: it/find.go#L231
+sourceRef: it/find.go#L246
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-minindexby.md
+++ b/docs/data/it-minindexby.md
@@ -1,7 +1,7 @@
 ---
 name: MinIndexBy
 slug: minindexby
-sourceRef: it/find.go#L258
+sourceRef: it/find.go#L276
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-mode.md
+++ b/docs/data/it-mode.md
@@ -1,7 +1,7 @@
 ---
 name: Mode
 slug: mode
-sourceRef: it/math.go#L124
+sourceRef: it/math.go#L134
 category: iter
 subCategory: math
 signatures:

--- a/docs/data/it-none.md
+++ b/docs/data/it-none.md
@@ -1,7 +1,7 @@
 ---
 name: None
 slug: none
-sourceRef: it/intersect.go#L63
+sourceRef: it/intersect.go#L95
 category: iter
 subCategory: intersect
 signatures:

--- a/docs/data/it-noneby.md
+++ b/docs/data/it-noneby.md
@@ -1,7 +1,7 @@
 ---
 name: NoneBy
 slug: noneby
-sourceRef: it/intersect.go#L69
+sourceRef: it/intersect.go#L109
 category: iter
 subCategory: intersect
 signatures:

--- a/docs/data/it-nth.md
+++ b/docs/data/it-nth.md
@@ -1,7 +1,7 @@
 ---
 name: Nth
 slug: nth
-sourceRef: it/find.go#L417
+sourceRef: it/find.go#L448
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-nthor.md
+++ b/docs/data/it-nthor.md
@@ -1,7 +1,7 @@
 ---
 name: NthOr
 slug: nthor
-sourceRef: it/find.go#L433
+sourceRef: it/find.go#L472
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-nthorempty.md
+++ b/docs/data/it-nthorempty.md
@@ -1,7 +1,7 @@
 ---
 name: NthOrEmpty
 slug: nthorempty
-sourceRef: it/find.go#L444
+sourceRef: it/find.go#L484
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-partitionby.md
+++ b/docs/data/it-partitionby.md
@@ -1,7 +1,7 @@
 ---
 name: PartitionBy
 slug: partitionby
-sourceRef: it/seq.go#L26
+sourceRef: it/seq.go#L396
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-product.md
+++ b/docs/data/it-product.md
@@ -1,7 +1,7 @@
 ---
 name: Product / ProductBy
 slug: product
-sourceRef: it/math.go#L70
+sourceRef: it/math.go#L90
 category: iter
 subCategory: math
 signatures:

--- a/docs/data/it-productby.md
+++ b/docs/data/it-productby.md
@@ -1,7 +1,7 @@
 ---
 name: ProductBy
 slug: productby
-sourceRef: it/math.go#L90
+sourceRef: it/math.go#L97
 category: iter
 subCategory: math
 signatures:

--- a/docs/data/it-range.md
+++ b/docs/data/it-range.md
@@ -1,7 +1,7 @@
 ---
 name: Range
 slug: range
-sourceRef: it/math.go#L12
+sourceRef: it/math.go#L14
 category: iter
 subCategory: math
 signatures:

--- a/docs/data/it-rangefrom.md
+++ b/docs/data/it-rangefrom.md
@@ -1,7 +1,7 @@
 ---
 name: RangeFrom
 slug: rangefrom
-sourceRef: it/math.go#L25
+sourceRef: it/math.go#L28
 category: iter
 subCategory: math
 signatures:

--- a/docs/data/it-rangewithsteps.md
+++ b/docs/data/it-rangewithsteps.md
@@ -1,7 +1,7 @@
 ---
 name: RangeWithSteps
 slug: rangewithsteps
-sourceRef: it/math.go#L35
+sourceRef: it/math.go#L43
 category: iter
 subCategory: math
 signatures:

--- a/docs/data/it-reduce.md
+++ b/docs/data/it-reduce.md
@@ -1,7 +1,7 @@
 ---
 name: Reduce
 slug: reduce
-sourceRef: it/seq.go#L133
+sourceRef: it/seq.go#L146
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-reducelast.md
+++ b/docs/data/it-reducelast.md
@@ -1,7 +1,7 @@
 ---
 name: ReduceLast
 slug: reducelast
-sourceRef: it/seq.go#L153
+sourceRef: it/seq.go#L168
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-reject.md
+++ b/docs/data/it-reject.md
@@ -1,7 +1,7 @@
 ---
 name: Reject
 slug: reject
-sourceRef: it/seq.go#L586
+sourceRef: it/seq.go#L785
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-rejectmap.md
+++ b/docs/data/it-rejectmap.md
@@ -1,7 +1,7 @@
 ---
 name: RejectMap
 slug: rejectmap
-sourceRef: it/seq.go#L608
+sourceRef: it/seq.go#L809
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-repeat.md
+++ b/docs/data/it-repeat.md
@@ -1,7 +1,7 @@
 ---
 name: Repeat
 slug: repeat
-sourceRef: it/seq.go#L384
+sourceRef: it/seq.go#L504
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-repeatby.md
+++ b/docs/data/it-repeatby.md
@@ -1,7 +1,7 @@
 ---
 name: RepeatBy
 slug: repeatby
-sourceRef: it/seq.go#L388
+sourceRef: it/seq.go#L510
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-replace.md
+++ b/docs/data/it-replace.md
@@ -1,7 +1,7 @@
 ---
 name: Replace
 slug: replace
-sourceRef: it/seq.go#L699
+sourceRef: it/seq.go#L912
 category: iter
 subCategory: slice
 signatures:

--- a/docs/data/it-replaceall.md
+++ b/docs/data/it-replaceall.md
@@ -1,7 +1,7 @@
 ---
 name: ReplaceAll
 slug: replaceall
-sourceRef: it/seq.go#L699
+sourceRef: it/seq.go#L927
 category: iter
 subCategory: slice
 signatures:

--- a/docs/data/it-reverse.md
+++ b/docs/data/it-reverse.md
@@ -1,7 +1,7 @@
 ---
 name: Reverse
 slug: reverse
-sourceRef: it/seq.go#L366
+sourceRef: it/seq.go#L477
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-sample.md
+++ b/docs/data/it-sample.md
@@ -1,7 +1,7 @@
 ---
 name: Sample
 slug: sample
-sourceRef: it/find.go#L455
+sourceRef: it/find.go#L493
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-sampleby.md
+++ b/docs/data/it-sampleby.md
@@ -1,7 +1,7 @@
 ---
 name: SampleBy
 slug: sampleby
-sourceRef: it/find.go#L455
+sourceRef: it/find.go#L501
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-samples.md
+++ b/docs/data/it-samples.md
@@ -1,7 +1,7 @@
 ---
 name: Samples
 slug: samples
-sourceRef: it/find.go#L467
+sourceRef: it/find.go#L510
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-samplesby.md
+++ b/docs/data/it-samplesby.md
@@ -1,7 +1,7 @@
 ---
 name: SamplesBy
 slug: samplesby
-sourceRef: it/find.go#L474
+sourceRef: it/find.go#L518
 category: iter
 subCategory: find
 signatures:

--- a/docs/data/it-seqtochannel.md
+++ b/docs/data/it-seqtochannel.md
@@ -1,7 +1,7 @@
 ---
 name: SeqToChannel
 slug: seqtochannel
-sourceRef: it/channel.go#L12
+sourceRef: it/channel.go#L13
 category: iter
 subCategory: channel
 signatures:

--- a/docs/data/it-seqtoseq2.md
+++ b/docs/data/it-seqtoseq2.md
@@ -1,7 +1,7 @@
 ---
 name: SeqToSeq2
 slug: seqtoseq2
-sourceRef: it/seq.go#L1167
+sourceRef: it/seq.go#L1170
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-sequencestate.md
+++ b/docs/data/it-sequencestate.md
@@ -1,7 +1,7 @@
 ---
 name: Empty
 slug: sequencestate
-sourceRef: it/type_manipulation.go#L43
+sourceRef: it/type_manipulation.go#L50
 category: iter
 subCategory: type
 signatures:

--- a/docs/data/it-shuffle.md
+++ b/docs/data/it-shuffle.md
@@ -1,7 +1,7 @@
 ---
 name: Shuffle
 slug: shuffle
-sourceRef: it/seq.go#L357
+sourceRef: it/seq.go#L467
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-slice.md
+++ b/docs/data/it-slice.md
@@ -1,7 +1,7 @@
 ---
 name: Slice
 slug: slice
-sourceRef: it/seq.go#L680
+sourceRef: it/seq.go#L891
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-sliding.md
+++ b/docs/data/it-sliding.md
@@ -1,7 +1,7 @@
 ---
 name: Sliding
 slug: sliding
-sourceRef: it/seq.go#L329
+sourceRef: it/seq.go#L332
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-some.md
+++ b/docs/data/it-some.md
@@ -1,7 +1,7 @@
 ---
 name: Some
 slug: some
-sourceRef: it/intersect.go#L52
+sourceRef: it/intersect.go#L67
 category: iter
 subCategory: intersect
 signatures:

--- a/docs/data/it-someby.md
+++ b/docs/data/it-someby.md
@@ -1,7 +1,7 @@
 ---
 name: SomeBy
 slug: someby
-sourceRef: it/intersect.go#L56
+sourceRef: it/intersect.go#L82
 category: iter
 subCategory: intersect
 signatures:

--- a/docs/data/it-splice.md
+++ b/docs/data/it-splice.md
@@ -1,7 +1,7 @@
 ---
 name: Splice
 slug: splice
-sourceRef: it/seq.go#L744
+sourceRef: it/seq.go#L964
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-subset.md
+++ b/docs/data/it-subset.md
@@ -1,7 +1,7 @@
 ---
 name: Subset
 slug: subset
-sourceRef: it/seq.go#L667
+sourceRef: it/seq.go#L877
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-sum.md
+++ b/docs/data/it-sum.md
@@ -1,7 +1,7 @@
 ---
 name: Sum / SumBy
 slug: sum
-sourceRef: it/math.go#L59
+sourceRef: it/math.go#L72
 category: iter
 subCategory: math
 signatures:

--- a/docs/data/it-sumby.md
+++ b/docs/data/it-sumby.md
@@ -1,7 +1,7 @@
 ---
 name: SumBy
 slug: sumby
-sourceRef: it/math.go#L74
+sourceRef: it/math.go#L79
 category: iter
 subCategory: math
 signatures:

--- a/docs/data/it-take.md
+++ b/docs/data/it-take.md
@@ -1,7 +1,7 @@
 ---
 name: Take
 slug: take
-sourceRef: it/seq.go#L682
+sourceRef: it/seq.go#L711
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-takefilter.md
+++ b/docs/data/it-takefilter.md
@@ -1,7 +1,7 @@
 ---
 name: TakeFilter
 slug: takefilter
-sourceRef: it/seq.go#L725
+sourceRef: it/seq.go#L753
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-takewhile.md
+++ b/docs/data/it-takewhile.md
@@ -1,7 +1,7 @@
 ---
 name: TakeWhile
 slug: takewhile
-sourceRef: it/seq.go#L706
+sourceRef: it/seq.go#L732
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-times.md
+++ b/docs/data/it-times.md
@@ -1,7 +1,7 @@
 ---
 name: Times
 slug: times
-sourceRef: it/seq.go#L202
+sourceRef: it/seq.go#L223
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-toanyseq.md
+++ b/docs/data/it-toanyseq.md
@@ -1,7 +1,7 @@
 ---
 name: ToAnySeq
 slug: toanyseq
-sourceRef: it/type_manipulation.go#L11
+sourceRef: it/type_manipulation.go#L32
 category: iter
 subCategory: type
 signatures:

--- a/docs/data/it-toseqptr.md
+++ b/docs/data/it-toseqptr.md
@@ -1,7 +1,7 @@
 ---
 name: ToSeqPtr
 slug: toseqptr
-sourceRef: it/type_manipulation.go#L11
+sourceRef: it/type_manipulation.go#L13
 category: iter
 subCategory: type
 signatures:

--- a/docs/data/it-trim.md
+++ b/docs/data/it-trim.md
@@ -1,7 +1,7 @@
 ---
 name: Trim
 slug: trim
-sourceRef: it/seq.go#L778
+sourceRef: it/seq.go#L1068
 category: iter
 subCategory: string
 signatures:

--- a/docs/data/it-trimfirst.md
+++ b/docs/data/it-trimfirst.md
@@ -1,7 +1,7 @@
 ---
 name: TrimFirst
 slug: trimfirst
-sourceRef: it/seq.go#L778
+sourceRef: it/seq.go#L1076
 category: iter
 subCategory: string
 signatures:

--- a/docs/data/it-trimlast.md
+++ b/docs/data/it-trimlast.md
@@ -1,7 +1,7 @@
 ---
 name: TrimLast
 slug: trimlast
-sourceRef: it/seq.go#L778
+sourceRef: it/seq.go#L1121
 category: iter
 subCategory: string
 signatures:

--- a/docs/data/it-trimprefix.md
+++ b/docs/data/it-trimprefix.md
@@ -1,7 +1,7 @@
 ---
 name: TrimPrefix
 slug: trimprefix
-sourceRef: it/seq.go#L778
+sourceRef: it/seq.go#L1082
 category: iter
 subCategory: string
 signatures:

--- a/docs/data/it-trimsuffix.md
+++ b/docs/data/it-trimsuffix.md
@@ -1,7 +1,7 @@
 ---
 name: TrimSuffix
 slug: trimsuffix
-sourceRef: it/seq.go#L778
+sourceRef: it/seq.go#L1127
 category: iter
 subCategory: string
 signatures:

--- a/docs/data/it-union.md
+++ b/docs/data/it-union.md
@@ -1,7 +1,7 @@
 ---
 name: Union
 slug: union
-sourceRef: it/intersect.go#L136
+sourceRef: it/intersect.go#L217
 category: iter
 subCategory: intersect
 signatures:

--- a/docs/data/it-uniq.md
+++ b/docs/data/it-uniq.md
@@ -1,7 +1,7 @@
 ---
 name: Uniq
 slug: uniq
-sourceRef: it/seq.go#L216
+sourceRef: it/seq.go#L238
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-uniqby.md
+++ b/docs/data/it-uniqby.md
@@ -1,7 +1,7 @@
 ---
 name: UniqBy
 slug: uniqby
-sourceRef: it/seq.go#L225
+sourceRef: it/seq.go#L248
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-uniqkeys.md
+++ b/docs/data/it-uniqkeys.md
@@ -1,7 +1,7 @@
 ---
 name: UniqKeys
 slug: uniqkeys
-sourceRef: it/map.go#L26
+sourceRef: it/map.go#L28
 category: iter
 subCategory: map
 signatures:

--- a/docs/data/it-uniqvalues.md
+++ b/docs/data/it-uniqvalues.md
@@ -1,7 +1,7 @@
 ---
 name: UniqValues
 slug: uniqvalues
-sourceRef: it/map.go#L59
+sourceRef: it/map.go#L67
 category: iter
 subCategory: map
 signatures:

--- a/docs/data/it-values.md
+++ b/docs/data/it-values.md
@@ -1,7 +1,7 @@
 ---
 name: Values
 slug: values
-sourceRef: it/map.go#L44
+sourceRef: it/map.go#L51
 category: iter
 subCategory: map
 signatures:

--- a/docs/data/it-window.md
+++ b/docs/data/it-window.md
@@ -1,7 +1,7 @@
 ---
 name: Window
 slug: window
-sourceRef: it/seq.go#L318
+sourceRef: it/seq.go#L319
 category: iter
 subCategory: sequence
 signatures:

--- a/docs/data/it-without.md
+++ b/docs/data/it-without.md
@@ -1,7 +1,7 @@
 ---
 name: Without
 slug: without
-sourceRef: it/intersect.go#L155
+sourceRef: it/intersect.go#L237
 category: iter
 subCategory: intersect
 signatures:

--- a/docs/data/it-withoutby.md
+++ b/docs/data/it-withoutby.md
@@ -1,7 +1,7 @@
 ---
 name: WithoutBy
 slug: withoutby
-sourceRef: it/intersect.go#L159
+sourceRef: it/intersect.go#L245
 category: iter
 subCategory: intersect
 signatures:

--- a/docs/data/it-withoutnth.md
+++ b/docs/data/it-withoutnth.md
@@ -1,7 +1,7 @@
 ---
 name: WithoutNth
 slug: withoutnth
-sourceRef: it/intersect.go#L167
+sourceRef: it/intersect.go#L253
 category: iter
 subCategory: intersect
 signatures:

--- a/docs/data/it-zipbyx.md
+++ b/docs/data/it-zipbyx.md
@@ -1,7 +1,7 @@
 ---
 name: ZipByX
 slug: zipbyx
-sourceRef: it/tuples.go#L295
+sourceRef: it/tuples.go#L283
 category: iter
 subCategory: tuple
 signatures:

--- a/docs/data/it-zipx.md
+++ b/docs/data/it-zipx.md
@@ -1,7 +1,7 @@
 ---
 name: ZipX
 slug: zipx
-sourceRef: it/tuples.go#L14
+sourceRef: it/tuples.go#L15
 category: iter
 subCategory: tuple
 signatures:

--- a/docs/data/mutable-filter.md
+++ b/docs/data/mutable-filter.md
@@ -1,7 +1,7 @@
 ---
 name: Filter
 slug: filter
-sourceRef: mutable/slice.go#L11
+sourceRef: mutable/slice.go#L15
 category: mutable
 subCategory: slice
 playUrl: https://go.dev/play/p/0jY3Z0B7O_5

--- a/docs/data/mutable-map.md
+++ b/docs/data/mutable-map.md
@@ -1,7 +1,7 @@
 ---
 name: Map
 slug: map
-sourceRef: mutable/slice.go#L41
+sourceRef: mutable/slice.go#L43
 category: mutable
 subCategory: slice
 playUrl: https://go.dev/play/p/0jY3Z0B7O_5

--- a/docs/data/mutable-reverse.md
+++ b/docs/data/mutable-reverse.md
@@ -1,7 +1,7 @@
 ---
 name: Reverse
 slug: reverse
-sourceRef: mutable/slice.go#L65
+sourceRef: mutable/slice.go#L66
 category: mutable
 subCategory: slice
 playUrl: https://go.dev/play/p/O-M5pmCRgzV

--- a/docs/data/mutable-shuffle.md
+++ b/docs/data/mutable-shuffle.md
@@ -1,7 +1,7 @@
 ---
 name: Shuffle
 slug: shuffle
-sourceRef: mutable/slice.go#L57
+sourceRef: mutable/slice.go#L58
 category: mutable
 subCategory: slice
 playUrl: https://go.dev/play/p/2xb3WdLjeSJ

--- a/docs/data/parallel-groupby.md
+++ b/docs/data/parallel-groupby.md
@@ -1,7 +1,7 @@
 ---
 name: GroupBy
 slug: groupby
-sourceRef: parallel/slice.go#L73
+sourceRef: parallel/slice.go#L75
 category: parallel
 subCategory: slice
 playUrl: "https://go.dev/play/p/EkyvA0gw4dj"

--- a/docs/data/parallel-partitionby.md
+++ b/docs/data/parallel-partitionby.md
@@ -1,7 +1,7 @@
 ---
 name: PartitionBy
 slug: partitionby
-sourceRef: parallel/slice.go#L92
+sourceRef: parallel/slice.go#L95
 category: parallel
 subCategory: slice
 playUrl: "https://go.dev/play/p/GwBQdMgx2nC"

--- a/docs/data/parallel-times.md
+++ b/docs/data/parallel-times.md
@@ -1,7 +1,7 @@
 ---
 name: Times
 slug: times
-sourceRef: parallel/slice.go#L49
+sourceRef: parallel/slice.go#L50
 category: parallel
 subCategory: slice
 playUrl: https://go.dev/play/p/ZNnWNcJ4Au-

--- a/docs/data/simd-clamp.md
+++ b/docs/data/simd-clamp.md
@@ -1,7 +1,7 @@
 ---
 name: Clamp
 slug: clamp
-sourceRef: exp/simd/math_avx.go#L453
+sourceRef: exp/simd/math_avx.go#L454
 category: experimental
 subCategory: simd
 similarHelpers:

--- a/docs/data/simd-contains.md
+++ b/docs/data/simd-contains.md
@@ -1,7 +1,7 @@
 ---
 name: Contains
 slug: contains
-sourceRef: exp/simd/intersect_avx512.go#L9
+sourceRef: exp/simd/intersect_avx512.go#L10
 category: experimental
 subCategory: simd
 similarHelpers:

--- a/docs/data/simd-max.md
+++ b/docs/data/simd-max.md
@@ -1,7 +1,7 @@
 ---
 name: Max
 slug: max
-sourceRef: exp/simd/math_avx.go#L1279
+sourceRef: exp/simd/math_avx.go#L1116
 category: experimental
 subCategory: simd
 similarHelpers:

--- a/docs/data/simd-mean.md
+++ b/docs/data/simd-mean.md
@@ -1,7 +1,7 @@
 ---
 name: Mean
 slug: mean
-sourceRef: exp/simd/math_avx.go#L352
+sourceRef: exp/simd/math_avx.go#L353
 category: experimental
 subCategory: simd
 similarHelpers:

--- a/docs/data/simd-meanby.md
+++ b/docs/data/simd-meanby.md
@@ -1,7 +1,7 @@
 ---
 name: MeanBy
 slug: meanby
-sourceRef: exp/simd/math.go#L1006
+sourceRef: exp/simd/math.go#L1023
 category: experimental
 subCategory: simd
 similarHelpers:

--- a/docs/data/simd-min.md
+++ b/docs/data/simd-min.md
@@ -1,7 +1,7 @@
 ---
 name: Min
 slug: min
-sourceRef: exp/simd/math_avx.go#L833
+sourceRef: exp/simd/math_avx.go#L758
 category: experimental
 subCategory: simd
 similarHelpers:

--- a/docs/data/simd-sum.md
+++ b/docs/data/simd-sum.md
@@ -1,7 +1,7 @@
 ---
 name: Sum
 slug: sum
-sourceRef: exp/simd/math_avx.go#L14
+sourceRef: exp/simd/math_avx.go#L18
 category: experimental
 subCategory: simd
 similarHelpers:

--- a/docs/data/simd-sumby.md
+++ b/docs/data/simd-sumby.md
@@ -1,7 +1,7 @@
 ---
 name: SumBy
 slug: sumby
-sourceRef: exp/simd/math.go#L841
+sourceRef: exp/simd/math.go#L848
 category: experimental
 subCategory: simd
 similarHelpers:


### PR DESCRIPTION
## Summary
- Add guidance in `docs/CLAUDE.md` on keeping `sourceRef` line numbers accurate: any change to a `.go` file can shift line numbers for helpers documented further down in the same file.
- Instructs running `gopls symbols <file>` to list current symbol line numbers and cross-reference against `docs/data/*.md` `sourceRef` fields.