### PR TITLE
perf(find): sample sparse selections in O(count) memory in SamplesBy

### DIFF
--- a/benchmark/core_find_bench_test.go
+++ b/benchmark/core_find_bench_test.go
@@ -307,4 +307,14 @@ func BenchmarkSamples(b *testing.B) {
 			}
 		})
 	}
+
+	// sparse: sample a few items from a large collection
+	for _, n := range []int{1_000, 100_000} {
+		ints := genSliceInt(n)
+		b.Run("sparse_"+strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Samples(ints, 10)
+			}
+		})
+	}
 }

--- a/find.go
+++ b/find.go
@@ -996,8 +996,36 @@ func SamplesBy[T any, Slice ~[]T](collection Slice, count int, randomIntGenerato
 		count = size
 	}
 
-	indexes := Range(size)
 	results := make(Slice, count)
+
+	// When only a small fraction of the collection is sampled, track displaced
+	// indexes in a map instead of materializing the whole index permutation,
+	// keeping time and memory proportional to count instead of size. Both
+	// paths consume the random generator and select elements identically.
+	if count <= size/16 {
+		displaced := make(map[int]int, count)
+
+		for i, n := 0, size; i < count; i, n = i+1, n-1 {
+			index := randomIntGenerator(n)
+
+			j, ok := displaced[index]
+			if !ok {
+				j = index
+			}
+			results[i] = collection[j]
+
+			// Removes index: swap it with the last (virtual) element.
+			last, ok := displaced[n-1]
+			if !ok {
+				last = n - 1
+			}
+			displaced[index] = last
+		}
+
+		return results
+	}
+
+	indexes := Range(size)
 
 	for i := range results {
 		n := len(indexes)

--- a/find_test.go
+++ b/find_test.go
@@ -1587,3 +1587,81 @@ func TestSamplesBy(t *testing.T) {
 	nonempty := SamplesBy(allStrings, 2, r.Intn)
 	is.IsType(nonempty, allStrings, "type preserved")
 }
+
+// SamplesBy switches between two different algorithms depending on the
+// count/size ratio: a map-based "sparse" selection (count <= size/16) and an
+// index-slice-based "dense" selection (count > size/16). A collection small
+// enough to fit the sparse branch's threshold with a non-trivial count
+// (e.g. the {"a", "b", "c"} slices used above) never exercises the sparse
+// branch at all, so it needs its own coverage on a large collection.
+func TestSamplesBySparse(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	collection := Range(10_000)
+	threshold := len(collection) / 16
+
+	for _, count := range []int{1, 2, 10, threshold} {
+		is.LessOrEqual(count, threshold, "sanity check: count must land in the sparse branch")
+
+		for seed := int64(0); seed < 10; seed++ {
+			r := rand.New(rand.NewSource(seed))
+			result := SamplesBy(collection, count, r.Intn)
+
+			is.Len(result, count)
+			is.Equal(count, len(Uniq(result)), "sparse branch must not return duplicate elements")
+			for _, v := range result {
+				is.True(v >= 0 && v < len(collection), "sampled value must belong to the collection")
+			}
+		}
+	}
+}
+
+// The sparse (map-based) and dense (index-slice-based) branches are two
+// independent implementations of the same abstract algorithm: draw
+// randomIntGenerator(n) for n = size, size-1, size-2, ... and swap the pick
+// out of the remaining pool. Because both branches consume the generator
+// with the exact same sequence of n values regardless of which one runs,
+// seeding two generators identically and requesting a smaller sparse count
+// and a larger dense count from the same collection must produce the same
+// prefix of picks. This pins down the equivalence promised by the comment in
+// find.go and would catch a regression in either branch that the two
+// single-branch tests above could miss (e.g. one branch drifting out of
+// sync with the other after an edit to just one of them).
+func TestSamplesBySparseDenseEquivalence(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	collection := Range(1_000)
+	threshold := len(collection) / 16
+
+	sparseCount := threshold     // <= threshold: takes the sparse branch
+	denseCount := threshold + 10 // > threshold: takes the dense branch
+
+	for seed := int64(0); seed < 10; seed++ {
+		sparse := SamplesBy(collection, sparseCount, rand.New(rand.NewSource(seed)).Intn)
+		dense := SamplesBy(collection, denseCount, rand.New(rand.NewSource(seed)).Intn)
+
+		is.Equal(sparse, dense[:sparseCount])
+	}
+}
+
+// Exercises the boundary of the count <= size/16 condition itself: one count
+// value on each side of the threshold, on the very same collection, so a
+// future change to the condition (e.g. an off-by-one on the comparison
+// operator or the division) is caught even if each branch is otherwise
+// individually correct.
+func TestSamplesBySparseBoundary(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	collection := Range(1_000)
+	threshold := len(collection) / 16
+
+	for _, count := range []int{threshold, threshold + 1} {
+		result := SamplesBy(collection, count, rand.New(rand.NewSource(7)).Intn)
+
+		is.Len(result, count)
+		is.Equal(count, len(Uniq(result)))
+	}
+}

--- a/find_test.go
+++ b/find_test.go
@@ -1609,7 +1609,7 @@ func TestSamplesBySparse(t *testing.T) {
 			result := SamplesBy(collection, count, r.Intn)
 
 			is.Len(result, count)
-			is.Equal(count, len(Uniq(result)), "sparse branch must not return duplicate elements")
+			is.Len(Uniq(result), count, "sparse branch must not return duplicate elements")
 			for _, v := range result {
 				is.True(v >= 0 && v < len(collection), "sampled value must belong to the collection")
 			}
@@ -1662,6 +1662,6 @@ func TestSamplesBySparseBoundary(t *testing.T) {
 		result := SamplesBy(collection, count, rand.New(rand.NewSource(7)).Intn)
 
 		is.Len(result, count)
-		is.Equal(count, len(Uniq(result)))
+		is.Len(Uniq(result), count)
 	}
 }


### PR DESCRIPTION
## Summary
- `SamplesBy` always materialized a full index permutation (`lo.Range(size)`) even when only a handful of items were sampled, costing O(size) time and memory — e.g. ~800KB to pick 10 items out of 100k.
- When `count <= size/16`, displaced indexes of the virtual Fisher-Yates shuffle are now tracked in a small map instead, keeping time and memory proportional to `count`. Above that threshold the existing permutation-based path remains faster and is kept.
- Both paths consume the random generator and select elements identically, so results are unchanged for a given generator.
- A `sparse` sub-case is added to `BenchmarkSamples` to cover the new path.

## Benchmark

```
goos: darwin
goarch: arm64
pkg: github.com/samber/lo/benchmark
cpu: Apple M3
                      │    before     │                after                │
                      │    sec/op     │    sec/op     vs base                │
Samples/10                43.80n ± 3%    43.87n ± 5%        ~ (p=0.699 n=6)
Samples/100               269.2n ± 1%    271.2n ± 2%        ~ (p=0.102 n=6)
Samples/1000              2.287µ ± 1%    2.269µ ± 0%   -0.79% (p=0.002 n=6)
Samples/sparse_1000       808.9n ± 1%    270.2n ± 1%  -66.59% (p=0.002 n=6)
Samples/sparse_100000   64674.0n ± 9%    271.9n ± 1%  -99.58% (p=0.002 n=6)
geomean                   1.071µ         288.0n       -73.11%

                      │    before     │                after                 │
                      │     B/op      │     B/op      vs base                │
Samples/10                96.00 ± 0%     96.00 ± 0%        ~ (p=1.000 n=6) ¹
Samples/100              1.078Ki ± 0%   1.078Ki ± 0%        ~ (p=1.000 n=6) ¹
Samples/1000             10.00Ki ± 0%   10.00Ki ± 0%        ~ (p=1.000 n=6) ¹
Samples/sparse_1000       8272.0 ± 0%    408.0 ± 0%  -95.07% (p=0.002 n=6)
Samples/sparse_100000   802896.0 ± 0%    408.0 ± 0%  -99.95% (p=0.002 n=6)
geomean                  5.771Ki         710.2       -87.98%
¹ all samples are equal
```

## Test plan
- [x] `go test ./...` passes
- [x] `go test ./benchmark/... -bench=BenchmarkSamples` before/after, compared with `benchstat`
