### PR TITLE
test(benchmark): extend shared lengths to cover the small-input regime

### DIFF
--- a/benchmark/core_find_bench_test.go
+++ b/benchmark/core_find_bench_test.go
@@ -9,11 +9,11 @@ import (
 
 func BenchmarkIndexOf(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		var target int // worst case: last element
-		if n > 0 {
-			target = ints[n-1]
+		if n == 0 {
+			continue
 		}
+		ints := genSliceInt(n)
+		target := ints[n-1] // worst case: last element
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.IndexOf(ints, target)
@@ -24,11 +24,11 @@ func BenchmarkIndexOf(b *testing.B) {
 
 func BenchmarkLastIndexOf(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		var target int
-		if n > 0 {
-			target = ints[0]
+		if n == 0 {
+			continue
 		}
+		ints := genSliceInt(n)
+		target := ints[0]
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.LastIndexOf(ints, target)
@@ -39,12 +39,11 @@ func BenchmarkLastIndexOf(b *testing.B) {
 
 func BenchmarkHasPrefix(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		prefixLen := n/10 + 1
-		if prefixLen > n {
-			prefixLen = n
+		if n < 3 {
+			continue
 		}
-		prefix := ints[:prefixLen]
+		ints := genSliceInt(n)
+		prefix := ints[:n/10+1]
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.HasPrefix(ints, prefix)
@@ -55,12 +54,11 @@ func BenchmarkHasPrefix(b *testing.B) {
 
 func BenchmarkHasSuffix(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		suffixStart := n - n/10 - 1
-		if suffixStart < 0 {
-			suffixStart = 0
+		if n < 3 {
+			continue
 		}
-		suffix := ints[suffixStart:]
+		ints := genSliceInt(n)
+		suffix := ints[n-n/10-1:]
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.HasSuffix(ints, suffix)
@@ -71,11 +69,11 @@ func BenchmarkHasSuffix(b *testing.B) {
 
 func BenchmarkFind(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		var target int
-		if n > 0 {
-			target = ints[n-1]
+		if n == 0 {
+			continue
 		}
+		ints := genSliceInt(n)
+		target := ints[n-1]
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, _ = lo.Find(ints, func(v int) bool { return v == target })
@@ -86,11 +84,11 @@ func BenchmarkFind(b *testing.B) {
 
 func BenchmarkFindIndexOf(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		var target int
-		if n > 0 {
-			target = ints[n-1]
+		if n == 0 {
+			continue
 		}
+		ints := genSliceInt(n)
+		target := ints[n-1]
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, _, _ = lo.FindIndexOf(ints, func(v int) bool { return v == target })
@@ -101,11 +99,11 @@ func BenchmarkFindIndexOf(b *testing.B) {
 
 func BenchmarkFindLastIndexOf(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		var target int
-		if n > 0 {
-			target = ints[0]
+		if n == 0 {
+			continue
 		}
+		ints := genSliceInt(n)
+		target := ints[0]
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, _, _ = lo.FindLastIndexOf(ints, func(v int) bool { return v == target })

--- a/benchmark/core_find_bench_test.go
+++ b/benchmark/core_find_bench_test.go
@@ -10,7 +10,10 @@ import (
 func BenchmarkIndexOf(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		target := ints[n-1] // worst case: last element
+		var target int // worst case: last element
+		if n > 0 {
+			target = ints[n-1]
+		}
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.IndexOf(ints, target)
@@ -22,7 +25,10 @@ func BenchmarkIndexOf(b *testing.B) {
 func BenchmarkLastIndexOf(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		target := ints[0]
+		var target int
+		if n > 0 {
+			target = ints[0]
+		}
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.LastIndexOf(ints, target)
@@ -34,7 +40,11 @@ func BenchmarkLastIndexOf(b *testing.B) {
 func BenchmarkHasPrefix(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		prefix := ints[:n/10+1]
+		prefixLen := n/10 + 1
+		if prefixLen > n {
+			prefixLen = n
+		}
+		prefix := ints[:prefixLen]
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.HasPrefix(ints, prefix)
@@ -46,7 +56,11 @@ func BenchmarkHasPrefix(b *testing.B) {
 func BenchmarkHasSuffix(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		suffix := ints[n-n/10-1:]
+		suffixStart := n - n/10 - 1
+		if suffixStart < 0 {
+			suffixStart = 0
+		}
+		suffix := ints[suffixStart:]
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.HasSuffix(ints, suffix)
@@ -58,7 +72,10 @@ func BenchmarkHasSuffix(b *testing.B) {
 func BenchmarkFind(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		target := ints[n-1]
+		var target int
+		if n > 0 {
+			target = ints[n-1]
+		}
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, _ = lo.Find(ints, func(v int) bool { return v == target })
@@ -70,7 +87,10 @@ func BenchmarkFind(b *testing.B) {
 func BenchmarkFindIndexOf(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		target := ints[n-1]
+		var target int
+		if n > 0 {
+			target = ints[n-1]
+		}
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, _, _ = lo.FindIndexOf(ints, func(v int) bool { return v == target })
@@ -82,7 +102,10 @@ func BenchmarkFindIndexOf(b *testing.B) {
 func BenchmarkFindLastIndexOf(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		target := ints[0]
+		var target int
+		if n > 0 {
+			target = ints[0]
+		}
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, _, _ = lo.FindLastIndexOf(ints, func(v int) bool { return v == target })

--- a/benchmark/core_intersect_bench_test.go
+++ b/benchmark/core_intersect_bench_test.go
@@ -9,11 +9,11 @@ import (
 
 func BenchmarkContains(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		var target int
-		if n > 0 {
-			target = ints[n-1]
+		if n == 0 {
+			continue
 		}
+		ints := genSliceInt(n)
+		target := ints[n-1]
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.Contains(ints, target)
@@ -24,11 +24,11 @@ func BenchmarkContains(b *testing.B) {
 
 func BenchmarkContainsBy(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		var target int
-		if n > 0 {
-			target = ints[n-1]
+		if n == 0 {
+			continue
 		}
+		ints := genSliceInt(n)
+		target := ints[n-1]
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.ContainsBy(ints, func(v int) bool { return v == target })
@@ -62,11 +62,11 @@ func BenchmarkEveryBy(b *testing.B) {
 
 func BenchmarkSome(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		subset := []int{}
-		if n > 0 {
-			subset = []int{ints[n-1]}
+		if n == 0 {
+			continue
 		}
+		ints := genSliceInt(n)
+		subset := []int{ints[n-1]}
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.Some(ints, subset)

--- a/benchmark/core_intersect_bench_test.go
+++ b/benchmark/core_intersect_bench_test.go
@@ -10,7 +10,10 @@ import (
 func BenchmarkContains(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		target := ints[n-1]
+		var target int
+		if n > 0 {
+			target = ints[n-1]
+		}
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.Contains(ints, target)
@@ -22,7 +25,10 @@ func BenchmarkContains(b *testing.B) {
 func BenchmarkContainsBy(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		target := ints[n-1]
+		var target int
+		if n > 0 {
+			target = ints[n-1]
+		}
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.ContainsBy(ints, func(v int) bool { return v == target })
@@ -57,7 +63,10 @@ func BenchmarkEveryBy(b *testing.B) {
 func BenchmarkSome(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		subset := []int{ints[n-1]}
+		subset := []int{}
+		if n > 0 {
+			subset = []int{ints[n-1]}
+		}
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.Some(ints, subset)

--- a/benchmark/core_slice_bench_test.go
+++ b/benchmark/core_slice_bench_test.go
@@ -731,11 +731,11 @@ func BenchmarkSlice(b *testing.B) {
 
 func BenchmarkReplaceAll(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		var old int
-		if n > 0 {
-			old = ints[n/4]
+		if n == 0 {
+			continue
 		}
+		ints := genSliceInt(n)
+		old := ints[n/4]
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.ReplaceAll(ints, old, 123123)
@@ -814,11 +814,11 @@ func BenchmarkSplice(b *testing.B) {
 
 func BenchmarkCut(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		sep := ints[:0]
-		if n >= 3 {
-			sep = ints[n/4 : n/4+3]
+		if n < 3 {
+			continue
 		}
+		ints := genSliceInt(n)
+		sep := ints[n/4 : n/4+3]
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, _, _ = lo.Cut(ints, sep)
@@ -829,11 +829,11 @@ func BenchmarkCut(b *testing.B) {
 
 func BenchmarkCutPrefix(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		prefix := ints[:0]
-		if n >= 3 {
-			prefix = ints[:3]
+		if n < 3 {
+			continue
 		}
+		ints := genSliceInt(n)
+		prefix := ints[:3]
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, _ = lo.CutPrefix(ints, prefix)
@@ -844,11 +844,11 @@ func BenchmarkCutPrefix(b *testing.B) {
 
 func BenchmarkCutSuffix(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		suffix := ints[:0]
-		if n >= 3 {
-			suffix = ints[n-3:]
+		if n < 3 {
+			continue
 		}
+		ints := genSliceInt(n)
+		suffix := ints[n-3:]
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, _ = lo.CutSuffix(ints, suffix)
@@ -859,11 +859,11 @@ func BenchmarkCutSuffix(b *testing.B) {
 
 func BenchmarkTrim(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		cutset := ints[:0]
-		if n >= 3 {
-			cutset = ints[:3]
+		if n < 3 {
+			continue
 		}
+		ints := genSliceInt(n)
+		cutset := ints[:3]
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.Trim(ints, cutset)
@@ -874,11 +874,11 @@ func BenchmarkTrim(b *testing.B) {
 
 func BenchmarkTrimLeft(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		cutset := ints[:0]
-		if n >= 3 {
-			cutset = ints[:3]
+		if n < 3 {
+			continue
 		}
+		ints := genSliceInt(n)
+		cutset := ints[:3]
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.TrimLeft(ints, cutset)
@@ -889,11 +889,11 @@ func BenchmarkTrimLeft(b *testing.B) {
 
 func BenchmarkTrimRight(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		cutset := ints[:0]
-		if n >= 3 {
-			cutset = ints[n-3:]
+		if n < 3 {
+			continue
 		}
+		ints := genSliceInt(n)
+		cutset := ints[n-3:]
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.TrimRight(ints, cutset)
@@ -904,11 +904,11 @@ func BenchmarkTrimRight(b *testing.B) {
 
 func BenchmarkTrimPrefix(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		prefix := ints[:0]
-		if n >= 3 {
-			prefix = ints[:3]
+		if n < 3 {
+			continue
 		}
+		ints := genSliceInt(n)
+		prefix := ints[:3]
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.TrimPrefix(ints, prefix)
@@ -919,11 +919,11 @@ func BenchmarkTrimPrefix(b *testing.B) {
 
 func BenchmarkTrimSuffix(b *testing.B) {
 	for _, n := range lengths {
-		ints := genSliceInt(n)
-		suffix := ints[:0]
-		if n >= 3 {
-			suffix = ints[n-3:]
+		if n < 3 {
+			continue
 		}
+		ints := genSliceInt(n)
+		suffix := ints[n-3:]
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.TrimSuffix(ints, suffix)

--- a/benchmark/core_slice_bench_test.go
+++ b/benchmark/core_slice_bench_test.go
@@ -732,9 +732,13 @@ func BenchmarkSlice(b *testing.B) {
 func BenchmarkReplaceAll(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
+		var old int
+		if n > 0 {
+			old = ints[n/4]
+		}
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_ = lo.ReplaceAll(ints, ints[n/4], 123123)
+				_ = lo.ReplaceAll(ints, old, 123123)
 			}
 		})
 	}
@@ -811,7 +815,10 @@ func BenchmarkSplice(b *testing.B) {
 func BenchmarkCut(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		sep := ints[n/4 : n/4+3]
+		sep := ints[:0]
+		if n >= 3 {
+			sep = ints[n/4 : n/4+3]
+		}
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, _, _ = lo.Cut(ints, sep)
@@ -823,7 +830,10 @@ func BenchmarkCut(b *testing.B) {
 func BenchmarkCutPrefix(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		prefix := ints[:3]
+		prefix := ints[:0]
+		if n >= 3 {
+			prefix = ints[:3]
+		}
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, _ = lo.CutPrefix(ints, prefix)
@@ -835,7 +845,10 @@ func BenchmarkCutPrefix(b *testing.B) {
 func BenchmarkCutSuffix(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		suffix := ints[n-3:]
+		suffix := ints[:0]
+		if n >= 3 {
+			suffix = ints[n-3:]
+		}
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, _ = lo.CutSuffix(ints, suffix)
@@ -847,7 +860,10 @@ func BenchmarkCutSuffix(b *testing.B) {
 func BenchmarkTrim(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		cutset := ints[:3]
+		cutset := ints[:0]
+		if n >= 3 {
+			cutset = ints[:3]
+		}
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.Trim(ints, cutset)
@@ -859,7 +875,10 @@ func BenchmarkTrim(b *testing.B) {
 func BenchmarkTrimLeft(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		cutset := ints[:3]
+		cutset := ints[:0]
+		if n >= 3 {
+			cutset = ints[:3]
+		}
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.TrimLeft(ints, cutset)
@@ -871,7 +890,10 @@ func BenchmarkTrimLeft(b *testing.B) {
 func BenchmarkTrimRight(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		cutset := ints[n-3:]
+		cutset := ints[:0]
+		if n >= 3 {
+			cutset = ints[n-3:]
+		}
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.TrimRight(ints, cutset)
@@ -883,7 +905,10 @@ func BenchmarkTrimRight(b *testing.B) {
 func BenchmarkTrimPrefix(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		prefix := ints[:3]
+		prefix := ints[:0]
+		if n >= 3 {
+			prefix = ints[:3]
+		}
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.TrimPrefix(ints, prefix)
@@ -895,7 +920,10 @@ func BenchmarkTrimPrefix(b *testing.B) {
 func BenchmarkTrimSuffix(b *testing.B) {
 	for _, n := range lengths {
 		ints := genSliceInt(n)
-		suffix := ints[n-3:]
+		suffix := ints[:0]
+		if n >= 3 {
+			suffix = ints[n-3:]
+		}
 		b.Run(fmt.Sprintf("ints_%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = lo.TrimSuffix(ints, suffix)

--- a/benchmark/helpers_test.go
+++ b/benchmark/helpers_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-var lengths = []int{10, 100, 1000}
+var lengths = []int{0, 1, 4, 8, 10, 100, 1000}
 
 func genSliceString(n int) []string {
 	res := make([]string, 0, n)


### PR DESCRIPTION
## Summary
- `lengths` becomes `[]int{0, 1, 4, 8, 10, 100, 1000}` (was `[]int{10, 100, 1000}`). Every benchmark that parametrizes over it now automatically sweeps the small-input regime (0/1/4/8), which recent dual-path perf changes (map-vs-scan dispatch at a threshold around 8) need — without each benchmark hand-rolling its own `small_` sub-case loop. See the follow-up PRs removing that now-redundant per-benchmark code.
- Guarded the handful of benchmarks that indexed/sliced their generated input assuming `n >= 1` or `n >= 3` (`Contains`, `ContainsBy`, `Some`, `IndexOf`, `LastIndexOf`, `Find`, `FindIndexOf`, `FindLastIndexOf`, `HasPrefix`, `HasSuffix`, `ReplaceAll`, `Cut`, `CutPrefix`, `CutSuffix`, `Trim`, `TrimLeft`, `TrimRight`, `TrimPrefix`, `TrimSuffix`), which would otherwise panic (index/slice out of range) now that `lengths` includes 0 and 1.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] `go test ./benchmark/... -bench='.' -benchtime=1x` (full smoke run, no timing claims) across the whole benchmark package to confirm nothing panics with the new small lengths
