### PR TITLE
perf(map): iterate entries directly in MapEntries and MapEntriesErr

### DIFF
--- a/map.go
+++ b/map.go
@@ -370,8 +370,8 @@ func MapValuesErr[K comparable, V, R any](in map[K]V, iteratee func(value V, key
 func MapEntries[K1 comparable, V1 any, K2 comparable, V2 any](in map[K1]V1, iteratee func(key K1, value V1) (K2, V2)) map[K2]V2 {
 	result := make(map[K2]V2, len(in))
 
-	for k1 := range in {
-		k2, v2 := iteratee(k1, in[k1])
+	for k1, v1 := range in {
+		k2, v2 := iteratee(k1, v1)
 		result[k2] = v2
 	}
 
@@ -383,8 +383,8 @@ func MapEntries[K1 comparable, V1 any, K2 comparable, V2 any](in map[K1]V1, iter
 func MapEntriesErr[K1 comparable, V1 any, K2 comparable, V2 any](in map[K1]V1, iteratee func(key K1, value V1) (K2, V2, error)) (map[K2]V2, error) {
 	result := make(map[K2]V2, len(in))
 
-	for k1 := range in {
-		k2, v2, err := iteratee(k1, in[k1])
+	for k1, v1 := range in {
+		k2, v2, err := iteratee(k1, v1)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- `MapEntries` and `MapEntriesErr` ranged over keys only and re-fetched each value with `in[k1]`, paying a redundant hash lookup per entry
- Range over key and value directly instead

## Benchmark

goos: darwin / goarch: arm64 / cpu: Apple M3

```
                  │   before    │              after                │
                  │   sec/op    │   sec/op     vs base               │
MapEntries/10-8     326.0n ± 64%  256.2n ±  7%  -21.40% (p=0.000 n=10)
MapEntries/100-8    2.379µ ±  8%  1.740µ ±  1%  -26.88% (p=0.000 n=10)
MapEntries/1000-8   25.04µ ±  8%  18.75µ ± 12%  -25.12% (p=0.001 n=10)
```

B/op and allocs/op are unchanged.

## Test plan
- [x] `go test ./...` passes
- [x] `go test -bench=BenchmarkMapEntries -benchmem -count=10` before/after compared with `benchstat`