### PR TITLE
test: use TestFoo_scenario naming for multi-function test helpers

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -34,6 +34,11 @@ For function variants, use consistent suffixes:
 ## Testing
 We try to maintain code coverage above 90%.
 
+### Naming multiple test functions for the same helper
+When a helper needs more than one `Test` function (e.g. to exercise distinct internal code paths, dispatch thresholds, or success/failure scenarios), name each one `TestHelperName_scenario`: the helper name exactly as declared, an underscore, then a lower-case-led scenario label (e.g. `TestUniq_small`, `TestUniq_large`, `TestCut_success`, `TestCut_fail`). This mirrors the convention Go itself uses for `ExampleFoo_suffix` functions, where a suffix that does not name a real symbol must start with a lower-case letter.
+
+Do not add an underscore when the suffix is itself one of the documented [variant suffixes](#variants) (`F`, `I`, `Err`, `WithContext`, `X`, `By`, ...) — e.g. `TestFindDuplicatesByErr` and `TestMustX` are correctly named as-is, since `ByErr` and `X` name real variant helpers/families, not test-only scenarios.
+
 ## Benchmark and performance
 Write performant helpers and limit extra memory consumption. Build an helper for general purpose and don't optimize for a particular use-case.
 

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -37,7 +37,7 @@ We try to maintain code coverage above 90%.
 ### Naming multiple test functions for the same helper
 When a helper needs more than one `Test` function (e.g. to exercise distinct internal code paths, dispatch thresholds, or success/failure scenarios), name each one `TestHelperName_scenario`: the helper name exactly as declared, an underscore, then a lower-case-led scenario label (e.g. `TestUniq_small`, `TestUniq_large`, `TestCut_success`, `TestCut_fail`). This mirrors the convention Go itself uses for `ExampleFoo_suffix` functions, where a suffix that does not name a real symbol must start with a lower-case letter.
 
-Do not add an underscore when the suffix is itself one of the documented [variant suffixes](#variants) (`F`, `I`, `Err`, `WithContext`, `X`, `By`, ...) — e.g. `TestFindDuplicatesByErr` and `TestMustX` are correctly named as-is, since `ByErr` and `X` name real variant helpers/families, not test-only scenarios.
+Do not add an underscore when the suffix is itself one of the documented variant suffixes from the "Variants" section above (`F`, `I`, `Err`, `WithContext`, `X`, `By`, ...) — e.g. `TestFindDuplicatesByErr` and `TestMustX` are correctly named as-is, since `ByErr` and `X` name real variant helpers/families, not test-only scenarios.
 
 ## Benchmark and performance
 Write performant helpers and limit extra memory consumption. Build an helper for general purpose and don't optimize for a particular use-case.

--- a/errors_test.go
+++ b/errors_test.go
@@ -324,7 +324,7 @@ func (es joinErrors) As(t any) bool {
 	return false
 }
 
-func TestMustUserCustomHandler(t *testing.T) { //nolint:paralleltest
+func TestMust_userCustomHandler(t *testing.T) { //nolint:paralleltest
 	oldMustChecker := MustChecker
 	MustChecker = mustCheckerWithStack
 	defer func() {

--- a/find_test.go
+++ b/find_test.go
@@ -282,10 +282,10 @@ func TestFindKeyBy(t *testing.T) {
 	is.False(ok2)
 }
 
-// TestFindUniquesSmallScan exercises the small-scan path (all collections
-// here are <= findSmallThreshold). See TestFindUniquesLarge for the
+// TestFindUniques_smallScan exercises the small-scan path (all collections
+// here are <= findSmallThreshold). See TestFindUniques_large for the
 // map-based path.
-func TestFindUniquesSmallScan(t *testing.T) {
+func TestFindUniques_smallScan(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -310,7 +310,7 @@ func TestFindUniquesSmallScan(t *testing.T) {
 // FindUniques dispatches on len(collection) <= findSmallThreshold (8): a
 // collection of 12 elements forces the findUniquesLarge path, which the
 // table above never exercises (its collections are all <= 6 elements).
-func TestFindUniquesLarge(t *testing.T) {
+func TestFindUniques_large(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -330,10 +330,10 @@ func TestFindUniquesLarge(t *testing.T) {
 	is.IsType(nonempty, allUnique, "type preserved")
 }
 
-// TestFindUniquesBySmallScan exercises the small-scan path (all collections
-// here are <= findSmallThreshold). See TestFindUniquesByLarge for the
+// TestFindUniquesBy_smallScan exercises the small-scan path (all collections
+// here are <= findSmallThreshold). See TestFindUniquesBy_large for the
 // map-based path.
-func TestFindUniquesBySmallScan(t *testing.T) {
+func TestFindUniquesBy_smallScan(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -368,7 +368,7 @@ func TestFindUniquesBySmallScan(t *testing.T) {
 // FindUniquesBy dispatches on len(collection) <= findSmallThreshold (8): a
 // collection of 12 elements forces the findUniquesByLarge path, which the
 // table above never exercises (its collections are all <= 6 elements).
-func TestFindUniquesByLarge(t *testing.T) {
+func TestFindUniquesBy_large(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -388,10 +388,10 @@ func TestFindUniquesByLarge(t *testing.T) {
 	is.IsType(nonempty, allStrings, "type preserved")
 }
 
-// TestFindDuplicatesSmallScan exercises the small-scan path (all
+// TestFindDuplicates_smallScan exercises the small-scan path (all
 // collections here are <= findSmallThreshold). See
-// TestFindDuplicatesLarge for the map-based path.
-func TestFindDuplicatesSmallScan(t *testing.T) {
+// TestFindDuplicates_large for the map-based path.
+func TestFindDuplicates_smallScan(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -413,7 +413,7 @@ func TestFindDuplicatesSmallScan(t *testing.T) {
 // FindDuplicates dispatches on len(collection) <= findSmallThreshold (8): a
 // collection of 12 elements forces the findDuplicatesLarge path, which the
 // table above never exercises (its collections are all <= 6 elements).
-func TestFindDuplicatesLarge(t *testing.T) {
+func TestFindDuplicates_large(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -432,10 +432,10 @@ func TestFindDuplicatesLarge(t *testing.T) {
 	is.IsType(nonempty, allStrings, "type preserved")
 }
 
-// TestFindDuplicatesBySmallScan exercises the small-scan path (all
+// TestFindDuplicatesBy_smallScan exercises the small-scan path (all
 // collections here are <= findSmallThreshold). See
-// TestFindDuplicatesByLarge for the map-based path.
-func TestFindDuplicatesBySmallScan(t *testing.T) {
+// TestFindDuplicatesBy_large for the map-based path.
+func TestFindDuplicatesBy_smallScan(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -465,7 +465,7 @@ func TestFindDuplicatesBySmallScan(t *testing.T) {
 // FindDuplicatesBy dispatches on len(collection) <= findSmallThreshold (8): a
 // collection of 12 elements forces the findDuplicatesByLarge path, which the
 // table above never exercises (its collections are all <= 5 elements).
-func TestFindDuplicatesByLarge(t *testing.T) {
+func TestFindDuplicatesBy_large(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -1697,7 +1697,7 @@ func TestSamplesBy(t *testing.T) {
 // enough to fit the sparse branch's threshold with a non-trivial count
 // (e.g. the {"a", "b", "c"} slices used above) never exercises the sparse
 // branch at all, so it needs its own coverage on a large collection.
-func TestSamplesBySparse(t *testing.T) {
+func TestSamplesBy_sparse(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -1731,7 +1731,7 @@ func TestSamplesBySparse(t *testing.T) {
 // find.go and would catch a regression in either branch that the two
 // single-branch tests above could miss (e.g. one branch drifting out of
 // sync with the other after an edit to just one of them).
-func TestSamplesBySparseDenseEquivalence(t *testing.T) {
+func TestSamplesBy_sparseDenseEquivalence(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -1754,7 +1754,7 @@ func TestSamplesBySparseDenseEquivalence(t *testing.T) {
 // future change to the condition (e.g. an off-by-one on the comparison
 // operator or the division) is caught even if each branch is otherwise
 // individually correct.
-func TestSamplesBySparseBoundary(t *testing.T) {
+func TestSamplesBy_sparseBoundary(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 

--- a/intersect_test.go
+++ b/intersect_test.go
@@ -42,9 +42,9 @@ func TestContainsBy(t *testing.T) {
 	is.False(result4)
 }
 
-// TestEverySmallScan exercises the small-scan path (all subsets here are
-// <= everySmallSubset). See TestEveryLarge for the map-based path.
-func TestEverySmallScan(t *testing.T) {
+// TestEvery_smallScan exercises the small-scan path (all subsets here are
+// <= everySmallSubset). See TestEvery_large for the map-based path.
+func TestEvery_smallScan(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -62,7 +62,7 @@ func TestEverySmallScan(t *testing.T) {
 // Every dispatches on len(subset) <= everySmallSubset (8): a subset of 9
 // elements forces the everyLarge path, which the table above never
 // exercises (its subsets are all <= 2 elements).
-func TestEveryLarge(t *testing.T) {
+func TestEvery_large(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -273,10 +273,10 @@ func TestIntersectBy(t *testing.T) {
 	is.ElementsMatch(result, []int{0, 1})
 }
 
-// TestDifferenceSmallScan exercises the small-scan path (all lists here are
-// <= differenceSmallThreshold). See TestDifferenceLarge for the map-based
+// TestDifference_smallScan exercises the small-scan path (all lists here are
+// <= differenceSmallThreshold). See TestDifference_large for the map-based
 // path.
-func TestDifferenceSmallScan(t *testing.T) {
+func TestDifference_smallScan(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -303,7 +303,7 @@ func TestDifferenceSmallScan(t *testing.T) {
 // len(list2) <= differenceSmallThreshold (8): a pair of 9-element lists
 // forces the differenceLarge path, which the table above never
 // exercises (its lists are all <= 6 elements).
-func TestDifferenceLarge(t *testing.T) {
+func TestDifference_large(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -468,9 +468,9 @@ func TestUnionByErr(t *testing.T) {
 	is.Equal(6, callCount, "should stop at first error")
 }
 
-// TestWithoutSmall exercises the small-scan path (all exclude lists here are
-// <= withoutSmallExcludeThreshold). See TestWithoutLarge for the map-based path.
-func TestWithoutSmall(t *testing.T) {
+// TestWithout_small exercises the small-scan path (all exclude lists here are
+// <= withoutSmallExcludeThreshold). See TestWithout_large for the map-based path.
+func TestWithout_small(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -490,9 +490,9 @@ func TestWithoutSmall(t *testing.T) {
 	is.IsType(nonempty, allStrings, "type preserved")
 }
 
-// TestWithoutLarge exercises the map-based path (all exclude lists here
-// exceed withoutSmallExcludeThreshold). See TestWithoutSmall for the linear-scan path.
-func TestWithoutLarge(t *testing.T) {
+// TestWithout_large exercises the map-based path (all exclude lists here
+// exceed withoutSmallExcludeThreshold). See TestWithout_small for the linear-scan path.
+func TestWithout_large(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -513,10 +513,10 @@ func TestWithoutLarge(t *testing.T) {
 	is.IsType(nonempty, allStrings, "type preserved")
 }
 
-// TestWithoutBySmall exercises the small-scan path (all exclude lists
-// here are <= withoutSmallExcludeThreshold). See TestWithoutByLarge for
+// TestWithoutBy_small exercises the small-scan path (all exclude lists
+// here are <= withoutSmallExcludeThreshold). See TestWithoutBy_large for
 // the map-based path.
-func TestWithoutBySmall(t *testing.T) {
+func TestWithoutBy_small(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -546,7 +546,7 @@ func TestWithoutBySmall(t *testing.T) {
 // WithoutBy dispatches on len(exclude) <= withoutSmallExcludeThreshold (4): an
 // exclude list of 5 keys forces the withoutByLarge path, which the table
 // above never exercises (its exclude lists are all <= 3 elements).
-func TestWithoutByLarge(t *testing.T) {
+func TestWithoutBy_large(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 

--- a/it/math_test.go
+++ b/it/math_test.go
@@ -193,7 +193,7 @@ func TestMode(t *testing.T) {
 	is.Equal([]int{1, 2, 3, 4, 5, 6, 7, 8, 9}, result5)
 }
 
-func TestModeCapacityConsistency(t *testing.T) {
+func TestMode_capacityConsistency(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 

--- a/map_test.go
+++ b/map_test.go
@@ -29,8 +29,8 @@ func TestKeys(t *testing.T) {
 	is.ElementsMatch(r5, []string{"bar", "bar", "foo"})
 }
 
-// TestUniqKeysZero exercises the len(in) == 0 branch: no maps at all.
-func TestUniqKeysZero(t *testing.T) {
+// TestUniqKeys_zero exercises the len(in) == 0 branch: no maps at all.
+func TestUniqKeys_zero(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -38,8 +38,8 @@ func TestUniqKeysZero(t *testing.T) {
 	is.Empty(r1)
 }
 
-// TestUniqKeysSingle exercises the len(in) == 1 branch, which delegates to Keys().
-func TestUniqKeysSingle(t *testing.T) {
+// TestUniqKeys_single exercises the len(in) == 1 branch, which delegates to Keys().
+func TestUniqKeys_single(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -54,8 +54,8 @@ func TestUniqKeysSingle(t *testing.T) {
 	is.Empty(r3)
 }
 
-// TestUniqKeysMultiple exercises the len(in) > 1 branch, which dedups via a seen-set.
-func TestUniqKeysMultiple(t *testing.T) {
+// TestUniqKeys_multiple exercises the len(in) > 1 branch, which dedups via a seen-set.
+func TestUniqKeys_multiple(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 

--- a/math_test.go
+++ b/math_test.go
@@ -501,9 +501,9 @@ func TestMeanByErr(t *testing.T) {
 	}
 }
 
-// TestModeSmall exercises the small-scan path (all collections here are
-// <= smallModeThreshold). See TestModeLarge for the map-based path.
-func TestModeSmall(t *testing.T) {
+// TestMode_small exercises the small-scan path (all collections here are
+// <= smallModeThreshold). See TestMode_large for the map-based path.
+func TestMode_small(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -521,7 +521,7 @@ func TestModeSmall(t *testing.T) {
 // Mode dispatches on len(collection) <= smallModeThreshold (8): a collection
 // of 9+ elements forces the modeLarge path, which the table above never
 // exercises (its collections are all <= 4 elements).
-func TestModeLarge(t *testing.T) {
+func TestMode_large(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -532,7 +532,7 @@ func TestModeLarge(t *testing.T) {
 	is.Equal([]int{1, 2}, result2)
 }
 
-func TestModeCapacityConsistency(t *testing.T) {
+func TestMode_capacityConsistency(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 

--- a/slice_test.go
+++ b/slice_test.go
@@ -770,9 +770,9 @@ func TestForEachWhile(t *testing.T) {
 	is.IsIncreasing(callParams2)
 }
 
-// TestUniqSmall exercises the small-scan path (all collections here are
-// <= uniqSmallInputThreshold). See TestUniqLarge for the map-based path.
-func TestUniqSmall(t *testing.T) {
+// TestUniq_small exercises the small-scan path (all collections here are
+// <= uniqSmallInputThreshold). See TestUniq_large for the map-based path.
+func TestUniq_small(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -788,7 +788,7 @@ func TestUniqSmall(t *testing.T) {
 // Uniq dispatches on len(collection) <= uniqSmallInputThreshold (8): a
 // collection of 12 elements forces the uniqLarge path, which the table
 // above never exercises (its collections are all <= 4 elements).
-func TestUniqLarge(t *testing.T) {
+func TestUniq_large(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -804,9 +804,9 @@ func TestUniqLarge(t *testing.T) {
 	is.IsType(nonempty, allStrings, "type preserved")
 }
 
-// TestUniqBySmall exercises the small-scan path (all collections here are
-// <= uniqSmallInputThreshold). See TestUniqByLarge for the map-based path.
-func TestUniqBySmall(t *testing.T) {
+// TestUniqBy_small exercises the small-scan path (all collections here are
+// <= uniqSmallInputThreshold). See TestUniqBy_large for the map-based path.
+func TestUniqBy_small(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -826,7 +826,7 @@ func TestUniqBySmall(t *testing.T) {
 // UniqBy dispatches on len(collection) <= uniqSmallInputThreshold (8): a
 // collection of 12 elements forces the uniqByLarge path, which the table
 // above never exercises (its collections are all <= 6 elements).
-func TestUniqByLarge(t *testing.T) {
+func TestUniqBy_large(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -3118,7 +3118,7 @@ func TestSplice(t *testing.T) {
 	is.IsType(nonempty, allStrings, "type preserved")
 }
 
-func TestCutSuccess(t *testing.T) {
+func TestCut_success(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -3165,7 +3165,7 @@ func TestCutSuccess(t *testing.T) {
 	is.Equal([]string{"b"}, actualRight)
 }
 
-func TestCutFail(t *testing.T) {
+func TestCut_fail(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -3277,9 +3277,9 @@ func TestCutSuffix(t *testing.T) {
 	is.Equal([]string{"a", "a", "b"}, actualAfterS)
 }
 
-// TestTrimSmallScan exercises the small-scan path (all cutsets here are
-// <= trimSmallCutset). See TestTrimLarge for the map-based path.
-func TestTrimSmallScan(t *testing.T) {
+// TestTrim_smallScan exercises the small-scan path (all cutsets here are
+// <= trimSmallCutset). See TestTrim_large for the map-based path.
+func TestTrim_smallScan(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -3298,7 +3298,7 @@ func TestTrimSmallScan(t *testing.T) {
 // Trim dispatches on len(cutset) <= trimSmallCutset (8): a cutset of 9 unique
 // elements forces the trimLarge path, which the table above never exercises
 // (its cutsets are all <= 8).
-func TestTrimLarge(t *testing.T) {
+func TestTrim_large(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -3316,9 +3316,9 @@ func TestTrimLarge(t *testing.T) {
 	is.Equal([]string{"X", "Y"}, actual)
 }
 
-// TestTrimLeftSmallScan exercises the small-scan path (all cutsets here are
-// <= trimSmallCutset). See TestTrimLeftLarge for the map-based path.
-func TestTrimLeftSmallScan(t *testing.T) {
+// TestTrimLeft_smallScan exercises the small-scan path (all cutsets here are
+// <= trimSmallCutset). See TestTrimLeft_large for the map-based path.
+func TestTrimLeft_smallScan(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -3339,7 +3339,7 @@ func TestTrimLeftSmallScan(t *testing.T) {
 // TrimLeft dispatches on len(cutset) <= trimSmallCutset (8): a cutset of 9
 // unique elements forces the trimLeftLarge path, which the table above never
 // exercises (its cutsets are all <= 8).
-func TestTrimLeftLarge(t *testing.T) {
+func TestTrimLeft_large(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -3375,9 +3375,9 @@ func TestTrimPrefix(t *testing.T) {
 	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, actual)
 }
 
-// TestTrimRightSmallScan exercises the small-scan path (all cutsets here are
-// <= trimSmallCutset). See TestTrimRightLarge for the map-based path.
-func TestTrimRightSmallScan(t *testing.T) {
+// TestTrimRight_smallScan exercises the small-scan path (all cutsets here are
+// <= trimSmallCutset). See TestTrimRight_large for the map-based path.
+func TestTrimRight_smallScan(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
@@ -3396,7 +3396,7 @@ func TestTrimRightSmallScan(t *testing.T) {
 // TrimRight dispatches on len(cutset) <= trimSmallCutset (8): a cutset of 9
 // unique elements forces the trimRightLarge path, which the table above
 // never exercises (its cutsets are all <= 8).
-func TestTrimRightLarge(t *testing.T) {
+func TestTrimRight_large(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 


### PR DESCRIPTION
## Summary

Several helpers have more than one `Test` function to cover distinct internal code paths (small-scan vs. large/map-based dispatch, success/failure branches, etc.). These extra `Test` functions were named by concatenating a scenario suffix directly onto the base name (e.g. `TestUniqSmall`/`TestUniqLarge`, `TestCutSuccess`/`TestCutFail`, `TestFindDuplicatesBySmallScan`), which reads as if it were testing a differently named helper.

This renames them to `TestFoo_scenario`, following the convention Go itself documents for `ExampleFoo_suffix` functions: a suffix that does not name a real declared symbol starts with a lower-case letter.

Renamed (37 functions across 7 files):
- `slice.go`: `Uniq`, `UniqBy`, `Cut`, `Trim`, `TrimLeft`, `TrimRight`
- `intersect.go`: `Every`, `Difference`, `Without`, `WithoutBy`
- `map.go`: `UniqKeys`
- `find.go`: `FindUniques`, `FindUniquesBy`, `FindDuplicates`, `FindDuplicatesBy`, `SamplesBy`
- `math.go` / `it/math.go`: `Mode`
- `errors.go`: `Must` (`TestMustUserCustomHandler`)

Variant-suffix tests such as `TestMustX`, `TestAsyncX`, `TestTryX`, `TestTryOrX`, `TestDurationX`, `TestFindDuplicatesByErr` are left untouched: `X`/`Err`/`By`/etc. are already documented helper-variant suffixes (see the "Variants" section of `docs/docs/contributing.md`), not test-only scenario labels.

Also documents the naming rule in `docs/docs/contributing.md` under the Testing section.

## Test plan

Verified locally: `go build ./...`, `go vet ./...`, `go test -race ./...`, and `gofmt -l .` all pass clean.