### PR TITLE
perf(slice): stop scanning in Replace once n replacements are done

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -1111,10 +1111,18 @@ func Replace[T comparable, Slice ~[]T](collection Slice, old, nEw T, n int) Slic
 	result := make(Slice, len(collection))
 	copy(result, collection)
 
+	if n == 0 {
+		return result
+	}
+
 	for i := range result {
-		if result[i] == old && n != 0 {
+		if result[i] == old {
 			result[i] = nEw
-			n--
+			// Stop scanning once the n first instances have been replaced.
+			// A negative n never reaches 0 and replaces all instances.
+			if n--; n == 0 {
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- `Replace` kept scanning (and comparing) the remaining elements after the `n` first instances had already been replaced.
- The loop now exits as soon as the replacement budget is exhausted, and the budget check moved out of the per-element comparison into the (rare) match branch — this also speeds up full scans like `ReplaceAll`.

## Benchmark

```
goos: darwin
goarch: arm64
pkg: github.com/samber/lo/benchmark
cpu: Apple M3
                        │   before    │                after                │
                        │   sec/op    │    sec/op     vs base               │
Replace/strings_1000-8    3.217µ ± 4%    3.445µ ± 10%        ~ (p=0.130 n=8)
Replace/strings_10000-8   43.63µ ± 3%   45.60µ ± 23%        ~ (p=0.083 n=8)
Replace/strings_100000-8  726.9µ ± 2%   729.3µ ±  5%        ~ (p=0.645 n=8)
Replace/ints1000-8        1.222µ ± 7%   1.167µ ±  7%        ~ (p=0.138 n=8)
Replace/ints10000-8       10.14µ ± 28%  9.596µ ±  1%  -5.33% (p=0.003 n=8)
Replace/ints100000-8      103.8µ ± 3%   95.19µ ±  2%  -8.26% (p=0.000 n=8)
ReplaceAll/ints_10-8      22.97n ± 3%   22.18n ±  1%  -3.46% (p=0.000 n=8)
ReplaceAll/ints_100-8     129.8n ± 7%   119.1n ±  1%  -8.24% (p=0.000 n=8)
ReplaceAll/ints_1000-8    1.046µ ± 1%   1.047µ ±  1%        ~ (p=0.552 n=8)
geomean                   4.203µ        4.114µ        -2.11%

B/op and allocs/op are unchanged.
```

Test plan: `go test ./...` passes, `golangci-lint run ./...` reports 0 issues.