### PR TITLE
perf(slice): scan small cutsets instead of building a map in Trim/TrimLeft/TrimRight

### DIFF
--- a/benchmark/core_slice_bench_test.go
+++ b/benchmark/core_slice_bench_test.go
@@ -854,6 +854,17 @@ func BenchmarkTrim(b *testing.B) {
 			}
 		})
 	}
+
+	// small_k1: single-element cutset exercises the allocation-free small-scan path.
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		cutset := ints[:1]
+		b.Run("small_k1_"+strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.Trim(ints, cutset)
+			}
+		})
+	}
 }
 
 func BenchmarkTrimLeft(b *testing.B) {
@@ -866,6 +877,17 @@ func BenchmarkTrimLeft(b *testing.B) {
 			}
 		})
 	}
+
+	// small_k1: single-element cutset exercises the allocation-free small-scan path.
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		cutset := ints[:1]
+		b.Run("small_k1_"+strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.TrimLeft(ints, cutset)
+			}
+		})
+	}
 }
 
 func BenchmarkTrimRight(b *testing.B) {
@@ -873,6 +895,17 @@ func BenchmarkTrimRight(b *testing.B) {
 		ints := genSliceInt(n)
 		cutset := ints[n-3:]
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.TrimRight(ints, cutset)
+			}
+		})
+	}
+
+	// small_k1: single-element cutset exercises the allocation-free small-scan path.
+	for _, n := range lengths {
+		ints := genSliceInt(n)
+		cutset := ints[n-1:]
+		b.Run("small_k1_"+strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.TrimRight(ints, cutset)
 			}

--- a/slice.go
+++ b/slice.go
@@ -1295,12 +1295,12 @@ func cutsetContains[T comparable, Slice ~[]T](cutset Slice, value T) bool {
 // Play: https://go.dev/play/p/LZLfLj5C8Lg
 func Trim[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 	if len(cutset) <= trimSmallCutset {
-		return trimBySmallScan(collection, cutset)
+		return trimSmall(collection, cutset)
 	}
-	return trimByMap(collection, cutset)
+	return trimLarge(collection, cutset)
 }
 
-func trimByMap[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
+func trimLarge[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 	set := Keyify(cutset)
 
 	i := 0
@@ -1325,7 +1325,7 @@ func trimByMap[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 	return append(result, collection[i:j+1]...)
 }
 
-func trimBySmallScan[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
+func trimSmall[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 	i := 0
 	for ; i < len(collection); i++ {
 		if !cutsetContains(cutset, collection[i]) {
@@ -1352,12 +1352,12 @@ func trimBySmallScan[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 // Play: https://go.dev/play/p/fJK-AhROy9w
 func TrimLeft[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 	if len(cutset) <= trimSmallCutset {
-		return trimLeftBySmallScan(collection, cutset)
+		return trimLeftSmall(collection, cutset)
 	}
-	return trimLeftByMap(collection, cutset)
+	return trimLeftLarge(collection, cutset)
 }
 
-func trimLeftByMap[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
+func trimLeftLarge[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 	set := Keyify(cutset)
 
 	return DropWhile(collection, func(item T) bool {
@@ -1366,7 +1366,7 @@ func trimLeftByMap[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 	})
 }
 
-func trimLeftBySmallScan[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
+func trimLeftSmall[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 	// Mirrors DropWhile exactly (same make cap and append) but tests membership
 	// against cutset directly to stay allocation-free.
 	i := 0
@@ -1398,12 +1398,12 @@ func TrimPrefix[T comparable, Slice ~[]T](collection, prefix Slice) Slice {
 // Play: https://go.dev/play/p/9V_N8sRyyiZ
 func TrimRight[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 	if len(cutset) <= trimSmallCutset {
-		return trimRightBySmallScan(collection, cutset)
+		return trimRightSmall(collection, cutset)
 	}
-	return trimRightByMap(collection, cutset)
+	return trimRightLarge(collection, cutset)
 }
 
-func trimRightByMap[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
+func trimRightLarge[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 	set := Keyify(cutset)
 
 	return DropRightWhile(collection, func(item T) bool {
@@ -1412,7 +1412,7 @@ func trimRightByMap[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 	})
 }
 
-func trimRightBySmallScan[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
+func trimRightSmall[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 	// Mirrors DropRightWhile exactly (same make cap and append) but tests
 	// membership against cutset directly to stay allocation-free.
 	i := len(collection) - 1

--- a/slice.go
+++ b/slice.go
@@ -1271,9 +1271,36 @@ func CutSuffix[T comparable, Slice ~[]T](collection, separator Slice) (before Sl
 	return collection, false
 }
 
+// trimSmallCutset is the cutset-size threshold below which Trim/TrimLeft/TrimRight
+// skip building a Keyify map and test membership with a direct linear scan instead.
+// For tiny cutsets the map's allocation and hashing cost dominate, so an
+// allocation-free scan over a handful of elements is faster; larger cutsets amortize
+// the map build and win on lookup cost.
+const trimSmallCutset = 8
+
+// cutsetContains reports whether value is present in cutset using a linear scan.
+// It is shared by the small-cutset fast paths of Trim/TrimLeft/TrimRight so the
+// three stay in sync, and uses the same == equality as the Keyify map lookup
+// (identical behavior for NaN keys, which are never matched by either path).
+func cutsetContains[T comparable, Slice ~[]T](cutset Slice, value T) bool {
+	for i := range cutset {
+		if cutset[i] == value {
+			return true
+		}
+	}
+	return false
+}
+
 // Trim removes all the leading and trailing cutset from the collection.
 // Play: https://go.dev/play/p/LZLfLj5C8Lg
 func Trim[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
+	if len(cutset) <= trimSmallCutset {
+		return trimBySmallScan(collection, cutset)
+	}
+	return trimByMap(collection, cutset)
+}
+
+func trimByMap[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 	set := Keyify(cutset)
 
 	i := 0
@@ -1298,15 +1325,59 @@ func Trim[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 	return append(result, collection[i:j+1]...)
 }
 
+func trimBySmallScan[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
+	i := 0
+	for ; i < len(collection); i++ {
+		if !cutsetContains(cutset, collection[i]) {
+			break
+		}
+	}
+
+	if i >= len(collection) {
+		return Slice{}
+	}
+
+	j := len(collection) - 1
+	for ; j >= 0; j-- {
+		if !cutsetContains(cutset, collection[j]) {
+			break
+		}
+	}
+
+	result := make(Slice, 0, j+1-i)
+	return append(result, collection[i:j+1]...)
+}
+
 // TrimLeft removes all the leading cutset from the collection.
 // Play: https://go.dev/play/p/fJK-AhROy9w
 func TrimLeft[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
+	if len(cutset) <= trimSmallCutset {
+		return trimLeftBySmallScan(collection, cutset)
+	}
+	return trimLeftByMap(collection, cutset)
+}
+
+func trimLeftByMap[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 	set := Keyify(cutset)
 
 	return DropWhile(collection, func(item T) bool {
 		_, ok := set[item]
 		return ok
 	})
+}
+
+func trimLeftBySmallScan[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
+	// Mirrors DropWhile exactly (same make cap and append) but tests membership
+	// against cutset directly to stay allocation-free.
+	i := 0
+	for ; i < len(collection); i++ {
+		if !cutsetContains(cutset, collection[i]) {
+			break
+		}
+	}
+
+	result := make(Slice, 0, len(collection)-i)
+	return append(result, collection[i:]...)
 }
 
 // TrimPrefix removes all the leading prefix from the collection.
@@ -1326,12 +1397,33 @@ func TrimPrefix[T comparable, Slice ~[]T](collection, prefix Slice) Slice {
 // TrimRight removes all the trailing cutset from the collection.
 // Play: https://go.dev/play/p/9V_N8sRyyiZ
 func TrimRight[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
+	if len(cutset) <= trimSmallCutset {
+		return trimRightBySmallScan(collection, cutset)
+	}
+	return trimRightByMap(collection, cutset)
+}
+
+func trimRightByMap[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
 	set := Keyify(cutset)
 
 	return DropRightWhile(collection, func(item T) bool {
 		_, ok := set[item]
 		return ok
 	})
+}
+
+func trimRightBySmallScan[T comparable, Slice ~[]T](collection, cutset Slice) Slice {
+	// Mirrors DropRightWhile exactly (same make cap and append) but tests
+	// membership against cutset directly to stay allocation-free.
+	i := len(collection) - 1
+	for ; i >= 0; i-- {
+		if !cutsetContains(cutset, collection[i]) {
+			break
+		}
+	}
+
+	result := make(Slice, 0, i+1)
+	return append(result, collection[:i+1]...)
 }
 
 // TrimSuffix removes all the trailing suffix from the collection.

--- a/slice_test.go
+++ b/slice_test.go
@@ -3250,6 +3250,44 @@ func TestTrim(t *testing.T) {
 	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, actual)
 }
 
+// Trim dispatches on len(cutset) <= trimSmallCutset (8): a cutset of 9 unique
+// elements forces the trimByMap path, which the table above never exercises
+// (its cutsets are all <= 8).
+func TestTrimMapPath(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	cutset := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}
+	is.Len(cutset, 9, "sanity check: cutset must exceed trimSmallCutset")
+
+	collection := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "X", "Y", "a", "b", "c", "d", "e", "f", "g", "h", "i"}
+	actual := Trim(collection, cutset)
+	is.Equal([]string{"X", "Y"}, actual)
+
+	actual = Trim(cutset, cutset)
+	is.Equal([]string{}, actual)
+
+	actual = Trim([]string{"X", "Y"}, cutset)
+	is.Equal([]string{"X", "Y"}, actual)
+}
+
+// The small-scan (len(cutset) <= 8) and map (len(cutset) > 8) paths must trim
+// identically. Same collection, cutset just below and just above the
+// threshold with an extra element absent from collection, so both trim the
+// exact same leading/trailing run.
+func TestTrimSmallMapBoundary(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	collection := []string{"a", "b", "c", "X", "Y", "a", "b", "c"}
+	small := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+	is.Len(small, 8, "sanity check: small must land in the small-scan branch")
+	mapped := append(append([]string{}, small...), "z")
+	is.Len(mapped, 9, "sanity check: mapped must land in the map branch")
+
+	is.Equal(Trim(collection, small), Trim(collection, mapped))
+}
+
 func TestTrimLeft(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -3266,6 +3304,44 @@ func TestTrimLeft(t *testing.T) {
 	is.Equal([]string{}, actual)
 	actual = TrimLeft([]string{"a", "b", "c", "d", "e", "f", "g"}, []string{})
 	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, actual)
+}
+
+// TrimLeft dispatches on len(cutset) <= trimSmallCutset (8): a cutset of 9
+// unique elements forces the trimLeftByMap path, which the table above never
+// exercises (its cutsets are all <= 8).
+func TestTrimLeftMapPath(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	cutset := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}
+	is.Len(cutset, 9, "sanity check: cutset must exceed trimSmallCutset")
+
+	collection := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "X", "Y"}
+	actual := TrimLeft(collection, cutset)
+	is.Equal([]string{"X", "Y"}, actual)
+
+	actual = TrimLeft(cutset, cutset)
+	is.Equal([]string{}, actual)
+
+	actual = TrimLeft([]string{"X", "Y"}, cutset)
+	is.Equal([]string{"X", "Y"}, actual)
+}
+
+// The small-scan (len(cutset) <= 8) and map (len(cutset) > 8) paths must trim
+// identically. Same collection, cutset just below and just above the
+// threshold with an extra element absent from collection, so both trim the
+// exact same leading run.
+func TestTrimLeftSmallMapBoundary(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	collection := []string{"a", "b", "c", "X", "Y"}
+	small := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+	is.Len(small, 8, "sanity check: small must land in the small-scan branch")
+	mapped := append(append([]string{}, small...), "z")
+	is.Len(mapped, 9, "sanity check: mapped must land in the map branch")
+
+	is.Equal(TrimLeft(collection, small), TrimLeft(collection, mapped))
 }
 
 func TestTrimPrefix(t *testing.T) {
@@ -3300,6 +3376,44 @@ func TestTrimRight(t *testing.T) {
 	is.Equal([]string{}, actual)
 	actual = TrimRight([]string{"a", "b", "c", "d", "e", "f", "g"}, []string{})
 	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, actual)
+}
+
+// TrimRight dispatches on len(cutset) <= trimSmallCutset (8): a cutset of 9
+// unique elements forces the trimRightByMap path, which the table above
+// never exercises (its cutsets are all <= 8).
+func TestTrimRightMapPath(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	cutset := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}
+	is.Len(cutset, 9, "sanity check: cutset must exceed trimSmallCutset")
+
+	collection := []string{"X", "Y", "a", "b", "c", "d", "e", "f", "g", "h", "i"}
+	actual := TrimRight(collection, cutset)
+	is.Equal([]string{"X", "Y"}, actual)
+
+	actual = TrimRight(cutset, cutset)
+	is.Equal([]string{}, actual)
+
+	actual = TrimRight([]string{"X", "Y"}, cutset)
+	is.Equal([]string{"X", "Y"}, actual)
+}
+
+// The small-scan (len(cutset) <= 8) and map (len(cutset) > 8) paths must trim
+// identically. Same collection, cutset just below and just above the
+// threshold with an extra element absent from collection, so both trim the
+// exact same trailing run.
+func TestTrimRightSmallMapBoundary(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	collection := []string{"X", "Y", "a", "b", "c"}
+	small := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+	is.Len(small, 8, "sanity check: small must land in the small-scan branch")
+	mapped := append(append([]string{}, small...), "z")
+	is.Len(mapped, 9, "sanity check: mapped must land in the map branch")
+
+	is.Equal(TrimRight(collection, small), TrimRight(collection, mapped))
 }
 
 func TestTrimSuffix(t *testing.T) {

--- a/slice_test.go
+++ b/slice_test.go
@@ -3253,7 +3253,7 @@ func TestTrimSmallScan(t *testing.T) {
 }
 
 // Trim dispatches on len(cutset) <= trimSmallCutset (8): a cutset of 9 unique
-// elements forces the trimByMap path, which the table above never exercises
+// elements forces the trimLarge path, which the table above never exercises
 // (its cutsets are all <= 8).
 func TestTrimMapPath(t *testing.T) {
 	t.Parallel()
@@ -3311,7 +3311,7 @@ func TestTrimLeftSmallScan(t *testing.T) {
 }
 
 // TrimLeft dispatches on len(cutset) <= trimSmallCutset (8): a cutset of 9
-// unique elements forces the trimLeftByMap path, which the table above never
+// unique elements forces the trimLeftLarge path, which the table above never
 // exercises (its cutsets are all <= 8).
 func TestTrimLeftMapPath(t *testing.T) {
 	t.Parallel()
@@ -3385,7 +3385,7 @@ func TestTrimRightSmallScan(t *testing.T) {
 }
 
 // TrimRight dispatches on len(cutset) <= trimSmallCutset (8): a cutset of 9
-// unique elements forces the trimRightByMap path, which the table above
+// unique elements forces the trimRightLarge path, which the table above
 // never exercises (its cutsets are all <= 8).
 func TestTrimRightMapPath(t *testing.T) {
 	t.Parallel()

--- a/slice_test.go
+++ b/slice_test.go
@@ -3260,7 +3260,7 @@ func TestTrimLarge(t *testing.T) {
 	is := assert.New(t)
 
 	cutset := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}
-	is.Len(cutset, 9, "sanity check: cutset must exceed trimSmallCutset")
+	is.Greater(len(cutset), trimSmallCutset, "sanity check: cutset must exceed trimSmallCutset")
 
 	collection := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "X", "Y", "a", "b", "c", "d", "e", "f", "g", "h", "i"}
 	actual := Trim(collection, cutset)
@@ -3301,7 +3301,7 @@ func TestTrimLeftLarge(t *testing.T) {
 	is := assert.New(t)
 
 	cutset := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}
-	is.Len(cutset, 9, "sanity check: cutset must exceed trimSmallCutset")
+	is.Greater(len(cutset), trimSmallCutset, "sanity check: cutset must exceed trimSmallCutset")
 
 	collection := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "X", "Y"}
 	actual := TrimLeft(collection, cutset)
@@ -3358,7 +3358,7 @@ func TestTrimRightLarge(t *testing.T) {
 	is := assert.New(t)
 
 	cutset := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}
-	is.Len(cutset, 9, "sanity check: cutset must exceed trimSmallCutset")
+	is.Greater(len(cutset), trimSmallCutset, "sanity check: cutset must exceed trimSmallCutset")
 
 	collection := []string{"X", "Y", "a", "b", "c", "d", "e", "f", "g", "h", "i"}
 	actual := TrimRight(collection, cutset)

--- a/slice_test.go
+++ b/slice_test.go
@@ -3234,7 +3234,9 @@ func TestCutSuffix(t *testing.T) {
 	is.Equal([]string{"a", "a", "b"}, actualAfterS)
 }
 
-func TestTrim(t *testing.T) {
+// TestTrimSmallScan exercises the small-scan path (all cutsets here are
+// <= trimSmallCutset). See TestTrimMapPath for the map-based path.
+func TestTrimSmallScan(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -3288,7 +3290,9 @@ func TestTrimSmallMapBoundary(t *testing.T) {
 	is.Equal(Trim(collection, small), Trim(collection, mapped))
 }
 
-func TestTrimLeft(t *testing.T) {
+// TestTrimLeftSmallScan exercises the small-scan path (all cutsets here are
+// <= trimSmallCutset). See TestTrimLeftMapPath for the map-based path.
+func TestTrimLeftSmallScan(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -3362,7 +3366,9 @@ func TestTrimPrefix(t *testing.T) {
 	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, actual)
 }
 
-func TestTrimRight(t *testing.T) {
+// TestTrimRightSmallScan exercises the small-scan path (all cutsets here are
+// <= trimSmallCutset). See TestTrimRightMapPath for the map-based path.
+func TestTrimRightSmallScan(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 

--- a/slice_test.go
+++ b/slice_test.go
@@ -3235,7 +3235,7 @@ func TestCutSuffix(t *testing.T) {
 }
 
 // TestTrimSmallScan exercises the small-scan path (all cutsets here are
-// <= trimSmallCutset). See TestTrimMapPath for the map-based path.
+// <= trimSmallCutset). See TestTrimLarge for the map-based path.
 func TestTrimSmallScan(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -3255,7 +3255,7 @@ func TestTrimSmallScan(t *testing.T) {
 // Trim dispatches on len(cutset) <= trimSmallCutset (8): a cutset of 9 unique
 // elements forces the trimLarge path, which the table above never exercises
 // (its cutsets are all <= 8).
-func TestTrimMapPath(t *testing.T) {
+func TestTrimLarge(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -3273,25 +3273,8 @@ func TestTrimMapPath(t *testing.T) {
 	is.Equal([]string{"X", "Y"}, actual)
 }
 
-// The small-scan (len(cutset) <= 8) and map (len(cutset) > 8) paths must trim
-// identically. Same collection, cutset just below and just above the
-// threshold with an extra element absent from collection, so both trim the
-// exact same leading/trailing run.
-func TestTrimSmallMapBoundary(t *testing.T) {
-	t.Parallel()
-	is := assert.New(t)
-
-	collection := []string{"a", "b", "c", "X", "Y", "a", "b", "c"}
-	small := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
-	is.Len(small, 8, "sanity check: small must land in the small-scan branch")
-	mapped := append(append([]string{}, small...), "z")
-	is.Len(mapped, 9, "sanity check: mapped must land in the map branch")
-
-	is.Equal(Trim(collection, small), Trim(collection, mapped))
-}
-
 // TestTrimLeftSmallScan exercises the small-scan path (all cutsets here are
-// <= trimSmallCutset). See TestTrimLeftMapPath for the map-based path.
+// <= trimSmallCutset). See TestTrimLeftLarge for the map-based path.
 func TestTrimLeftSmallScan(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -3313,7 +3296,7 @@ func TestTrimLeftSmallScan(t *testing.T) {
 // TrimLeft dispatches on len(cutset) <= trimSmallCutset (8): a cutset of 9
 // unique elements forces the trimLeftLarge path, which the table above never
 // exercises (its cutsets are all <= 8).
-func TestTrimLeftMapPath(t *testing.T) {
+func TestTrimLeftLarge(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -3329,23 +3312,6 @@ func TestTrimLeftMapPath(t *testing.T) {
 
 	actual = TrimLeft([]string{"X", "Y"}, cutset)
 	is.Equal([]string{"X", "Y"}, actual)
-}
-
-// The small-scan (len(cutset) <= 8) and map (len(cutset) > 8) paths must trim
-// identically. Same collection, cutset just below and just above the
-// threshold with an extra element absent from collection, so both trim the
-// exact same leading run.
-func TestTrimLeftSmallMapBoundary(t *testing.T) {
-	t.Parallel()
-	is := assert.New(t)
-
-	collection := []string{"a", "b", "c", "X", "Y"}
-	small := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
-	is.Len(small, 8, "sanity check: small must land in the small-scan branch")
-	mapped := append(append([]string{}, small...), "z")
-	is.Len(mapped, 9, "sanity check: mapped must land in the map branch")
-
-	is.Equal(TrimLeft(collection, small), TrimLeft(collection, mapped))
 }
 
 func TestTrimPrefix(t *testing.T) {
@@ -3367,7 +3333,7 @@ func TestTrimPrefix(t *testing.T) {
 }
 
 // TestTrimRightSmallScan exercises the small-scan path (all cutsets here are
-// <= trimSmallCutset). See TestTrimRightMapPath for the map-based path.
+// <= trimSmallCutset). See TestTrimRightLarge for the map-based path.
 func TestTrimRightSmallScan(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -3387,7 +3353,7 @@ func TestTrimRightSmallScan(t *testing.T) {
 // TrimRight dispatches on len(cutset) <= trimSmallCutset (8): a cutset of 9
 // unique elements forces the trimRightLarge path, which the table above
 // never exercises (its cutsets are all <= 8).
-func TestTrimRightMapPath(t *testing.T) {
+func TestTrimRightLarge(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -3403,23 +3369,6 @@ func TestTrimRightMapPath(t *testing.T) {
 
 	actual = TrimRight([]string{"X", "Y"}, cutset)
 	is.Equal([]string{"X", "Y"}, actual)
-}
-
-// The small-scan (len(cutset) <= 8) and map (len(cutset) > 8) paths must trim
-// identically. Same collection, cutset just below and just above the
-// threshold with an extra element absent from collection, so both trim the
-// exact same trailing run.
-func TestTrimRightSmallMapBoundary(t *testing.T) {
-	t.Parallel()
-	is := assert.New(t)
-
-	collection := []string{"X", "Y", "a", "b", "c"}
-	small := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
-	is.Len(small, 8, "sanity check: small must land in the small-scan branch")
-	mapped := append(append([]string{}, small...), "z")
-	is.Len(mapped, 9, "sanity check: mapped must land in the map branch")
-
-	is.Equal(TrimRight(collection, small), TrimRight(collection, mapped))
 }
 
 func TestTrimSuffix(t *testing.T) {


### PR DESCRIPTION
## Summary
- `Trim`, `TrimLeft` and `TrimRight` always called `Keyify(cutset)` to build a `map[T]struct{}` before scanning the collection's ends for membership. For the common case of a small cutset (a handful of characters/values), the map allocation and hashing cost more than a plain linear scan.
- Each function now dispatches on `len(cutset) <= trimSmallCutset` (8): below the threshold it scans the cutset directly (allocation-free), above it keeps the original map-based path. Both paths share the same `==` equality (NaN behaves identically), preserving order and `Slice` type exactly.
- Added a dedicated `TestTrim*Large` test per function covering the map path (the existing table only exercised cutsets `<= 8`), with a sanity-check assertion tying the cutset size to `trimSmallCutset` so it keeps forcing that path if the threshold changes. All `Trim*` functions and their new helpers are now at 100% statement coverage.

## Benchmark

```
goos: darwin
goarch: arm64
pkg: github.com/samber/lo/benchmark
cpu: Apple M3
                        │ before.txt  │              after.txt              │
                        │   sec/op    │    sec/op     vs base               │
Trim/ints_10              93.52n ± 7%   45.68n ±  2%  -51.16% (p=0.000 n=8)
Trim/ints_100             216.6n ± 2%   145.1n ±  3%  -32.99% (p=0.000 n=8)
Trim/ints_1000            1.149µ ± 2%   1.066µ ±  2%   -7.27% (p=0.000 n=8)
Trim/small_k1_10          63.53n ± 1%   39.70n ±  4%  -37.50% (p=0.000 n=8)
Trim/small_k1_100         183.9n ± 1%   147.0n ±  2%  -20.09% (p=0.000 n=8)
Trim/small_k1_1000        1.110µ ± 2%   1.061µ ±  1%   -4.41% (p=0.010 n=8)
TrimLeft/ints_10          86.46n ± 2%   40.16n ±  1%  -53.55% (p=0.000 n=8)
TrimLeft/ints_100         211.9n ± 3%   147.5n ± 10%  -30.41% (p=0.000 n=8)
TrimLeft/ints_1000        1.135µ ± 2%   1.072µ ±  2%   -5.59% (p=0.000 n=8)
TrimLeft/small_k1_10      59.13n ± 2%   36.27n ±  1%  -38.66% (p=0.000 n=8)
TrimLeft/small_k1_100     180.2n ± 2%   143.8n ± 10%  -20.20% (p=0.000 n=8)
TrimLeft/small_k1_1000    1.109µ ± 1%   1.060µ ±  1%   -4.33% (p=0.000 n=8)
TrimRight/ints_10         86.44n ± 2%   40.91n ±  2%  -52.68% (p=0.000 n=8)
TrimRight/ints_100        211.2n ± 1%   143.9n ±  2%  -31.87% (p=0.000 n=8)
TrimRight/ints_1000       1.139µ ± 1%   1.061µ ±  2%   -6.76% (p=0.000 n=8)
TrimRight/small_k1_10     59.38n ± 8%   35.22n ±  2%  -40.67% (p=0.000 n=8)
TrimRight/small_k1_100    180.0n ± 2%   140.0n ±  3%  -22.19% (p=0.000 n=8)
TrimRight/small_k1_1000   1.104µ ± 2%   1.049µ ±  3%   -4.98% (p=0.009 n=8)
geomean                   253.1n        182.3n        -27.96%
```

`allocs/op` and `B/op` unchanged (~0.00%) across all cases.

## Test plan
- [x] `go test ./...` passes
- [x] Dedicated tests (`TestTrimLarge`, `TestTrimLeftLarge`, `TestTrimRightLarge`) cover the map path for all three functions
- [x] 100% statement coverage on `Trim`, `TrimLeft`, `TrimRight` and their new helpers
- [x] `golangci-lint run ./...` clean
- [x] `go test ./benchmark/... -bench='^(BenchmarkTrim|BenchmarkTrimLeft|BenchmarkTrimRight)$' -benchmem -count=8 -cpu=1` before/after, compared with `benchstat`

