### PR TITLE
perf(map): skip the seen-map for the single-map case in UniqKeys

### DIFF
--- a/benchmark/core_map_bench_test.go
+++ b/benchmark/core_map_bench_test.go
@@ -29,6 +29,12 @@ func BenchmarkUniqKeys(b *testing.B) {
 				_ = lo.UniqKeys(m1, m2)
 			}
 		})
+		// single: the dominant call shape, keys of one map are already unique.
+		b.Run("single_"+strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = lo.UniqKeys(m1)
+			}
+		})
 	}
 }
 

--- a/map.go
+++ b/map.go
@@ -21,6 +21,25 @@ func Keys[K comparable, V any](in ...map[K]V) []K {
 // UniqKeys creates a slice of unique keys in the map.
 // Play: https://go.dev/play/p/TPKAb6ILdHk
 func UniqKeys[K comparable, V any](in ...map[K]V) []K {
+	// The keys of a SINGLE map are already unique, so the dominant single-map call
+	// shape never needs a seen-set at all: just copy the keys out.
+	if len(in) == 1 {
+		return uniqKeysSingle(in[0])
+	}
+	return uniqKeysMerge(in...)
+}
+
+// uniqKeysSingle copies the keys of a single map, which are inherently unique.
+func uniqKeysSingle[K comparable, V any](m map[K]V) []K {
+	result := make([]K, 0, len(m))
+	for k := range m {
+		result = append(result, k)
+	}
+	return result
+}
+
+// uniqKeysMerge dedups keys across multiple maps using a seen-set.
+func uniqKeysMerge[K comparable, V any](in ...map[K]V) []K {
 	size := 0
 	for i := range in {
 		size += len(in[i])

--- a/map.go
+++ b/map.go
@@ -21,25 +21,16 @@ func Keys[K comparable, V any](in ...map[K]V) []K {
 // UniqKeys creates a slice of unique keys in the map.
 // Play: https://go.dev/play/p/TPKAb6ILdHk
 func UniqKeys[K comparable, V any](in ...map[K]V) []K {
+	if len(in) == 0 {
+		return []K{}
+	}
+
 	// The keys of a SINGLE map are already unique, so the dominant single-map call
 	// shape never needs a seen-set at all: just copy the keys out.
 	if len(in) == 1 {
-		return uniqKeysSingle(in[0])
+		return Keys(in[0])
 	}
-	return uniqKeysMerge(in...)
-}
 
-// uniqKeysSingle copies the keys of a single map, which are inherently unique.
-func uniqKeysSingle[K comparable, V any](m map[K]V) []K {
-	result := make([]K, 0, len(m))
-	for k := range m {
-		result = append(result, k)
-	}
-	return result
-}
-
-// uniqKeysMerge dedups keys across multiple maps using a seen-set.
-func uniqKeysMerge[K comparable, V any](in ...map[K]V) []K {
 	size := 0
 	for i := range in {
 		size += len(in[i])

--- a/map_test.go
+++ b/map_test.go
@@ -51,6 +51,18 @@ func TestUniqKeys(t *testing.T) {
 	// check order
 	r6 := UniqKeys(map[string]int{"foo": 1}, map[string]int{"bar": 3})
 	is.Equal([]string{"foo", "bar"}, r6)
+
+	// multiple maps, all empty (still takes the merge path, not the single-map shortcut)
+	r7 := UniqKeys(map[string]int{}, map[string]int{})
+	is.Empty(r7)
+
+	// a nil map is a valid, empty map
+	r8 := UniqKeys[string, int](nil)
+	is.Empty(r8)
+
+	// dedup across more than two maps, keeping first-occurrence order
+	r9 := UniqKeys(map[string]int{"foo": 1}, map[string]int{"foo": 2, "bar": 3}, map[string]int{"bar": 4, "baz": 5})
+	is.Equal([]string{"foo", "bar", "baz"}, r9)
 }
 
 func TestHasKey(t *testing.T) {

--- a/map_test.go
+++ b/map_test.go
@@ -29,6 +29,10 @@ func TestKeys(t *testing.T) {
 	is.ElementsMatch(r5, []string{"bar", "bar", "foo"})
 }
 
+// TestUniqKeys already mixes single-map calls (the uniqKeysSingle path) with
+// multi-map and zero-map calls (the uniqKeysMerge path), so unlike its
+// dual-path siblings it needs no separate SmallScan/MapPath split: it
+// already exercises both paths (see r1/r2 for single, r3/r4/r5/r6 for merge).
 func TestUniqKeys(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)

--- a/map_test.go
+++ b/map_test.go
@@ -29,10 +29,6 @@ func TestKeys(t *testing.T) {
 	is.ElementsMatch(r5, []string{"bar", "bar", "foo"})
 }
 
-// TestUniqKeys already mixes single-map calls (the uniqKeysSingle path) with
-// multi-map and zero-map calls (the uniqKeysMerge path), so unlike its
-// dual-path siblings it needs no separate SmallScan/MapPath split: it
-// already exercises both paths (see r1/r2 for single, r3/r4/r5/r6 for merge).
 func TestUniqKeys(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)

--- a/map_test.go
+++ b/map_test.go
@@ -29,7 +29,17 @@ func TestKeys(t *testing.T) {
 	is.ElementsMatch(r5, []string{"bar", "bar", "foo"})
 }
 
-func TestUniqKeys(t *testing.T) {
+// TestUniqKeysZero exercises the len(in) == 0 branch: no maps at all.
+func TestUniqKeysZero(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	r1 := UniqKeys[string, int]()
+	is.Empty(r1)
+}
+
+// TestUniqKeysSingle exercises the len(in) == 1 branch, which delegates to Keys().
+func TestUniqKeysSingle(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -39,30 +49,33 @@ func TestUniqKeys(t *testing.T) {
 	r2 := UniqKeys(map[string]int{})
 	is.Empty(r2)
 
-	r3 := UniqKeys(map[string]int{"foo": 1, "bar": 2}, map[string]int{"baz": 3})
-	is.ElementsMatch(r3, []string{"bar", "baz", "foo"})
+	// a nil map is a valid, empty map
+	r3 := UniqKeys[string, int](nil)
+	is.Empty(r3)
+}
 
-	r4 := UniqKeys[string, int]()
-	is.Empty(r4)
+// TestUniqKeysMultiple exercises the len(in) > 1 branch, which dedups via a seen-set.
+func TestUniqKeysMultiple(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
 
-	r5 := UniqKeys(map[string]int{"foo": 1, "bar": 2}, map[string]int{"foo": 1, "bar": 3})
-	is.ElementsMatch(r5, []string{"bar", "foo"})
+	r1 := UniqKeys(map[string]int{"foo": 1, "bar": 2}, map[string]int{"baz": 3})
+	is.ElementsMatch(r1, []string{"bar", "baz", "foo"})
+
+	r2 := UniqKeys(map[string]int{"foo": 1, "bar": 2}, map[string]int{"foo": 1, "bar": 3})
+	is.ElementsMatch(r2, []string{"bar", "foo"})
 
 	// check order
-	r6 := UniqKeys(map[string]int{"foo": 1}, map[string]int{"bar": 3})
-	is.Equal([]string{"foo", "bar"}, r6)
+	r3 := UniqKeys(map[string]int{"foo": 1}, map[string]int{"bar": 3})
+	is.Equal([]string{"foo", "bar"}, r3)
 
-	// multiple maps, all empty (still takes the merge path, not the single-map shortcut)
-	r7 := UniqKeys(map[string]int{}, map[string]int{})
-	is.Empty(r7)
-
-	// a nil map is a valid, empty map
-	r8 := UniqKeys[string, int](nil)
-	is.Empty(r8)
+	// multiple maps, all empty
+	r4 := UniqKeys(map[string]int{}, map[string]int{})
+	is.Empty(r4)
 
 	// dedup across more than two maps, keeping first-occurrence order
-	r9 := UniqKeys(map[string]int{"foo": 1}, map[string]int{"foo": 2, "bar": 3}, map[string]int{"bar": 4, "baz": 5})
-	is.Equal([]string{"foo", "bar", "baz"}, r9)
+	r5 := UniqKeys(map[string]int{"foo": 1}, map[string]int{"foo": 2, "bar": 3}, map[string]int{"bar": 4, "baz": 5})
+	is.Equal([]string{"foo", "bar", "baz"}, r5)
 }
 
 func TestHasKey(t *testing.T) {


### PR DESCRIPTION
## Summary
- `UniqKeys` always allocated a seen `map[K]struct{}` sized to the total key count and walked every key across the variadic input maps, inserting into `seen` to dedup. But the keys of a **single** Go map are already unique by construction — for the dominant single-map call shape, the seen-map is pure overhead.
- `UniqKeys` now returns immediately for zero maps, reuses the existing `Keys()` helper for the single-map case (no seen-map at all), and keeps the seen-map merge inline for the general case (zero or multiple maps). This does **not** apply to `UniqValues`, whose values are not guaranteed unique even for a single map.
- Tests are split one-per-branch: `TestUniqKeysZero`, `TestUniqKeysSingle`, `TestUniqKeysMultiple` (including zero-map, empty-map, nil-map, all-empty multi-map, and three-way dedup ordering scenarios). `UniqKeys` is now at 100% statement coverage.

## Benchmark

```
goos: darwin
goarch: arm64
pkg: github.com/samber/lo/benchmark
cpu: Apple M3
                     │ before.txt  │              after.txt              │
                     │   sec/op    │    sec/op     vs base               │
UniqKeys/10            1.206µ ± 1%   1.198µ ±  1%        ~ (p=0.068 n=8)
UniqKeys/single_10     772.5n ± 1%   316.8n ±  0%  -58.99% (p=0.000 n=8)
UniqKeys/100           9.617µ ± 1%   9.532µ ±  1%        ~ (p=0.161 n=8)
UniqKeys/single_100    6.343µ ± 2%   2.559µ ±  0%  -59.65% (p=0.000 n=8)
UniqKeys/1000          113.3µ ± 2%   112.3µ ± 11%        ~ (p=0.645 n=8)
UniqKeys/single_1000   65.07µ ± 1%   29.08µ ±  7%  -55.31% (p=0.000 n=8)
geomean                8.650µ        5.581µ        -35.48%
```

`B/op` geomean: `8.429Ki` → `4.403Ki` (**-47.76%**). `allocs/op` geomean: `4.986` → `2.330` (**-53.27%**).

The `single_*` sub-cases (the new dispatch target) show a consistent ~55-60% time win and a real, measured drop in allocations (-74% to -83% `B/op` and `allocs/op`) — unlike some of the other PRs in this series, the eliminated map here is genuinely large enough that escape analysis was never masking it. The default `10/100/1000` sub-cases (two-map calls, unaffected by this change) stay flat, as expected.

## Test plan
- [x] `go test ./...` passes
- [x] 100% statement coverage on `UniqKeys`, with a dedicated test per dispatch branch
- [x] `golangci-lint run ./...` clean
- [x] `go test ./benchmark/... -bench='^BenchmarkUniqKeys$' -benchmem -count=8 -cpu=1` before/after, compared with `benchstat`

