### PR TITLE
fix(xrand): make the pre-go1.22 Int64 non-negative and single-call

### DIFF
--- a/internal/xrand/ordered_go118.go
+++ b/internal/xrand/ordered_go118.go
@@ -21,12 +21,5 @@ func IntN(n int) int {
 // from the default Source.
 func Int64() int64 {
 	// bearer:disable go_gosec_crypto_weak_random
-	n := rand.Int63()
-
-	// bearer:disable go_gosec_crypto_weak_random
-	if rand.Intn(2) == 0 {
-		return -n
-	}
-
-	return n
+	return rand.Int63()
 }


### PR DESCRIPTION
## Summary
- `math/rand/v2`'s `Int64()` (used on go1.22+) can only return positive values, per its own doc contract.
- The go1.18 fallback's docstring claimed the same non-negative contract but flipped the sign with a second `rand` call half the time, breaking parity between the two build-tagged implementations and wasting a rand call.
- Returning `rand.Int63()` directly keeps both versions equivalent and halves the number of rand calls on go < 1.22.

## Test plan
- [x] `go build ./internal/xrand/...`
- [x] `gofmt -l` clean
- [ ] Covered by the existing CI test matrix on Go 1.18-1.21 (file is gated to `!go1.22`, not exercisable on this machine's go1.26 toolchain)
