### PR TITLE
test(it): convert to table-driven tests

### DIFF
--- a/it/find_test.go
+++ b/it/find_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestIndexOf(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -31,6 +30,7 @@ func TestIndexOf(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := IndexOf(values(tt.input...), tt.target)
 			is.Equal(tt.expected, result)
 		})
@@ -39,7 +39,6 @@ func TestIndexOf(t *testing.T) {
 
 func TestLastIndexOf(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -55,6 +54,7 @@ func TestLastIndexOf(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := LastIndexOf(values(tt.input...), tt.target)
 			is.Equal(tt.expected, result)
 		})
@@ -63,7 +63,6 @@ func TestLastIndexOf(t *testing.T) {
 
 func TestHasPrefix(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -82,6 +81,7 @@ func TestHasPrefix(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := HasPrefix(values(tt.input...), tt.prefix...)
 			is.Equal(tt.expected, result)
 		})
@@ -90,7 +90,6 @@ func TestHasPrefix(t *testing.T) {
 
 func TestHasSuffix(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -111,6 +110,7 @@ func TestHasSuffix(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := HasSuffix(values(tt.input...), tt.suffix...)
 			is.Equal(tt.expected, result)
 		})
@@ -119,7 +119,6 @@ func TestHasSuffix(t *testing.T) {
 
 func TestFind(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name           string
@@ -135,6 +134,7 @@ func TestFind(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 
 			index := 0
 			result, ok := Find(values(tt.input...), func(item string) bool {
@@ -151,7 +151,6 @@ func TestFind(t *testing.T) {
 
 func TestFindIndexOf(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name          string
@@ -168,6 +167,7 @@ func TestFindIndexOf(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 
 			index := 0
 			item, idx, ok := FindIndexOf(values(tt.input...), func(item string) bool {
@@ -185,7 +185,6 @@ func TestFindIndexOf(t *testing.T) {
 
 func TestFindLastIndexOf(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name          string
@@ -202,6 +201,7 @@ func TestFindLastIndexOf(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 
 			item, idx, ok := FindLastIndexOf(values(tt.input...), func(item string) bool {
 				return item == "b"
@@ -216,7 +216,6 @@ func TestFindLastIndexOf(t *testing.T) {
 
 func TestFindOrElse(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -231,6 +230,7 @@ func TestFindOrElse(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 
 			index := 0
 			result := FindOrElse(values(tt.input...), "x", func(item string) bool {
@@ -246,7 +246,6 @@ func TestFindOrElse(t *testing.T) {
 
 func TestFindUniques(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -263,6 +262,7 @@ func TestFindUniques(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := FindUniques(values(tt.input...))
 			is.Equal(tt.expected, slices.Collect(result))
 		})
@@ -281,7 +281,6 @@ func TestFindUniques(t *testing.T) {
 
 func TestFindUniquesBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	mod3 := func(i int) int { return i % 3 }
 
@@ -300,6 +299,7 @@ func TestFindUniquesBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := FindUniquesBy(values(tt.input...), mod3)
 			is.Equal(tt.expected, slices.Collect(result))
 		})
@@ -320,7 +320,6 @@ func TestFindUniquesBy(t *testing.T) {
 
 func TestFindDuplicates(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -336,6 +335,7 @@ func TestFindDuplicates(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := FindDuplicates(values(tt.input...))
 			is.Equal(tt.expected, slices.Collect(result))
 		})
@@ -354,7 +354,6 @@ func TestFindDuplicates(t *testing.T) {
 
 func TestFindDuplicatesBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -371,6 +370,7 @@ func TestFindDuplicatesBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := FindDuplicatesBy(values(tt.input...), tt.keyFn)
 			is.Equal(tt.expected, slices.Collect(result))
 		})
@@ -466,7 +466,6 @@ func TestMinIndex(t *testing.T) {
 
 func TestMinBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	shorter := func(item, mIn string) bool {
 		return len(item) < len(mIn)
@@ -486,6 +485,7 @@ func TestMinBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := MinBy(values(tt.input...), shorter)
 			is.Equal(tt.expected, result)
 		})
@@ -494,7 +494,6 @@ func TestMinBy(t *testing.T) {
 
 func TestMinIndexBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	shorter := func(item, mIn string) bool {
 		return len(item) < len(mIn)
@@ -515,6 +514,7 @@ func TestMinIndexBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result, index := MinIndexBy(values(tt.input...), shorter)
 			is.Equal(tt.expected, result)
 			is.Equal(tt.expectedIndex, index)
@@ -524,7 +524,6 @@ func TestMinIndexBy(t *testing.T) {
 
 func TestEarliest(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	a := time.Now()
 	b := a.Add(time.Hour)
@@ -542,6 +541,7 @@ func TestEarliest(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := Earliest(values(tt.input...))
 			is.Equal(tt.expected, result)
 		})
@@ -550,7 +550,6 @@ func TestEarliest(t *testing.T) {
 
 func TestEarliestBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	type foo struct {
 		bar time.Time
@@ -575,6 +574,7 @@ func TestEarliestBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := EarliestBy(values(tt.input...), extractBar)
 			is.Equal(tt.expected, result)
 		})
@@ -658,7 +658,6 @@ func TestMaxIndex(t *testing.T) {
 
 func TestMaxBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	longer := func(item, mAx string) bool {
 		return len(item) > len(mAx)
@@ -678,6 +677,7 @@ func TestMaxBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := MaxBy(values(tt.input...), longer)
 			is.Equal(tt.expected, result)
 		})
@@ -686,7 +686,6 @@ func TestMaxBy(t *testing.T) {
 
 func TestMaxIndexBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	longer := func(item, mAx string) bool {
 		return len(item) > len(mAx)
@@ -707,6 +706,7 @@ func TestMaxIndexBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result, index := MaxIndexBy(values(tt.input...), longer)
 			is.Equal(tt.expected, result)
 			is.Equal(tt.expectedIndex, index)
@@ -716,7 +716,6 @@ func TestMaxIndexBy(t *testing.T) {
 
 func TestLatest(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	a := time.Now()
 	b := a.Add(time.Hour)
@@ -734,6 +733,7 @@ func TestLatest(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := Latest(values(tt.input...))
 			is.Equal(tt.expected, result)
 		})
@@ -742,7 +742,6 @@ func TestLatest(t *testing.T) {
 
 func TestLatestBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	type foo struct {
 		bar time.Time
@@ -767,6 +766,7 @@ func TestLatestBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := LatestBy(values(tt.input...), extractBar)
 			is.Equal(tt.expected, result)
 		})
@@ -775,7 +775,6 @@ func TestLatestBy(t *testing.T) {
 
 func TestFirst(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name       string
@@ -791,6 +790,7 @@ func TestFirst(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result, ok := First(values(tt.input...))
 			is.Equal(tt.expected, result)
 			is.Equal(tt.expectedOk, ok)
@@ -871,7 +871,6 @@ func TestFirstOr(t *testing.T) {
 
 func TestLast(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name       string
@@ -887,6 +886,7 @@ func TestLast(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result, ok := Last(values(tt.input...))
 			is.Equal(tt.expected, result)
 			is.Equal(tt.expectedOk, ok)
@@ -967,7 +967,6 @@ func TestLastOr(t *testing.T) {
 
 func TestNth(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name        string
@@ -988,6 +987,7 @@ func TestNth(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result, err := Nth(values(tt.input...), tt.n)
 			is.Equal(tt.expected, result)
 			if tt.expectedErr == "" {
@@ -1094,7 +1094,6 @@ func TestNthOrEmpty(t *testing.T) {
 
 func TestSample(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name        string
@@ -1109,6 +1108,7 @@ func TestSample(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := Sample(values(tt.input...))
 			if tt.expectEmpty {
 				is.Empty(result)
@@ -1121,7 +1121,6 @@ func TestSample(t *testing.T) {
 
 func TestSampleBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name        string
@@ -1136,6 +1135,7 @@ func TestSampleBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := SampleBy(values(tt.input...), xrand.IntN)
 			if tt.expectEmpty {
 				is.Empty(result)
@@ -1148,7 +1148,6 @@ func TestSampleBy(t *testing.T) {
 
 func TestSamples(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name        string
@@ -1163,6 +1162,7 @@ func TestSamples(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := slices.Collect(Samples(values(tt.input...), 3))
 			if tt.expectEmpty {
 				is.Empty(result)
@@ -1185,7 +1185,6 @@ func TestSamples(t *testing.T) {
 
 func TestSamplesBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name  string
@@ -1207,6 +1206,7 @@ func TestSamplesBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := slices.Collect(SamplesBy(values(tt.input...), tt.n, tt.keyFn))
 			switch tt.mode {
 			case "elementsMatch":

--- a/it/find_test.go
+++ b/it/find_test.go
@@ -17,309 +17,509 @@ func TestIndexOf(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := IndexOf(values(0, 1, 2, 1, 2, 3), 2)
-	result2 := IndexOf(values(0, 1, 2, 1, 2, 3), 6)
+	tests := []struct {
+		name     string
+		input    []int
+		target   int
+		expected int
+	}{
+		{name: "found", input: []int{0, 1, 2, 1, 2, 3}, target: 2, expected: 2},
+		{name: "not found", input: []int{0, 1, 2, 1, 2, 3}, target: 6, expected: -1},
+	}
 
-	is.Equal(2, result1)
-	is.Equal(-1, result2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := IndexOf(values(tt.input...), tt.target)
+			is.Equal(tt.expected, result)
+		})
+	}
 }
 
 func TestLastIndexOf(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := LastIndexOf(values(0, 1, 2, 1, 2, 3), 2)
-	result2 := LastIndexOf(values(0, 1, 2, 1, 2, 3), 6)
+	tests := []struct {
+		name     string
+		input    []int
+		target   int
+		expected int
+	}{
+		{name: "found", input: []int{0, 1, 2, 1, 2, 3}, target: 2, expected: 4},
+		{name: "not found", input: []int{0, 1, 2, 1, 2, 3}, target: 6, expected: -1},
+	}
 
-	is.Equal(4, result1)
-	is.Equal(-1, result2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := LastIndexOf(values(tt.input...), tt.target)
+			is.Equal(tt.expected, result)
+		})
+	}
 }
 
 func TestHasPrefix(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.True(HasPrefix(values(1, 2, 3, 4), 1, 2, 3, 4))
-	is.True(HasPrefix(values(1, 2, 3, 4), 1, 2))
-	is.False(HasPrefix(values(1, 2, 3, 4), 42))
-	is.False(HasPrefix(values(1, 2), 1, 2, 3, 4))
-	is.True(HasPrefix(values(1, 2, 3, 4)))
+	tests := []struct {
+		name     string
+		input    []int
+		prefix   []int
+		expected bool
+	}{
+		{name: "full prefix match", input: []int{1, 2, 3, 4}, prefix: []int{1, 2, 3, 4}, expected: true},
+		{name: "partial prefix match", input: []int{1, 2, 3, 4}, prefix: []int{1, 2}, expected: true},
+		{name: "no match", input: []int{1, 2, 3, 4}, prefix: []int{42}, expected: false},
+		{name: "prefix longer than input", input: []int{1, 2}, prefix: []int{1, 2, 3, 4}, expected: false},
+		{name: "empty prefix", input: []int{1, 2, 3, 4}, prefix: []int{}, expected: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := HasPrefix(values(tt.input...), tt.prefix...)
+			is.Equal(tt.expected, result)
+		})
+	}
 }
 
 func TestHasSuffix(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.True(HasSuffix(values(1, 2, 3, 4), 1, 2, 3, 4))
-	is.True(HasSuffix(values(1, 2, 3, 4), 3, 4))
-	is.True(HasSuffix(values(1, 2, 3, 4, 5), 3, 4, 5))
-	is.False(HasSuffix(values(1, 2, 3, 4), 42))
-	is.False(HasSuffix(values(1, 2), 1, 2, 3, 4))
-	is.True(HasSuffix(values(1, 2, 3, 4)))
-	is.False(HasSuffix(values(0), 0, 0))
+	tests := []struct {
+		name     string
+		input    []int
+		suffix   []int
+		expected bool
+	}{
+		{name: "full suffix match", input: []int{1, 2, 3, 4}, suffix: []int{1, 2, 3, 4}, expected: true},
+		{name: "partial suffix match", input: []int{1, 2, 3, 4}, suffix: []int{3, 4}, expected: true},
+		{name: "partial suffix match longer input", input: []int{1, 2, 3, 4, 5}, suffix: []int{3, 4, 5}, expected: true},
+		{name: "no match", input: []int{1, 2, 3, 4}, suffix: []int{42}, expected: false},
+		{name: "suffix longer than input", input: []int{1, 2}, suffix: []int{1, 2, 3, 4}, expected: false},
+		{name: "empty suffix", input: []int{1, 2, 3, 4}, suffix: []int{}, expected: true},
+		{name: "suffix longer than single-element input", input: []int{0}, suffix: []int{0, 0}, expected: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := HasSuffix(values(tt.input...), tt.suffix...)
+			is.Equal(tt.expected, result)
+		})
+	}
 }
 
 func TestFind(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	index := 0
-	result1, ok1 := Find(values("a", "b", "c", "d"), func(item string) bool {
-		is.Equal([]string{"a", "b", "c", "d"}[index], item)
-		index++
-		return item == "b"
-	})
+	tests := []struct {
+		name           string
+		input          []string
+		expectedResult string
+		expectedOk     bool
+	}{
+		{name: "finds matching element", input: []string{"a", "b", "c", "d"}, expectedResult: "b", expectedOk: true},
+		{name: "element not found", input: []string{"foobar"}, expectedResult: "", expectedOk: false},
+	}
 
-	result2, ok2 := Find(values("foobar"), func(item string) bool {
-		is.Equal("foobar", item)
-		return item == "b"
-	})
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	is.True(ok1)
-	is.Equal("b", result1)
-	is.False(ok2)
-	is.Empty(result2)
+			index := 0
+			result, ok := Find(values(tt.input...), func(item string) bool {
+				is.Equal(tt.input[index], item)
+				index++
+				return item == "b"
+			})
+
+			is.Equal(tt.expectedOk, ok)
+			is.Equal(tt.expectedResult, result)
+		})
+	}
 }
 
 func TestFindIndexOf(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	index := 0
-	item1, index1, ok1 := FindIndexOf(values("a", "b", "c", "d", "b"), func(item string) bool {
-		is.Equal([]string{"a", "b", "c", "d", "b"}[index], item)
-		index++
-		return item == "b"
-	})
-	item2, index2, ok2 := FindIndexOf(values("foobar"), func(item string) bool {
-		is.Equal("foobar", item)
-		return item == "b"
-	})
+	tests := []struct {
+		name          string
+		input         []string
+		expectedItem  string
+		expectedIndex int
+		expectedOk    bool
+	}{
+		{name: "finds matching element", input: []string{"a", "b", "c", "d", "b"}, expectedItem: "b", expectedIndex: 1, expectedOk: true},
+		{name: "element not found", input: []string{"foobar"}, expectedItem: "", expectedIndex: -1, expectedOk: false},
+	}
 
-	is.Equal("b", item1)
-	is.True(ok1)
-	is.Equal(1, index1)
-	is.Empty(item2)
-	is.False(ok2)
-	is.Equal(-1, index2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			index := 0
+			item, idx, ok := FindIndexOf(values(tt.input...), func(item string) bool {
+				is.Equal(tt.input[index], item)
+				index++
+				return item == "b"
+			})
+
+			is.Equal(tt.expectedItem, item)
+			is.Equal(tt.expectedOk, ok)
+			is.Equal(tt.expectedIndex, idx)
+		})
+	}
 }
 
 func TestFindLastIndexOf(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	item1, index1, ok1 := FindLastIndexOf(values("a", "b", "c", "d", "b"), func(item string) bool {
-		return item == "b"
-	})
-	item2, index2, ok2 := FindLastIndexOf(values("foobar"), func(item string) bool {
-		return item == "b"
-	})
+	tests := []struct {
+		name          string
+		input         []string
+		expectedItem  string
+		expectedIndex int
+		expectedOk    bool
+	}{
+		{name: "finds last matching element", input: []string{"a", "b", "c", "d", "b"}, expectedItem: "b", expectedIndex: 4, expectedOk: true},
+		{name: "element not found", input: []string{"foobar"}, expectedItem: "", expectedIndex: -1, expectedOk: false},
+	}
 
-	is.Equal("b", item1)
-	is.True(ok1)
-	is.Equal(4, index1)
-	is.Empty(item2)
-	is.False(ok2)
-	is.Equal(-1, index2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			item, idx, ok := FindLastIndexOf(values(tt.input...), func(item string) bool {
+				return item == "b"
+			})
+
+			is.Equal(tt.expectedItem, item)
+			is.Equal(tt.expectedOk, ok)
+			is.Equal(tt.expectedIndex, idx)
+		})
+	}
 }
 
 func TestFindOrElse(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	index := 0
-	result1 := FindOrElse(values("a", "b", "c", "d"), "x", func(item string) bool {
-		is.Equal([]string{"a", "b", "c", "d"}[index], item)
-		index++
-		return item == "b"
-	})
-	result2 := FindOrElse(values("foobar"), "x", func(item string) bool {
-		is.Equal("foobar", item)
-		return item == "b"
-	})
+	tests := []struct {
+		name     string
+		input    []string
+		expected string
+	}{
+		{name: "finds matching element", input: []string{"a", "b", "c", "d"}, expected: "b"},
+		{name: "falls back when not found", input: []string{"foobar"}, expected: "x"},
+	}
 
-	is.Equal("b", result1)
-	is.Equal("x", result2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			index := 0
+			result := FindOrElse(values(tt.input...), "x", func(item string) bool {
+				is.Equal(tt.input[index], item)
+				index++
+				return item == "b"
+			})
+
+			is.Equal(tt.expected, result)
+		})
+	}
 }
 
 func TestFindUniques(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := FindUniques(values(1, 2, 3))
-	is.Equal([]int{1, 2, 3}, slices.Collect(result1))
+	tests := []struct {
+		name     string
+		input    []int
+		expected []int
+	}{
+		{name: "all unique", input: []int{1, 2, 3}, expected: []int{1, 2, 3}},
+		{name: "some duplicates", input: []int{1, 2, 2, 3, 1, 2}, expected: []int{3}},
+		{name: "all duplicates", input: []int{1, 2, 2, 1}, expected: nil},
+		{name: "empty", input: []int{}, expected: nil},
+	}
 
-	result2 := FindUniques(values(1, 2, 2, 3, 1, 2))
-	is.Equal([]int{3}, slices.Collect(result2))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := FindUniques(values(tt.input...))
+			is.Equal(tt.expected, slices.Collect(result))
+		})
+	}
 
-	result3 := FindUniques(values(1, 2, 2, 1))
-	is.Empty(slices.Collect(result3))
+	t.Run("preserves iterator type", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	result4 := FindUniques(values[int]())
-	is.Empty(slices.Collect(result4))
-
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := FindUniques(allStrings)
-	is.IsType(nonempty, allStrings, "type preserved")
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := FindUniques(allStrings)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestFindUniquesBy(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := FindUniquesBy(values(0, 1, 2), func(i int) int {
-		return i % 3
-	})
-	is.Equal([]int{0, 1, 2}, slices.Collect(result1))
+	mod3 := func(i int) int { return i % 3 }
 
-	result2 := FindUniquesBy(values(0, 1, 2, 3, 4), func(i int) int {
-		return i % 3
-	})
-	is.Equal([]int{2}, slices.Collect(result2))
+	tests := []struct {
+		name     string
+		input    []int
+		expected []int
+	}{
+		{name: "all unique keys", input: []int{0, 1, 2}, expected: []int{0, 1, 2}},
+		{name: "one unique key", input: []int{0, 1, 2, 3, 4}, expected: []int{2}},
+		{name: "no unique key", input: []int{0, 1, 2, 3, 4, 5}, expected: nil},
+		{name: "empty", input: []int{}, expected: nil},
+	}
 
-	result3 := FindUniquesBy(values(0, 1, 2, 3, 4, 5), func(i int) int {
-		return i % 3
-	})
-	is.Empty(slices.Collect(result3))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := FindUniquesBy(values(tt.input...), mod3)
+			is.Equal(tt.expected, slices.Collect(result))
+		})
+	}
 
-	result4 := FindUniquesBy(values[int](), func(i int) int {
-		return i % 3
-	})
-	is.Empty(slices.Collect(result4))
+	t.Run("preserves iterator type", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := FindUniquesBy(allStrings, func(i string) string {
-		return i
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := FindUniquesBy(allStrings, func(i string) string {
+			return i
+		})
+		is.IsType(nonempty, allStrings, "type preserved")
 	})
-	is.IsType(nonempty, allStrings, "type preserved")
 }
 
 func TestFindDuplicates(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := FindDuplicates(values(1, 2, 2, 1, 2, 3))
-	is.Equal([]int{2, 1}, slices.Collect(result1))
+	tests := []struct {
+		name     string
+		input    []int
+		expected []int
+	}{
+		{name: "has duplicates", input: []int{1, 2, 2, 1, 2, 3}, expected: []int{2, 1}},
+		{name: "no duplicates", input: []int{1, 2, 3}, expected: nil},
+		{name: "empty", input: []int{}, expected: nil},
+	}
 
-	result2 := FindDuplicates(values(1, 2, 3))
-	is.Empty(slices.Collect(result2))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := FindDuplicates(values(tt.input...))
+			is.Equal(tt.expected, slices.Collect(result))
+		})
+	}
 
-	result3 := FindDuplicates(values[int]())
-	is.Empty(slices.Collect(result3))
+	t.Run("preserves iterator type", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := FindDuplicates(allStrings)
-	is.IsType(nonempty, allStrings, "type preserved")
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := FindDuplicates(allStrings)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestFindDuplicatesBy(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := FindDuplicatesBy(values(3, 4, 5, 6, 7), func(i int) int {
-		return i % 3
-	})
-	is.Equal([]int{3, 4}, slices.Collect(result1))
+	tests := []struct {
+		name     string
+		input    []int
+		keyFn    func(int) int
+		expected []int
+	}{
+		{name: "has duplicate keys", input: []int{3, 4, 5, 6, 7}, keyFn: func(i int) int { return i % 3 }, expected: []int{3, 4}},
+		{name: "no duplicate keys", input: []int{0, 1, 2, 3, 4}, keyFn: func(i int) int { return i % 5 }, expected: nil},
+		{name: "empty", input: []int{}, keyFn: func(i int) int { return i % 3 }, expected: nil},
+	}
 
-	result2 := FindDuplicatesBy(values(0, 1, 2, 3, 4), func(i int) int {
-		return i % 5
-	})
-	is.Empty(slices.Collect(result2))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := FindDuplicatesBy(values(tt.input...), tt.keyFn)
+			is.Equal(tt.expected, slices.Collect(result))
+		})
+	}
 
-	result3 := FindDuplicatesBy(values[int](), func(i int) int {
-		return i % 3
-	})
-	is.Empty(slices.Collect(result3))
+	t.Run("preserves iterator type", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := FindDuplicatesBy(allStrings, func(i string) string {
-		return i
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := FindDuplicatesBy(allStrings, func(i string) string {
+			return i
+		})
+		is.IsType(nonempty, allStrings, "type preserved")
 	})
-	is.IsType(nonempty, allStrings, "type preserved")
 }
 
 func TestMin(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1 := Min(values(1, 2, 3))
-	result2 := Min(values(3, 2, 1))
-	result3 := Min(values(time.Second, time.Minute, time.Hour))
-	result4 := Min(values[int]())
+	t.Run("ints", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.Equal(1, result1)
-	is.Equal(1, result2)
-	is.Equal(time.Second, result3)
-	is.Zero(result4)
+		tests := []struct {
+			name     string
+			input    []int
+			expected int
+		}{
+			{name: "ascending", input: []int{1, 2, 3}, expected: 1},
+			{name: "descending", input: []int{3, 2, 1}, expected: 1},
+			{name: "empty", input: []int{}, expected: 0},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				result := Min(values(tt.input...))
+				is.Equal(tt.expected, result)
+			})
+		}
+	})
+
+	t.Run("durations", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := Min(values(time.Second, time.Minute, time.Hour))
+		is.Equal(time.Second, result)
+	})
 }
 
 func TestMinIndex(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1, index1 := MinIndex(values(1, 2, 3))
-	result2, index2 := MinIndex(values(3, 2, 1))
-	result3, index3 := MinIndex(values(time.Second, time.Minute, time.Hour))
-	result4, index4 := MinIndex(values[int]())
+	t.Run("ints", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.Equal(1, result1)
-	is.Zero(index1)
+		tests := []struct {
+			name          string
+			input         []int
+			expected      int
+			expectedIndex int
+		}{
+			{name: "ascending", input: []int{1, 2, 3}, expected: 1, expectedIndex: 0},
+			{name: "descending", input: []int{3, 2, 1}, expected: 1, expectedIndex: 2},
+			{name: "empty", input: []int{}, expected: 0, expectedIndex: -1},
+		}
 
-	is.Equal(1, result2)
-	is.Equal(2, index2)
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				result, index := MinIndex(values(tt.input...))
+				is.Equal(tt.expected, result)
+				is.Equal(tt.expectedIndex, index)
+			})
+		}
+	})
 
-	is.Equal(time.Second, result3)
-	is.Zero(index3)
+	t.Run("durations", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.Zero(result4)
-	is.Equal(-1, index4)
+		result, index := MinIndex(values(time.Second, time.Minute, time.Hour))
+		is.Equal(time.Second, result)
+		is.Zero(index)
+	})
 }
 
 func TestMinBy(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := MinBy(values("s1", "string2", "s3"), func(item, mIn string) bool {
+	shorter := func(item, mIn string) bool {
 		return len(item) < len(mIn)
-	})
-	result2 := MinBy(values("string1", "string2", "s3"), func(item, mIn string) bool {
-		return len(item) < len(mIn)
-	})
-	result3 := MinBy(values[string](), func(item, mIn string) bool {
-		return len(item) < len(mIn)
-	})
+	}
 
-	is.Equal("s1", result1)
-	is.Equal("s3", result2)
-	is.Empty(result3)
+	tests := []struct {
+		name     string
+		input    []string
+		expected string
+	}{
+		{name: "shortest first", input: []string{"s1", "string2", "s3"}, expected: "s1"},
+		{name: "shortest last", input: []string{"string1", "string2", "s3"}, expected: "s3"},
+		{name: "empty", input: []string{}, expected: ""},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := MinBy(values(tt.input...), shorter)
+			is.Equal(tt.expected, result)
+		})
+	}
 }
 
 func TestMinIndexBy(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1, index1 := MinIndexBy(values("s1", "string2", "s3"), func(item, mIn string) bool {
+	shorter := func(item, mIn string) bool {
 		return len(item) < len(mIn)
-	})
-	result2, index2 := MinIndexBy(values("string1", "string2", "s3"), func(item, mIn string) bool {
-		return len(item) < len(mIn)
-	})
-	result3, index3 := MinIndexBy(values[string](), func(item, mIn string) bool {
-		return len(item) < len(mIn)
-	})
+	}
 
-	is.Equal("s1", result1)
-	is.Zero(index1)
+	tests := []struct {
+		name          string
+		input         []string
+		expected      string
+		expectedIndex int
+	}{
+		{name: "shortest first", input: []string{"s1", "string2", "s3"}, expected: "s1", expectedIndex: 0},
+		{name: "shortest last", input: []string{"string1", "string2", "s3"}, expected: "s3", expectedIndex: 2},
+		{name: "empty", input: []string{}, expected: "", expectedIndex: -1},
+	}
 
-	is.Equal("s3", result2)
-	is.Equal(2, index2)
-
-	is.Empty(result3)
-	is.Equal(-1, index3)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, index := MinIndexBy(values(tt.input...), shorter)
+			is.Equal(tt.expected, result)
+			is.Equal(tt.expectedIndex, index)
+		})
+	}
 }
 
 func TestEarliest(t *testing.T) {
@@ -328,11 +528,24 @@ func TestEarliest(t *testing.T) {
 
 	a := time.Now()
 	b := a.Add(time.Hour)
-	result1 := Earliest(values(a, b))
-	result2 := Earliest(values[time.Time]())
 
-	is.Equal(a, result1)
-	is.Zero(result2)
+	tests := []struct {
+		name     string
+		input    []time.Time
+		expected time.Time
+	}{
+		{name: "non-empty", input: []time.Time{a, b}, expected: a},
+		{name: "empty", input: []time.Time{}, expected: time.Time{}},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := Earliest(values(tt.input...))
+			is.Equal(tt.expected, result)
+		})
+	}
 }
 
 func TestEarliestBy(t *testing.T) {
@@ -346,99 +559,159 @@ func TestEarliestBy(t *testing.T) {
 	t1 := time.Now()
 	t2 := t1.Add(time.Hour)
 	t3 := t1.Add(-time.Hour)
-	result1 := EarliestBy(values(foo{t1}, foo{t2}, foo{t3}), func(i foo) time.Time {
-		return i.bar
-	})
-	result2 := EarliestBy(values(foo{t1}), func(i foo) time.Time {
-		return i.bar
-	})
-	result3 := EarliestBy(values[foo](), func(i foo) time.Time {
-		return i.bar
-	})
+	extractBar := func(i foo) time.Time { return i.bar }
 
-	is.Equal(foo{t3}, result1)
-	is.Equal(foo{t1}, result2)
-	is.Zero(result3)
+	tests := []struct {
+		name     string
+		input    []foo
+		expected foo
+	}{
+		{name: "multiple items", input: []foo{{t1}, {t2}, {t3}}, expected: foo{t3}},
+		{name: "single item", input: []foo{{t1}}, expected: foo{t1}},
+		{name: "empty", input: []foo{}, expected: foo{}},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := EarliestBy(values(tt.input...), extractBar)
+			is.Equal(tt.expected, result)
+		})
+	}
 }
 
 func TestMax(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1 := Max(values(1, 2, 3))
-	result2 := Max(values(3, 2, 1))
-	result3 := Max(values(time.Second, time.Minute, time.Hour))
-	result4 := Max(values[int]())
+	t.Run("ints", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.Equal(3, result1)
-	is.Equal(3, result2)
-	is.Equal(time.Hour, result3)
-	is.Zero(result4)
+		tests := []struct {
+			name     string
+			input    []int
+			expected int
+		}{
+			{name: "ascending", input: []int{1, 2, 3}, expected: 3},
+			{name: "descending", input: []int{3, 2, 1}, expected: 3},
+			{name: "empty", input: []int{}, expected: 0},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				result := Max(values(tt.input...))
+				is.Equal(tt.expected, result)
+			})
+		}
+	})
+
+	t.Run("durations", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := Max(values(time.Second, time.Minute, time.Hour))
+		is.Equal(time.Hour, result)
+	})
 }
 
 func TestMaxIndex(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1, index1 := MaxIndex(values(1, 2, 3))
-	result2, index2 := MaxIndex(values(3, 2, 1))
-	result3, index3 := MaxIndex(values(time.Second, time.Minute, time.Hour))
-	result4, index4 := MaxIndex(values[int]())
+	t.Run("ints", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.Equal(3, result1)
-	is.Equal(2, index1)
+		tests := []struct {
+			name          string
+			input         []int
+			expected      int
+			expectedIndex int
+		}{
+			{name: "ascending", input: []int{1, 2, 3}, expected: 3, expectedIndex: 2},
+			{name: "descending", input: []int{3, 2, 1}, expected: 3, expectedIndex: 0},
+			{name: "empty", input: []int{}, expected: 0, expectedIndex: -1},
+		}
 
-	is.Equal(3, result2)
-	is.Zero(index2)
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				result, index := MaxIndex(values(tt.input...))
+				is.Equal(tt.expected, result)
+				is.Equal(tt.expectedIndex, index)
+			})
+		}
+	})
 
-	is.Equal(time.Hour, result3)
-	is.Equal(2, index3)
+	t.Run("durations", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.Zero(result4)
-	is.Equal(-1, index4)
+		result, index := MaxIndex(values(time.Second, time.Minute, time.Hour))
+		is.Equal(time.Hour, result)
+		is.Equal(2, index)
+	})
 }
 
 func TestMaxBy(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := MaxBy(values("s1", "string2", "s3"), func(item, mAx string) bool {
+	longer := func(item, mAx string) bool {
 		return len(item) > len(mAx)
-	})
-	result2 := MaxBy(values("string1", "string2", "s3"), func(item, mAx string) bool {
-		return len(item) > len(mAx)
-	})
-	result3 := MaxBy(values[string](), func(item, mAx string) bool {
-		return len(item) > len(mAx)
-	})
+	}
 
-	is.Equal("string2", result1)
-	is.Equal("string1", result2)
-	is.Empty(result3)
+	tests := []struct {
+		name     string
+		input    []string
+		expected string
+	}{
+		{name: "longest last", input: []string{"s1", "string2", "s3"}, expected: "string2"},
+		{name: "longest first", input: []string{"string1", "string2", "s3"}, expected: "string1"},
+		{name: "empty", input: []string{}, expected: ""},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := MaxBy(values(tt.input...), longer)
+			is.Equal(tt.expected, result)
+		})
+	}
 }
 
 func TestMaxIndexBy(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1, index1 := MaxIndexBy(values("s1", "string2", "s3"), func(item, mAx string) bool {
+	longer := func(item, mAx string) bool {
 		return len(item) > len(mAx)
-	})
-	result2, index2 := MaxIndexBy(values("string1", "string2", "s3"), func(item, mAx string) bool {
-		return len(item) > len(mAx)
-	})
-	result3, index3 := MaxIndexBy(values[string](), func(item, mAx string) bool {
-		return len(item) > len(mAx)
-	})
+	}
 
-	is.Equal("string2", result1)
-	is.Equal(1, index1)
+	tests := []struct {
+		name          string
+		input         []string
+		expected      string
+		expectedIndex int
+	}{
+		{name: "longest last", input: []string{"s1", "string2", "s3"}, expected: "string2", expectedIndex: 1},
+		{name: "longest first", input: []string{"string1", "string2", "s3"}, expected: "string1", expectedIndex: 0},
+		{name: "empty", input: []string{}, expected: "", expectedIndex: -1},
+	}
 
-	is.Equal("string1", result2)
-	is.Zero(index2)
-
-	is.Empty(result3)
-	is.Equal(-1, index3)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, index := MaxIndexBy(values(tt.input...), longer)
+			is.Equal(tt.expected, result)
+			is.Equal(tt.expectedIndex, index)
+		})
+	}
 }
 
 func TestLatest(t *testing.T) {
@@ -447,11 +720,24 @@ func TestLatest(t *testing.T) {
 
 	a := time.Now()
 	b := a.Add(time.Hour)
-	result1 := Latest(values(a, b))
-	result2 := Latest(values[time.Time]())
 
-	is.Equal(b, result1)
-	is.Zero(result2)
+	tests := []struct {
+		name     string
+		input    []time.Time
+		expected time.Time
+	}{
+		{name: "non-empty", input: []time.Time{a, b}, expected: b},
+		{name: "empty", input: []time.Time{}, expected: time.Time{}},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := Latest(values(tt.input...))
+			is.Equal(tt.expected, result)
+		})
+	}
 }
 
 func TestLatestBy(t *testing.T) {
@@ -465,122 +751,252 @@ func TestLatestBy(t *testing.T) {
 	t1 := time.Now()
 	t2 := t1.Add(time.Hour)
 	t3 := t1.Add(-time.Hour)
-	result1 := LatestBy(values(foo{t1}, foo{t2}, foo{t3}), func(i foo) time.Time {
-		return i.bar
-	})
-	result2 := LatestBy(values(foo{t1}), func(i foo) time.Time {
-		return i.bar
-	})
-	result3 := LatestBy(values[foo](), func(i foo) time.Time {
-		return i.bar
-	})
+	extractBar := func(i foo) time.Time { return i.bar }
 
-	is.Equal(foo{t2}, result1)
-	is.Equal(foo{t1}, result2)
-	is.Zero(result3)
+	tests := []struct {
+		name     string
+		input    []foo
+		expected foo
+	}{
+		{name: "multiple items", input: []foo{{t1}, {t2}, {t3}}, expected: foo{t2}},
+		{name: "single item", input: []foo{{t1}}, expected: foo{t1}},
+		{name: "empty", input: []foo{}, expected: foo{}},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := LatestBy(values(tt.input...), extractBar)
+			is.Equal(tt.expected, result)
+		})
+	}
 }
 
 func TestFirst(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1, ok1 := First(values(1, 2, 3))
-	result2, ok2 := First(values[int]())
+	tests := []struct {
+		name       string
+		input      []int
+		expected   int
+		expectedOk bool
+	}{
+		{name: "non-empty", input: []int{1, 2, 3}, expected: 1, expectedOk: true},
+		{name: "empty", input: []int{}, expected: 0, expectedOk: false},
+	}
 
-	is.Equal(1, result1)
-	is.True(ok1)
-	is.Zero(result2)
-	is.False(ok2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, ok := First(values(tt.input...))
+			is.Equal(tt.expected, result)
+			is.Equal(tt.expectedOk, ok)
+		})
+	}
 }
 
 func TestFirstOrEmpty(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1 := FirstOrEmpty(values(1, 2, 3))
-	result2 := FirstOrEmpty(values[int]())
-	result3 := FirstOrEmpty(values[string]())
+	t.Run("ints", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.Equal(1, result1)
-	is.Zero(result2)
-	is.Empty(result3)
+		tests := []struct {
+			name     string
+			input    []int
+			expected int
+		}{
+			{name: "non-empty", input: []int{1, 2, 3}, expected: 1},
+			{name: "empty", input: []int{}, expected: 0},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				result := FirstOrEmpty(values(tt.input...))
+				is.Equal(tt.expected, result)
+			})
+		}
+	})
+
+	t.Run("strings", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := FirstOrEmpty(values[string]())
+		is.Empty(result)
+	})
 }
 
 func TestFirstOr(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1 := FirstOr(values(1, 2, 3), 63)
-	result2 := FirstOr(values[int](), 23)
-	result3 := FirstOr(values[string](), "test")
+	t.Run("ints", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.Equal(1, result1)
-	is.Equal(23, result2)
-	is.Equal("test", result3)
+		tests := []struct {
+			name     string
+			input    []int
+			fallback int
+			expected int
+		}{
+			{name: "non-empty", input: []int{1, 2, 3}, fallback: 63, expected: 1},
+			{name: "empty", input: []int{}, fallback: 23, expected: 23},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				result := FirstOr(values(tt.input...), tt.fallback)
+				is.Equal(tt.expected, result)
+			})
+		}
+	})
+
+	t.Run("strings", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := FirstOr(values[string](), "test")
+		is.Equal("test", result)
+	})
 }
 
 func TestLast(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1, ok1 := Last(values(1, 2, 3))
-	result2, ok2 := Last(values[int]())
+	tests := []struct {
+		name       string
+		input      []int
+		expected   int
+		expectedOk bool
+	}{
+		{name: "non-empty", input: []int{1, 2, 3}, expected: 3, expectedOk: true},
+		{name: "empty", input: []int{}, expected: 0, expectedOk: false},
+	}
 
-	is.Equal(3, result1)
-	is.True(ok1)
-	is.Zero(result2)
-	is.False(ok2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, ok := Last(values(tt.input...))
+			is.Equal(tt.expected, result)
+			is.Equal(tt.expectedOk, ok)
+		})
+	}
 }
 
 func TestLastOrEmpty(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1 := LastOrEmpty(values(1, 2, 3))
-	result2 := LastOrEmpty(values[int]())
-	result3 := LastOrEmpty(values[string]())
+	t.Run("ints", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.Equal(3, result1)
-	is.Zero(result2)
-	is.Empty(result3)
+		tests := []struct {
+			name     string
+			input    []int
+			expected int
+		}{
+			{name: "non-empty", input: []int{1, 2, 3}, expected: 3},
+			{name: "empty", input: []int{}, expected: 0},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				result := LastOrEmpty(values(tt.input...))
+				is.Equal(tt.expected, result)
+			})
+		}
+	})
+
+	t.Run("strings", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := LastOrEmpty(values[string]())
+		is.Empty(result)
+	})
 }
 
 func TestLastOr(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1 := LastOr(values(1, 2, 3), 63)
-	result2 := LastOr(values[int](), 23)
-	result3 := LastOr(values[string](), "test")
+	t.Run("ints", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.Equal(3, result1)
-	is.Equal(23, result2)
-	is.Equal("test", result3)
+		tests := []struct {
+			name     string
+			input    []int
+			fallback int
+			expected int
+		}{
+			{name: "non-empty", input: []int{1, 2, 3}, fallback: 63, expected: 3},
+			{name: "empty", input: []int{}, fallback: 23, expected: 23},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				result := LastOr(values(tt.input...), tt.fallback)
+				is.Equal(tt.expected, result)
+			})
+		}
+	})
+
+	t.Run("strings", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := LastOr(values[string](), "test")
+		is.Equal("test", result)
+	})
 }
 
 func TestNth(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1, err1 := Nth(values(0, 1, 2, 3), 2)
-	result2, err2 := Nth(values(0, 1, 2, 3), -2)
-	result3, err3 := Nth(values(0, 1, 2, 3), 42)
-	result4, err4 := Nth(values[int](), 0)
-	result5, err5 := Nth(values(42), 0)
-	result6, err6 := Nth(values(42), -1)
+	tests := []struct {
+		name        string
+		input       []int
+		n           int
+		expected    int
+		expectedErr string
+	}{
+		{name: "positive index in range", input: []int{0, 1, 2, 3}, n: 2, expected: 2},
+		{name: "negative index", input: []int{0, 1, 2, 3}, n: -2, expected: 0, expectedErr: "nth: -2 out of bounds"},
+		{name: "index out of range", input: []int{0, 1, 2, 3}, n: 42, expected: 0, expectedErr: "nth: 42 out of bounds"},
+		{name: "empty collection", input: []int{}, n: 0, expected: 0, expectedErr: "nth: 0 out of bounds"},
+		{name: "single element in range", input: []int{42}, n: 0, expected: 42},
+		{name: "single element out of range", input: []int{42}, n: -1, expected: 0, expectedErr: "nth: -1 out of bounds"},
+	}
 
-	is.Equal(2, result1)
-	is.NoError(err1)
-	is.Zero(result2)
-	is.EqualError(err2, "nth: -2 out of bounds")
-	is.Zero(result3)
-	is.EqualError(err3, "nth: 42 out of bounds")
-	is.Zero(result4)
-	is.EqualError(err4, "nth: 0 out of bounds")
-	is.Equal(42, result5)
-	is.NoError(err5)
-	is.Zero(result6)
-	is.EqualError(err6, "nth: -1 out of bounds")
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := Nth(values(tt.input...), tt.n)
+			is.Equal(tt.expected, result)
+			if tt.expectedErr == "" {
+				is.NoError(err)
+			} else {
+				is.EqualError(err, tt.expectedErr)
+			}
+		})
+	}
 }
 
 func TestNthOr(t *testing.T) {
@@ -680,65 +1096,146 @@ func TestSample(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Sample(values("a", "b", "c"))
-	result2 := Sample(values[string]())
+	tests := []struct {
+		name        string
+		input       []string
+		expectEmpty bool
+	}{
+		{name: "non-empty", input: []string{"a", "b", "c"}, expectEmpty: false},
+		{name: "empty", input: []string{}, expectEmpty: true},
+	}
 
-	is.True(Contains(values("a", "b", "c"), result1))
-	is.Empty(result2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := Sample(values(tt.input...))
+			if tt.expectEmpty {
+				is.Empty(result)
+			} else {
+				is.True(Contains(values(tt.input...), result))
+			}
+		})
+	}
 }
 
 func TestSampleBy(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := SampleBy(values("a", "b", "c"), xrand.IntN)
-	result2 := SampleBy(values[string](), xrand.IntN)
+	tests := []struct {
+		name        string
+		input       []string
+		expectEmpty bool
+	}{
+		{name: "non-empty", input: []string{"a", "b", "c"}, expectEmpty: false},
+		{name: "empty", input: []string{}, expectEmpty: true},
+	}
 
-	is.True(Contains(values("a", "b", "c"), result1))
-	is.Empty(result2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := SampleBy(values(tt.input...), xrand.IntN)
+			if tt.expectEmpty {
+				is.Empty(result)
+			} else {
+				is.True(Contains(values(tt.input...), result))
+			}
+		})
+	}
 }
 
 func TestSamples(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Samples(values("a", "b", "c"), 3)
-	result2 := Samples(values[string](), 3)
+	tests := []struct {
+		name        string
+		input       []string
+		expectEmpty bool
+	}{
+		{name: "non-empty", input: []string{"a", "b", "c"}, expectEmpty: false},
+		{name: "empty", input: []string{}, expectEmpty: true},
+	}
 
-	is.ElementsMatch(slices.Collect(result1), []string{"a", "b", "c"})
-	is.Empty(slices.Collect(result2))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := slices.Collect(Samples(values(tt.input...), 3))
+			if tt.expectEmpty {
+				is.Empty(result)
+			} else {
+				is.ElementsMatch(result, tt.input)
+			}
+		})
+	}
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Samples(allStrings, 2)
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("preserves iterator type", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Samples(allStrings, 2)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestSamplesBy(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := SamplesBy(values("a", "b", "c"), 3, xrand.IntN)
-	result2 := SamplesBy(values[string](), 3, xrand.IntN)
-	result3 := SamplesBy(values("a", "b", "c"), 3, func(n int) int { return n - 1 })
-	result4 := SamplesBy(values("a", "b", "c"), 3, func(int) int { return 0 })
-	result5 := SamplesBy(values("a", "b", "c"), 0, func(int) int { return 1 })
-	result6 := SamplesBy(values("a", "b", "c"), -1, nil)
+	tests := []struct {
+		name  string
+		input []string
+		n     int
+		keyFn func(int) int
+		mode  string // "elementsMatch", "equal", "empty"
+		exact []string
+	}{
+		{name: "random selection", input: []string{"a", "b", "c"}, n: 3, keyFn: xrand.IntN, mode: "elementsMatch"},
+		{name: "empty input", input: []string{}, n: 3, keyFn: xrand.IntN, mode: "empty"},
+		{name: "reverse order key", input: []string{"a", "b", "c"}, n: 3, keyFn: func(n int) int { return n - 1 }, mode: "equal", exact: []string{"c", "b", "a"}},
+		{name: "constant zero key", input: []string{"a", "b", "c"}, n: 3, keyFn: func(int) int { return 0 }, mode: "equal", exact: []string{"a", "c", "b"}},
+		{name: "zero count", input: []string{"a", "b", "c"}, n: 0, keyFn: func(int) int { return 1 }, mode: "empty"},
+		{name: "negative count with nil keyFn", input: []string{"a", "b", "c"}, n: -1, keyFn: nil, mode: "empty"},
+	}
 
-	// index out of range [1] with length 1
-	is.Panics(func() {
-		SamplesBy(values("a", "b", "c"), 3, func(int) int { return 1 })
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := slices.Collect(SamplesBy(values(tt.input...), tt.n, tt.keyFn))
+			switch tt.mode {
+			case "elementsMatch":
+				is.ElementsMatch(result, tt.input)
+			case "equal":
+				is.Equal(tt.exact, result)
+			case "empty":
+				is.Empty(result)
+			}
+		})
+	}
+
+	t.Run("panics on out of range key", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		// index out of range [1] with length 1
+		is.Panics(func() {
+			SamplesBy(values("a", "b", "c"), 3, func(int) int { return 1 })
+		})
 	})
 
-	is.ElementsMatch(slices.Collect(result1), []string{"a", "b", "c"})
-	is.Empty(slices.Collect(result2))
-	is.Equal([]string{"c", "b", "a"}, slices.Collect(result3))
-	is.Equal([]string{"a", "c", "b"}, slices.Collect(result4))
-	is.Empty(slices.Collect(result5))
-	is.Empty(slices.Collect(result6))
+	t.Run("preserves iterator type", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := SamplesBy(allStrings, 2, xrand.IntN)
-	is.IsType(nonempty, allStrings, "type preserved")
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := SamplesBy(allStrings, 2, xrand.IntN)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }

--- a/it/find_test.go
+++ b/it/find_test.go
@@ -394,7 +394,6 @@ func TestMin(t *testing.T) {
 
 	t.Run("ints", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name     string
@@ -431,7 +430,6 @@ func TestMinIndex(t *testing.T) {
 
 	t.Run("ints", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name          string
@@ -588,7 +586,6 @@ func TestMax(t *testing.T) {
 
 	t.Run("ints", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name     string
@@ -625,7 +622,6 @@ func TestMaxIndex(t *testing.T) {
 
 	t.Run("ints", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name          string

--- a/it/find_test.go
+++ b/it/find_test.go
@@ -410,6 +410,7 @@ func TestMin(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 				result := Min(values(tt.input...))
 				is.Equal(tt.expected, result)
 			})
@@ -447,6 +448,7 @@ func TestMinIndex(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 				result, index := MinIndex(values(tt.input...))
 				is.Equal(tt.expected, result)
 				is.Equal(tt.expectedIndex, index)
@@ -602,6 +604,7 @@ func TestMax(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 				result := Max(values(tt.input...))
 				is.Equal(tt.expected, result)
 			})
@@ -639,6 +642,7 @@ func TestMaxIndex(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 				result, index := MaxIndex(values(tt.input...))
 				is.Equal(tt.expected, result)
 				is.Equal(tt.expectedIndex, index)

--- a/it/intersect_test.go
+++ b/it/intersect_test.go
@@ -15,11 +15,23 @@ func TestContains(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Contains(values(0, 1, 2, 3, 4, 5), 5)
-	result2 := Contains(values(0, 1, 2, 3, 4, 5), 6)
+	tests := []struct {
+		name     string
+		seq      iter.Seq[int]
+		target   int
+		expected bool
+	}{
+		{name: "found", seq: values(0, 1, 2, 3, 4, 5), target: 5, expected: true},
+		{name: "not found", seq: values(0, 1, 2, 3, 4, 5), target: 6, expected: false},
+	}
 
-	is.True(result1)
-	is.False(result2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, Contains(tt.seq, tt.target))
+		})
+	}
 }
 
 func TestContainsBy(t *testing.T) {
@@ -31,182 +43,243 @@ func TestContainsBy(t *testing.T) {
 		B string
 	}
 
-	a1 := values(a{A: 1, B: "1"}, a{A: 2, B: "2"}, a{A: 3, B: "3"})
-	result1 := ContainsBy(a1, func(t a) bool { return t.A == 1 && t.B == "2" })
-	result2 := ContainsBy(a1, func(t a) bool { return t.A == 2 && t.B == "2" })
+	t.Run("struct type", func(t *testing.T) {
+		t.Parallel()
 
-	a2 := values("aaa", "bbb", "ccc")
-	result3 := ContainsBy(a2, func(t string) bool { return t == "ccc" })
-	result4 := ContainsBy(a2, func(t string) bool { return t == "ddd" })
+		a1 := values(a{A: 1, B: "1"}, a{A: 2, B: "2"}, a{A: 3, B: "3"})
 
-	is.False(result1)
-	is.True(result2)
-	is.True(result3)
-	is.False(result4)
+		tests := []struct {
+			name      string
+			predicate func(a) bool
+			expected  bool
+		}{
+			{name: "no match", predicate: func(t a) bool { return t.A == 1 && t.B == "2" }, expected: false},
+			{name: "match", predicate: func(t a) bool { return t.A == 2 && t.B == "2" }, expected: true},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				is.Equal(tt.expected, ContainsBy(a1, tt.predicate))
+			})
+		}
+	})
+
+	t.Run("string type", func(t *testing.T) {
+		t.Parallel()
+
+		a2 := values("aaa", "bbb", "ccc")
+
+		tests := []struct {
+			name      string
+			predicate func(string) bool
+			expected  bool
+		}{
+			{name: "match", predicate: func(t string) bool { return t == "ccc" }, expected: true},
+			{name: "no match", predicate: func(t string) bool { return t == "ddd" }, expected: false},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				is.Equal(tt.expected, ContainsBy(a2, tt.predicate))
+			})
+		}
+	})
 }
 
 func TestEvery(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Every(values(0, 1, 2, 3, 4, 5), 0, 2)
-	result2 := Every(values(0, 1, 2, 3, 4, 5), 0, 6)
-	result3 := Every(values(0, 1, 2, 3, 4, 5), -1, 6)
-	result4 := Every(values(0, 1, 2, 3, 4, 5))
+	tests := []struct {
+		name     string
+		args     []int
+		expected bool
+	}{
+		{name: "both present", args: []int{0, 2}, expected: true},
+		{name: "one present one missing", args: []int{0, 6}, expected: false},
+		{name: "both missing", args: []int{-1, 6}, expected: false},
+		{name: "no args", args: nil, expected: true},
+	}
 
-	is.True(result1)
-	is.False(result2)
-	is.False(result3)
-	is.True(result4)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, Every(values(0, 1, 2, 3, 4, 5), tt.args...))
+		})
+	}
 }
 
 func TestEveryBy(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := EveryBy(values(1, 2, 3, 4), func(x int) bool {
-		return x < 5
-	})
+	tests := []struct {
+		name      string
+		seq       iter.Seq[int]
+		predicate func(int) bool
+		expected  bool
+	}{
+		{name: "all match", seq: values(1, 2, 3, 4), predicate: func(x int) bool { return x < 5 }, expected: true},
+		{name: "some match", seq: values(1, 2, 3, 4), predicate: func(x int) bool { return x < 3 }, expected: false},
+		{name: "none match", seq: values(1, 2, 3, 4), predicate: func(x int) bool { return x < 0 }, expected: false},
+		{name: "empty collection", seq: values[int](), predicate: func(x int) bool { return x < 5 }, expected: true},
+	}
 
-	is.True(result1)
-
-	result2 := EveryBy(values(1, 2, 3, 4), func(x int) bool {
-		return x < 3
-	})
-
-	is.False(result2)
-
-	result3 := EveryBy(values(1, 2, 3, 4), func(x int) bool {
-		return x < 0
-	})
-
-	is.False(result3)
-
-	result4 := EveryBy(values[int](), func(x int) bool {
-		return x < 5
-	})
-
-	is.True(result4)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, EveryBy(tt.seq, tt.predicate))
+		})
+	}
 }
 
 func TestSome(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Some(values(0, 1, 2, 3, 4, 5), 0, 2)
-	result2 := Some(values(0, 1, 2, 3, 4, 5), 0, 6)
-	result3 := Some(values(0, 1, 2, 3, 4, 5), -1, 6)
-	result4 := Some(values(0, 1, 2, 3, 4, 5))
+	tests := []struct {
+		name     string
+		args     []int
+		expected bool
+	}{
+		{name: "both present", args: []int{0, 2}, expected: true},
+		{name: "one present one missing", args: []int{0, 6}, expected: true},
+		{name: "both missing", args: []int{-1, 6}, expected: false},
+		{name: "no args", args: nil, expected: false},
+	}
 
-	is.True(result1)
-	is.True(result2)
-	is.False(result3)
-	is.False(result4)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, Some(values(0, 1, 2, 3, 4, 5), tt.args...))
+		})
+	}
 }
 
 func TestSomeBy(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := SomeBy(values(1, 2, 3, 4), func(x int) bool {
-		return x < 5
-	})
+	tests := []struct {
+		name      string
+		seq       iter.Seq[int]
+		predicate func(int) bool
+		expected  bool
+	}{
+		{name: "some match", seq: values(1, 2, 3, 4), predicate: func(x int) bool { return x < 5 }, expected: true},
+		{name: "one match", seq: values(1, 2, 3, 4), predicate: func(x int) bool { return x < 3 }, expected: true},
+		{name: "none match", seq: values(1, 2, 3, 4), predicate: func(x int) bool { return x < 0 }, expected: false},
+		{name: "empty collection", seq: values[int](), predicate: func(x int) bool { return x < 5 }, expected: false},
+	}
 
-	is.True(result1)
-
-	result2 := SomeBy(values(1, 2, 3, 4), func(x int) bool {
-		return x < 3
-	})
-
-	is.True(result2)
-
-	result3 := SomeBy(values(1, 2, 3, 4), func(x int) bool {
-		return x < 0
-	})
-
-	is.False(result3)
-
-	result4 := SomeBy(values[int](), func(x int) bool {
-		return x < 5
-	})
-
-	is.False(result4)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, SomeBy(tt.seq, tt.predicate))
+		})
+	}
 }
 
 func TestNone(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := None(values(0, 1, 2, 3, 4, 5), 0, 2)
-	result2 := None(values(0, 1, 2, 3, 4, 5), 0, 6)
-	result3 := None(values(0, 1, 2, 3, 4, 5), -1, 6)
-	result4 := None(values(0, 1, 2, 3, 4, 5))
+	tests := []struct {
+		name     string
+		args     []int
+		expected bool
+	}{
+		{name: "both present", args: []int{0, 2}, expected: false},
+		{name: "one present one missing", args: []int{0, 6}, expected: false},
+		{name: "both missing", args: []int{-1, 6}, expected: true},
+		{name: "no args", args: nil, expected: true},
+	}
 
-	is.False(result1)
-	is.False(result2)
-	is.True(result3)
-	is.True(result4)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, None(values(0, 1, 2, 3, 4, 5), tt.args...))
+		})
+	}
 }
 
 func TestNoneBy(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := NoneBy(values(1, 2, 3, 4), func(x int) bool {
-		return x < 5
-	})
+	tests := []struct {
+		name      string
+		seq       iter.Seq[int]
+		predicate func(int) bool
+		expected  bool
+	}{
+		{name: "some match", seq: values(1, 2, 3, 4), predicate: func(x int) bool { return x < 5 }, expected: false},
+		{name: "one match", seq: values(1, 2, 3, 4), predicate: func(x int) bool { return x < 3 }, expected: false},
+		{name: "none match", seq: values(1, 2, 3, 4), predicate: func(x int) bool { return x < 0 }, expected: true},
+		{name: "empty collection", seq: values[int](), predicate: func(x int) bool { return x < 5 }, expected: true},
+	}
 
-	is.False(result1)
-
-	result2 := NoneBy(values(1, 2, 3, 4), func(x int) bool {
-		return x < 3
-	})
-
-	is.False(result2)
-
-	result3 := NoneBy(values(1, 2, 3, 4), func(x int) bool {
-		return x < 0
-	})
-
-	is.True(result3)
-
-	result4 := NoneBy(values[int](), func(x int) bool {
-		return x < 5
-	})
-
-	is.True(result4)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, NoneBy(tt.seq, tt.predicate))
+		})
+	}
 }
 
 func TestIntersect(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Intersect([]iter.Seq[int]{}...)
-	result2 := Intersect(values(0, 1, 2, 3, 4, 5))
-	result3 := Intersect(values(0, 1, 2, 3, 4, 5), values(0, 6))
-	result4 := Intersect(values(0, 1, 2, 3, 4, 5), values(-1, 6))
-	result5 := Intersect(values(0, 6, 0), values(0, 1, 2, 3, 4, 5))
-	result6 := Intersect(values(0, 1, 2, 3, 4, 5), values(0, 6, 0))
-	result7 := Intersect(values(0, 1, 2), values(1, 2, 3), values(2, 3, 4))
-	result8 := Intersect(values(0, 1, 2), values(1, 2, 3), values(2, 3, 4), values(3, 4, 5))
-	result9 := Intersect(values(0, 1, 2), values(0, 1, 2), values(1, 2, 3), values(2, 3, 4), values(3, 4, 5))
-	resultA := Intersect(values(0, 1, 1))
+	tests := []struct {
+		name     string
+		inputs   []iter.Seq[int]
+		expected []int
+	}{
+		{name: "no sequences", inputs: []iter.Seq[int]{}, expected: nil},
+		{name: "single sequence", inputs: []iter.Seq[int]{values(0, 1, 2, 3, 4, 5)}, expected: []int{0, 1, 2, 3, 4, 5}},
+		{name: "one common element", inputs: []iter.Seq[int]{values(0, 1, 2, 3, 4, 5), values(0, 6)}, expected: []int{0}},
+		{name: "no common element", inputs: []iter.Seq[int]{values(0, 1, 2, 3, 4, 5), values(-1, 6)}, expected: nil},
+		{name: "duplicates in first sequence", inputs: []iter.Seq[int]{values(0, 6, 0), values(0, 1, 2, 3, 4, 5)}, expected: []int{0}},
+		{name: "duplicates in second sequence", inputs: []iter.Seq[int]{values(0, 1, 2, 3, 4, 5), values(0, 6, 0)}, expected: []int{0}},
+		{name: "three sequences", inputs: []iter.Seq[int]{values(0, 1, 2), values(1, 2, 3), values(2, 3, 4)}, expected: []int{2}},
+		{name: "four sequences no overlap", inputs: []iter.Seq[int]{values(0, 1, 2), values(1, 2, 3), values(2, 3, 4), values(3, 4, 5)}, expected: nil},
+		{name: "five sequences with duplicate no overlap", inputs: []iter.Seq[int]{values(0, 1, 2), values(0, 1, 2), values(1, 2, 3), values(2, 3, 4), values(3, 4, 5)}, expected: nil},
+		{name: "duplicates within single sequence", inputs: []iter.Seq[int]{values(0, 1, 1)}, expected: []int{0, 1}},
+	}
 
-	is.Empty(slices.Collect(result1))
-	is.Equal([]int{0, 1, 2, 3, 4, 5}, slices.Collect(result2))
-	is.Equal([]int{0}, slices.Collect(result3))
-	is.Empty(slices.Collect(result4))
-	is.Equal([]int{0}, slices.Collect(result5))
-	is.Equal([]int{0}, slices.Collect(result6))
-	is.Equal([]int{2}, slices.Collect(result7))
-	is.Empty(slices.Collect(result8))
-	is.Empty(slices.Collect(result9))
-	is.Equal([]int{0, 1}, slices.Collect(resultA))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := slices.Collect(Intersect(tt.inputs...))
+			if tt.expected == nil {
+				is.Empty(result)
+			} else {
+				is.Equal(tt.expected, result)
+			}
+		})
+	}
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Intersect(allStrings, allStrings)
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Intersect(allStrings, allStrings)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestIntersectBy(t *testing.T) {
@@ -215,87 +288,132 @@ func TestIntersectBy(t *testing.T) {
 
 	transform := strconv.Itoa
 
-	result1 := IntersectBy(transform, []iter.Seq[int]{}...)
-	result2 := IntersectBy(transform, values(0, 1, 2, 3, 4, 5))
-	result3 := IntersectBy(transform, values(0, 1, 2, 3, 4, 5), values(0, 6))
-	result4 := IntersectBy(transform, values(0, 1, 2, 3, 4, 5), values(-1, 6))
-	result5 := IntersectBy(transform, values(0, 6, 0), values(0, 1, 2, 3, 4, 5))
-	result6 := IntersectBy(transform, values(0, 1, 2, 3, 4, 5), values(0, 6, 0))
-	result7 := IntersectBy(transform, values(0, 1, 2), values(1, 2, 3), values(2, 3, 4))
-	result8 := IntersectBy(transform, values(0, 1, 2), values(1, 2, 3), values(2, 3, 4), values(3, 4, 5))
-	result9 := IntersectBy(transform, values(0, 1, 2), values(0, 1, 2), values(1, 2, 3), values(2, 3, 4), values(3, 4, 5))
-	resultA := IntersectBy(transform, values(0, 1, 1))
+	tests := []struct {
+		name     string
+		inputs   []iter.Seq[int]
+		expected []int
+	}{
+		{name: "no sequences", inputs: []iter.Seq[int]{}, expected: nil},
+		{name: "single sequence", inputs: []iter.Seq[int]{values(0, 1, 2, 3, 4, 5)}, expected: []int{0, 1, 2, 3, 4, 5}},
+		{name: "one common element", inputs: []iter.Seq[int]{values(0, 1, 2, 3, 4, 5), values(0, 6)}, expected: []int{0}},
+		{name: "no common element", inputs: []iter.Seq[int]{values(0, 1, 2, 3, 4, 5), values(-1, 6)}, expected: nil},
+		{name: "duplicates in first sequence", inputs: []iter.Seq[int]{values(0, 6, 0), values(0, 1, 2, 3, 4, 5)}, expected: []int{0}},
+		{name: "duplicates in second sequence", inputs: []iter.Seq[int]{values(0, 1, 2, 3, 4, 5), values(0, 6, 0)}, expected: []int{0}},
+		{name: "three sequences", inputs: []iter.Seq[int]{values(0, 1, 2), values(1, 2, 3), values(2, 3, 4)}, expected: []int{2}},
+		{name: "four sequences no overlap", inputs: []iter.Seq[int]{values(0, 1, 2), values(1, 2, 3), values(2, 3, 4), values(3, 4, 5)}, expected: nil},
+		{name: "five sequences with duplicate no overlap", inputs: []iter.Seq[int]{values(0, 1, 2), values(0, 1, 2), values(1, 2, 3), values(2, 3, 4), values(3, 4, 5)}, expected: nil},
+		{name: "duplicates within single sequence", inputs: []iter.Seq[int]{values(0, 1, 1)}, expected: []int{0, 1}},
+	}
 
-	is.Empty(slices.Collect(result1))
-	is.Equal([]int{0, 1, 2, 3, 4, 5}, slices.Collect(result2))
-	is.Equal([]int{0}, slices.Collect(result3))
-	is.Empty(slices.Collect(result4))
-	is.Equal([]int{0}, slices.Collect(result5))
-	is.Equal([]int{0}, slices.Collect(result6))
-	is.Equal([]int{2}, slices.Collect(result7))
-	is.Empty(slices.Collect(result8))
-	is.Empty(slices.Collect(result9))
-	is.Equal([]int{0, 1}, slices.Collect(resultA))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := slices.Collect(IntersectBy(transform, tt.inputs...))
+			if tt.expected == nil {
+				is.Empty(result)
+			} else {
+				is.Equal(tt.expected, result)
+			}
+		})
+	}
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := IntersectBy(func(s string) string { return s + s }, allStrings, allStrings)
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := IntersectBy(func(s string) string { return s + s }, allStrings, allStrings)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestUnion(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Union(values(0, 1, 2, 3, 4, 5), values(0, 2, 10))
-	result2 := Union(values(0, 1, 2, 3, 4, 5), values(6, 7))
-	result3 := Union(values(0, 1, 2, 3, 4, 5), values[int]())
-	result4 := Union(values(0, 1, 2), values(0, 1, 2, 3, 3))
-	result5 := Union(values(0, 1, 2), values(0, 1, 2))
-	result6 := Union(values[int](), values[int]())
-	is.Equal([]int{0, 1, 2, 3, 4, 5, 10}, slices.Collect(result1))
-	is.Equal([]int{0, 1, 2, 3, 4, 5, 6, 7}, slices.Collect(result2))
-	is.Equal([]int{0, 1, 2, 3, 4, 5}, slices.Collect(result3))
-	is.Equal([]int{0, 1, 2, 3}, slices.Collect(result4))
-	is.Equal([]int{0, 1, 2}, slices.Collect(result5))
-	is.Empty(slices.Collect(result6))
+	tests := []struct {
+		name     string
+		inputs   []iter.Seq[int]
+		expected []int
+	}{
+		{name: "two sequences with new elements", inputs: []iter.Seq[int]{values(0, 1, 2, 3, 4, 5), values(0, 2, 10)}, expected: []int{0, 1, 2, 3, 4, 5, 10}},
+		{name: "two disjoint sequences", inputs: []iter.Seq[int]{values(0, 1, 2, 3, 4, 5), values(6, 7)}, expected: []int{0, 1, 2, 3, 4, 5, 6, 7}},
+		{name: "second sequence empty", inputs: []iter.Seq[int]{values(0, 1, 2, 3, 4, 5), values[int]()}, expected: []int{0, 1, 2, 3, 4, 5}},
+		{name: "second sequence with duplicates", inputs: []iter.Seq[int]{values(0, 1, 2), values(0, 1, 2, 3, 3)}, expected: []int{0, 1, 2, 3}},
+		{name: "two identical sequences", inputs: []iter.Seq[int]{values(0, 1, 2), values(0, 1, 2)}, expected: []int{0, 1, 2}},
+		{name: "two empty sequences", inputs: []iter.Seq[int]{values[int](), values[int]()}, expected: nil},
+		{name: "three sequences with new elements", inputs: []iter.Seq[int]{values(0, 1, 2, 3, 4, 5), values(0, 2, 10), values(0, 1, 11)}, expected: []int{0, 1, 2, 3, 4, 5, 10, 11}},
+		{name: "three disjoint sequences", inputs: []iter.Seq[int]{values(0, 1, 2, 3, 4, 5), values(6, 7), values(8, 9)}, expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}},
+		{name: "three sequences two empty", inputs: []iter.Seq[int]{values(0, 1, 2, 3, 4, 5), values[int](), values[int]()}, expected: []int{0, 1, 2, 3, 4, 5}},
+		{name: "three identical sequences", inputs: []iter.Seq[int]{values(0, 1, 2), values(0, 1, 2), values(0, 1, 2)}, expected: []int{0, 1, 2}},
+		{name: "three empty sequences", inputs: []iter.Seq[int]{values[int](), values[int](), values[int]()}, expected: nil},
+	}
 
-	result11 := Union(values(0, 1, 2, 3, 4, 5), values(0, 2, 10), values(0, 1, 11))
-	result12 := Union(values(0, 1, 2, 3, 4, 5), values(6, 7), values(8, 9))
-	result13 := Union(values(0, 1, 2, 3, 4, 5), values[int](), values[int]())
-	result14 := Union(values(0, 1, 2), values(0, 1, 2), values(0, 1, 2))
-	result15 := Union(values[int](), values[int](), values[int]())
-	is.Equal([]int{0, 1, 2, 3, 4, 5, 10, 11}, slices.Collect(result11))
-	is.Equal([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, slices.Collect(result12))
-	is.Equal([]int{0, 1, 2, 3, 4, 5}, slices.Collect(result13))
-	is.Equal([]int{0, 1, 2}, slices.Collect(result14))
-	is.Empty(slices.Collect(result15))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := slices.Collect(Union(tt.inputs...))
+			if tt.expected == nil {
+				is.Empty(result)
+			} else {
+				is.Equal(tt.expected, result)
+			}
+		})
+	}
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Union(allStrings, allStrings)
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Union(allStrings, allStrings)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestWithout(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Without(values(0, 2, 10), 0, 1, 2, 3, 4, 5)
-	result2 := Without(values(0, 7), 0, 1, 2, 3, 4, 5)
-	result3 := Without(values[int](), 0, 1, 2, 3, 4, 5)
-	result4 := Without(values(0, 1, 2), 0, 1, 2)
-	result5 := Without(values[int]())
-	is.Equal([]int{10}, slices.Collect(result1))
-	is.Equal([]int{7}, slices.Collect(result2))
-	is.Empty(slices.Collect(result3))
-	is.Empty(slices.Collect(result4))
-	is.Empty(slices.Collect(result5))
+	tests := []struct {
+		name     string
+		seq      iter.Seq[int]
+		exclude  []int
+		expected []int
+	}{
+		{name: "removes some elements", seq: values(0, 2, 10), exclude: []int{0, 1, 2, 3, 4, 5}, expected: []int{10}},
+		{name: "removes one element", seq: values(0, 7), exclude: []int{0, 1, 2, 3, 4, 5}, expected: []int{7}},
+		{name: "empty sequence", seq: values[int](), exclude: []int{0, 1, 2, 3, 4, 5}, expected: nil},
+		{name: "removes all elements", seq: values(0, 1, 2), exclude: []int{0, 1, 2}, expected: nil},
+		{name: "empty sequence no exclude", seq: values[int](), exclude: nil, expected: nil},
+	}
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Without(allStrings, "")
-	is.IsType(nonempty, allStrings, "type preserved")
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := slices.Collect(Without(tt.seq, tt.exclude...))
+			if tt.expected == nil {
+				is.Empty(result)
+			} else {
+				is.Equal(tt.expected, result)
+			}
+		})
+	}
+
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Without(allStrings, "")
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestWithoutBy(t *testing.T) {
@@ -307,57 +425,123 @@ func TestWithoutBy(t *testing.T) {
 		Age  int
 	}
 
-	result1 := WithoutBy(values(User{Name: "nick"}, User{Name: "peter"}),
-		func(item User) string {
-			return item.Name
-		}, "nick", "lily")
-	result2 := WithoutBy(values[User](), func(item User) int { return item.Age }, 1, 2, 3)
-	result3 := WithoutBy(values[User](), func(item User) string { return item.Name })
-	is.Equal([]User{{Name: "peter"}}, slices.Collect(result1))
-	is.Empty(slices.Collect(result2))
-	is.Empty(slices.Collect(result3))
+	// result1 and result3 share the same generic instantiation (K=string), so
+	// they're grouped in one table; result2 uses K=int and can't share the
+	// row type, so it gets its own subtest per the multi-instantiation rule.
+	t.Run("string key", func(t *testing.T) {
+		t.Parallel()
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := WithoutBy(allStrings, func(string) string { return "" })
-	is.IsType(nonempty, allStrings, "type preserved")
+		byName := func(item User) string { return item.Name }
+
+		tests := []struct {
+			name     string
+			seq      iter.Seq[User]
+			exclude  []string
+			expected []User
+		}{
+			{name: "excludes by name", seq: values(User{Name: "nick"}, User{Name: "peter"}), exclude: []string{"nick", "lily"}, expected: []User{{Name: "peter"}}},
+			{name: "empty sequence no exclude", seq: values[User](), exclude: nil, expected: nil},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				result := slices.Collect(WithoutBy(tt.seq, byName, tt.exclude...))
+				if tt.expected == nil {
+					is.Empty(result)
+				} else {
+					is.Equal(tt.expected, result)
+				}
+			})
+		}
+	})
+
+	t.Run("int key", func(t *testing.T) {
+		t.Parallel()
+
+		result := WithoutBy(values[User](), func(item User) int { return item.Age }, 1, 2, 3)
+		is.Empty(slices.Collect(result))
+	})
+
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := WithoutBy(allStrings, func(string) string { return "" })
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestWithoutNth(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := WithoutNth(values(5, 6, 7), 1, 0)
-	is.Equal([]int{7}, slices.Collect(result1))
+	tests := []struct {
+		name     string
+		seq      iter.Seq[int]
+		nths     []int
+		expected []int
+	}{
+		{name: "removes indices", seq: values(5, 6, 7), nths: []int{1, 0}, expected: []int{7}},
+		{name: "no indices", seq: values(1, 2), nths: nil, expected: []int{1, 2}},
+		{name: "empty sequence", seq: values[int](), nths: nil, expected: nil},
+		{name: "out of range indices", seq: values(0, 1, 2, 3), nths: []int{-1, 4}, expected: []int{0, 1, 2, 3}},
+	}
 
-	result2 := WithoutNth(values(1, 2))
-	is.Equal([]int{1, 2}, slices.Collect(result2))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := slices.Collect(WithoutNth(tt.seq, tt.nths...))
+			if tt.expected == nil {
+				is.Empty(result)
+			} else {
+				is.Equal(tt.expected, result)
+			}
+		})
+	}
 
-	result3 := WithoutNth(values[int]())
-	is.Empty(slices.Collect(result3))
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	result4 := WithoutNth(values(0, 1, 2, 3), -1, 4)
-	is.Equal([]int{0, 1, 2, 3}, slices.Collect(result4))
-
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := WithoutNth(allStrings)
-	is.IsType(nonempty, allStrings, "type preserved")
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := WithoutNth(allStrings)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestElementsMatch(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.False(ElementsMatch(values[int](), values(1)))
-	is.False(ElementsMatch(values(1), values(2)))
-	is.False(ElementsMatch(values(1), values(1, 2)))
-	is.False(ElementsMatch(values(1, 1, 2), values(2, 2, 1)))
+	tests := []struct {
+		name     string
+		a        iter.Seq[int]
+		b        iter.Seq[int]
+		expected bool
+	}{
+		{name: "empty vs non-empty", a: values[int](), b: values(1), expected: false},
+		{name: "different single elements", a: values(1), b: values(2), expected: false},
+		{name: "different lengths", a: values(1), b: values(1, 2), expected: false},
+		{name: "different element counts", a: values(1, 1, 2), b: values(2, 2, 1), expected: false},
+		{name: "same single element", a: values(1), b: values(1), expected: true},
+		{name: "same repeated elements", a: values(1, 1), b: values(1, 1), expected: true},
+		{name: "same elements different order", a: values(1, 2), b: values(2, 1), expected: true},
+		{name: "same multiset different order", a: values(1, 1, 2), b: values(1, 2, 1), expected: true},
+	}
 
-	is.True(ElementsMatch(values(1), values(1)))
-	is.True(ElementsMatch(values(1, 1), values(1, 1)))
-	is.True(ElementsMatch(values(1, 2), values(2, 1)))
-	is.True(ElementsMatch(values(1, 1, 2), values(1, 2, 1)))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, ElementsMatch(tt.a, tt.b))
+		})
+	}
 }
 
 func TestElementsMatchBy(t *testing.T) {

--- a/it/intersect_test.go
+++ b/it/intersect_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestContains(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -29,6 +28,7 @@ func TestContains(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, Contains(tt.seq, tt.target))
 		})
 	}
@@ -36,7 +36,6 @@ func TestContains(t *testing.T) {
 
 func TestContainsBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	type a struct {
 		A int
@@ -61,6 +60,7 @@ func TestContainsBy(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 				is.Equal(tt.expected, ContainsBy(a1, tt.predicate))
 			})
 		}
@@ -84,6 +84,7 @@ func TestContainsBy(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 				is.Equal(tt.expected, ContainsBy(a2, tt.predicate))
 			})
 		}
@@ -92,7 +93,6 @@ func TestContainsBy(t *testing.T) {
 
 func TestEvery(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -109,6 +109,7 @@ func TestEvery(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, Every(values(0, 1, 2, 3, 4, 5), tt.args...))
 		})
 	}
@@ -116,7 +117,6 @@ func TestEvery(t *testing.T) {
 
 func TestEveryBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name      string
@@ -134,6 +134,7 @@ func TestEveryBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, EveryBy(tt.seq, tt.predicate))
 		})
 	}
@@ -141,7 +142,6 @@ func TestEveryBy(t *testing.T) {
 
 func TestSome(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -158,6 +158,7 @@ func TestSome(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, Some(values(0, 1, 2, 3, 4, 5), tt.args...))
 		})
 	}
@@ -165,7 +166,6 @@ func TestSome(t *testing.T) {
 
 func TestSomeBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name      string
@@ -183,6 +183,7 @@ func TestSomeBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, SomeBy(tt.seq, tt.predicate))
 		})
 	}
@@ -190,7 +191,6 @@ func TestSomeBy(t *testing.T) {
 
 func TestNone(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -207,6 +207,7 @@ func TestNone(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, None(values(0, 1, 2, 3, 4, 5), tt.args...))
 		})
 	}
@@ -214,7 +215,6 @@ func TestNone(t *testing.T) {
 
 func TestNoneBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name      string
@@ -232,6 +232,7 @@ func TestNoneBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, NoneBy(tt.seq, tt.predicate))
 		})
 	}
@@ -239,7 +240,6 @@ func TestNoneBy(t *testing.T) {
 
 func TestIntersect(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -262,6 +262,7 @@ func TestIntersect(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := slices.Collect(Intersect(tt.inputs...))
 			if tt.expected == nil {
 				is.Empty(result)
@@ -284,7 +285,6 @@ func TestIntersect(t *testing.T) {
 
 func TestIntersectBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	transform := strconv.Itoa
 
@@ -309,6 +309,7 @@ func TestIntersectBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := slices.Collect(IntersectBy(transform, tt.inputs...))
 			if tt.expected == nil {
 				is.Empty(result)
@@ -331,7 +332,6 @@ func TestIntersectBy(t *testing.T) {
 
 func TestUnion(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -355,6 +355,7 @@ func TestUnion(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := slices.Collect(Union(tt.inputs...))
 			if tt.expected == nil {
 				is.Empty(result)
@@ -377,7 +378,6 @@ func TestUnion(t *testing.T) {
 
 func TestWithout(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -396,6 +396,7 @@ func TestWithout(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := slices.Collect(Without(tt.seq, tt.exclude...))
 			if tt.expected == nil {
 				is.Empty(result)
@@ -418,7 +419,6 @@ func TestWithout(t *testing.T) {
 
 func TestWithoutBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	type User struct {
 		Name string
@@ -447,6 +447,7 @@ func TestWithoutBy(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 				result := slices.Collect(WithoutBy(tt.seq, byName, tt.exclude...))
 				if tt.expected == nil {
 					is.Empty(result)
@@ -459,6 +460,7 @@ func TestWithoutBy(t *testing.T) {
 
 	t.Run("int key", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		result := WithoutBy(values[User](), func(item User) int { return item.Age }, 1, 2, 3)
 		is.Empty(slices.Collect(result))
@@ -477,7 +479,6 @@ func TestWithoutBy(t *testing.T) {
 
 func TestWithoutNth(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -495,6 +496,7 @@ func TestWithoutNth(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := slices.Collect(WithoutNth(tt.seq, tt.nths...))
 			if tt.expected == nil {
 				is.Empty(result)
@@ -517,7 +519,6 @@ func TestWithoutNth(t *testing.T) {
 
 func TestElementsMatch(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -539,6 +540,7 @@ func TestElementsMatch(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, ElementsMatch(tt.a, tt.b))
 		})
 	}

--- a/it/map_test.go
+++ b/it/map_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestKeys(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -32,6 +31,7 @@ func TestKeys(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.ElementsMatch(tt.expected, slices.Collect(Keys(tt.maps...)))
 		})
 	}
@@ -39,7 +39,6 @@ func TestKeys(t *testing.T) {
 
 func TestUniqKeys(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -59,6 +58,7 @@ func TestUniqKeys(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := slices.Collect(UniqKeys(tt.maps...))
 			if tt.exact {
 				is.Equal(tt.expected, result)
@@ -71,7 +71,6 @@ func TestUniqKeys(t *testing.T) {
 
 func TestValues(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -89,6 +88,7 @@ func TestValues(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.ElementsMatch(tt.expected, slices.Collect(Values(tt.maps...)))
 		})
 	}
@@ -96,7 +96,6 @@ func TestValues(t *testing.T) {
 
 func TestUniqValues(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -117,6 +116,7 @@ func TestUniqValues(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := slices.Collect(UniqValues(tt.maps...))
 			if tt.exact {
 				is.Equal(tt.expected, result)
@@ -167,16 +167,17 @@ func TestFromPairs(t *testing.T) {
 
 func TestInvert(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	t.Run("no collisions", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r1 := Invert(maps.All(map[string]int{"a": 1, "b": 2}))
 		is.Equal(map[int]string{1: "a", 2: "b"}, maps.Collect(r1))
 	})
 
 	t.Run("colliding values keep one key", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r2 := Invert(maps.All(map[string]int{"a": 1, "b": 2, "c": 1}))
 		is.Len(maps.Collect(r2), 2)
 	})
@@ -184,16 +185,17 @@ func TestInvert(t *testing.T) {
 
 func TestAssign(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	t.Run("merges maps with later keys overriding earlier ones", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result1 := Assign(values(map[string]int{"a": 1, "b": 2}, map[string]int{"b": 3, "c": 4}))
 		is.Equal(map[string]int{"a": 1, "b": 3, "c": 4}, result1)
 	})
 
 	t.Run("preserves custom map type", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myMap map[string]int
 		before := myMap{"": 0, "foobar": 6, "baz": 3}
 		after := Assign(values(before, before))
@@ -203,7 +205,6 @@ func TestAssign(t *testing.T) {
 
 func TestChunkEntries(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	t.Run("chunk counts", func(t *testing.T) {
 		t.Parallel()
@@ -225,6 +226,7 @@ func TestChunkEntries(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 				is.Len(slices.Collect(ChunkEntries(tt.input, tt.size)), tt.expectedLen)
 			})
 		}
@@ -245,6 +247,7 @@ func TestChunkEntries(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 				is.PanicsWithValue("it.ChunkEntries: size must be greater than 0", func() {
 					ChunkEntries(map[string]int{"a": 1}, tt.size)
 				})
@@ -254,6 +257,7 @@ func TestChunkEntries(t *testing.T) {
 
 	t.Run("chunks a map of struct values", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		type myStruct struct {
 			Name  string
@@ -267,6 +271,7 @@ func TestChunkEntries(t *testing.T) {
 
 	t.Run("mutating a returned chunk does not affect the original map", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		originalMap := map[string]int{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}
 		result := slices.Collect(ChunkEntries(originalMap, 2))
@@ -279,7 +284,6 @@ func TestChunkEntries(t *testing.T) {
 
 func TestMapToSeq(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name      string
@@ -305,6 +309,7 @@ func TestMapToSeq(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.ElementsMatch(tt.expected, slices.Collect(MapToSeq(tt.input, tt.transform)))
 		})
 	}
@@ -312,7 +317,6 @@ func TestMapToSeq(t *testing.T) {
 
 func TestFilterMapToSeq(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -338,6 +342,7 @@ func TestFilterMapToSeq(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.ElementsMatch(tt.expected, slices.Collect(FilterMapToSeq(tt.input, tt.filter)))
 		})
 	}
@@ -345,10 +350,10 @@ func TestFilterMapToSeq(t *testing.T) {
 
 func TestFilterKeys(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	t.Run("int keys filtered by matching string value", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result1 := FilterKeys(map[int]string{1: "foo", 2: "bar", 3: "baz"}, func(k int, v string) bool {
 			return v == "foo"
 		})
@@ -357,6 +362,7 @@ func TestFilterKeys(t *testing.T) {
 
 	t.Run("string keys with predicate always false", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result2 := FilterKeys(map[string]int{"foo": 1, "bar": 2, "baz": 3}, func(k string, v int) bool {
 			return false
 		})
@@ -366,10 +372,10 @@ func TestFilterKeys(t *testing.T) {
 
 func TestFilterValues(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	t.Run("string values filtered by matching predicate", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result1 := FilterValues(map[int]string{1: "foo", 2: "bar", 3: "baz"}, func(k int, v string) bool {
 			return v == "foo"
 		})
@@ -378,6 +384,7 @@ func TestFilterValues(t *testing.T) {
 
 	t.Run("int values with predicate always false", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result2 := FilterValues(map[string]int{"foo": 1, "bar": 2, "baz": 3}, func(k string, v int) bool {
 			return false
 		})
@@ -387,7 +394,6 @@ func TestFilterValues(t *testing.T) {
 
 func TestSeq2KeyToSeq(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -402,6 +408,7 @@ func TestSeq2KeyToSeq(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.ElementsMatch(tt.expected, slices.Collect(Seq2KeyToSeq(maps.All(tt.input))))
 		})
 	}
@@ -409,7 +416,6 @@ func TestSeq2KeyToSeq(t *testing.T) {
 
 func TestSeq2ValueToSeq(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -424,6 +430,7 @@ func TestSeq2ValueToSeq(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.ElementsMatch(tt.expected, slices.Collect(Seq2ValueToSeq(maps.All(tt.input))))
 		})
 	}

--- a/it/map_test.go
+++ b/it/map_test.go
@@ -16,91 +16,115 @@ func TestKeys(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := slices.Collect(Keys(map[string]int{"foo": 1, "bar": 2}))
-	is.ElementsMatch(r1, []string{"bar", "foo"})
+	tests := []struct {
+		name     string
+		maps     []map[string]int
+		expected []string
+	}{
+		{name: "single map", maps: []map[string]int{{"foo": 1, "bar": 2}}, expected: []string{"bar", "foo"}},
+		{name: "empty map", maps: []map[string]int{{}}, expected: []string{}},
+		{name: "multiple maps", maps: []map[string]int{{"foo": 1, "bar": 2}, {"baz": 3}}, expected: []string{"bar", "baz", "foo"}},
+		{name: "no maps", maps: nil, expected: []string{}},
+		{name: "duplicate keys across maps", maps: []map[string]int{{"foo": 1, "bar": 2}, {"bar": 3}}, expected: []string{"bar", "bar", "foo"}},
+	}
 
-	r2 := slices.Collect(Keys(map[string]int{}))
-	is.Empty(r2)
-
-	r3 := slices.Collect(Keys(map[string]int{"foo": 1, "bar": 2}, map[string]int{"baz": 3}))
-	is.ElementsMatch(r3, []string{"bar", "baz", "foo"})
-
-	r4 := slices.Collect(Keys[string, int]())
-	is.Empty(r4)
-
-	r5 := slices.Collect(Keys(map[string]int{"foo": 1, "bar": 2}, map[string]int{"bar": 3}))
-	is.ElementsMatch(r5, []string{"bar", "bar", "foo"})
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.ElementsMatch(tt.expected, slices.Collect(Keys(tt.maps...)))
+		})
+	}
 }
 
 func TestUniqKeys(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := slices.Collect(UniqKeys(map[string]int{"foo": 1, "bar": 2}))
-	is.ElementsMatch(r1, []string{"bar", "foo"})
+	tests := []struct {
+		name     string
+		maps     []map[string]int
+		expected []string
+		exact    bool
+	}{
+		{name: "single map", maps: []map[string]int{{"foo": 1, "bar": 2}}, expected: []string{"bar", "foo"}},
+		{name: "empty map", maps: []map[string]int{{}}, expected: []string{}},
+		{name: "multiple maps", maps: []map[string]int{{"foo": 1, "bar": 2}, {"baz": 3}}, expected: []string{"bar", "baz", "foo"}},
+		{name: "no maps", maps: nil, expected: []string{}},
+		{name: "duplicate keys across maps are deduplicated", maps: []map[string]int{{"foo": 1, "bar": 2}, {"foo": 1, "bar": 3}}, expected: []string{"bar", "foo"}},
+		{name: "preserves first-seen order", maps: []map[string]int{{"foo": 1}, {"bar": 3}}, expected: []string{"foo", "bar"}, exact: true},
+	}
 
-	r2 := slices.Collect(UniqKeys(map[string]int{}))
-	is.Empty(r2)
-
-	r3 := slices.Collect(UniqKeys(map[string]int{"foo": 1, "bar": 2}, map[string]int{"baz": 3}))
-	is.ElementsMatch(r3, []string{"bar", "baz", "foo"})
-
-	r4 := slices.Collect(UniqKeys[string, int]())
-	is.Empty(r4)
-
-	r5 := slices.Collect(UniqKeys(map[string]int{"foo": 1, "bar": 2}, map[string]int{"foo": 1, "bar": 3}))
-	is.ElementsMatch(r5, []string{"bar", "foo"})
-
-	// check order
-	r6 := slices.Collect(UniqKeys(map[string]int{"foo": 1}, map[string]int{"bar": 3}))
-	is.Equal([]string{"foo", "bar"}, r6)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := slices.Collect(UniqKeys(tt.maps...))
+			if tt.exact {
+				is.Equal(tt.expected, result)
+			} else {
+				is.ElementsMatch(tt.expected, result)
+			}
+		})
+	}
 }
 
 func TestValues(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := slices.Collect(Values(map[string]int{"foo": 1, "bar": 2}))
-	is.ElementsMatch(r1, []int{1, 2})
+	tests := []struct {
+		name     string
+		maps     []map[string]int
+		expected []int
+	}{
+		{name: "single map", maps: []map[string]int{{"foo": 1, "bar": 2}}, expected: []int{1, 2}},
+		{name: "empty map", maps: []map[string]int{{}}, expected: []int{}},
+		{name: "multiple maps", maps: []map[string]int{{"foo": 1, "bar": 2}, {"baz": 3}}, expected: []int{1, 2, 3}},
+		{name: "no maps", maps: nil, expected: []int{}},
+		{name: "duplicate keys across maps", maps: []map[string]int{{"foo": 1, "bar": 2}, {"foo": 1, "bar": 3}}, expected: []int{1, 1, 2, 3}},
+	}
 
-	r2 := slices.Collect(Values(map[string]int{}))
-	is.Empty(r2)
-
-	r3 := slices.Collect(Values(map[string]int{"foo": 1, "bar": 2}, map[string]int{"baz": 3}))
-	is.ElementsMatch(r3, []int{1, 2, 3})
-
-	r4 := slices.Collect(Values[string, int]())
-	is.Empty(r4)
-
-	r5 := slices.Collect(Values(map[string]int{"foo": 1, "bar": 2}, map[string]int{"foo": 1, "bar": 3}))
-	is.ElementsMatch(r5, []int{1, 1, 2, 3})
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.ElementsMatch(tt.expected, slices.Collect(Values(tt.maps...)))
+		})
+	}
 }
 
 func TestUniqValues(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := slices.Collect(UniqValues(map[string]int{"foo": 1, "bar": 2}))
-	is.ElementsMatch(r1, []int{1, 2})
+	tests := []struct {
+		name     string
+		maps     []map[string]int
+		expected []int
+		exact    bool
+	}{
+		{name: "single map", maps: []map[string]int{{"foo": 1, "bar": 2}}, expected: []int{1, 2}},
+		{name: "empty map", maps: []map[string]int{{}}, expected: []int{}},
+		{name: "multiple maps", maps: []map[string]int{{"foo": 1, "bar": 2}, {"baz": 3}}, expected: []int{1, 2, 3}},
+		{name: "no maps", maps: nil, expected: []int{}},
+		{name: "duplicate values across maps", maps: []map[string]int{{"foo": 1, "bar": 2}, {"foo": 1, "bar": 3}}, expected: []int{1, 2, 3}},
+		{name: "duplicate values within and across maps", maps: []map[string]int{{"foo": 1, "bar": 1}, {"foo": 1, "bar": 3}}, expected: []int{1, 3}},
+		{name: "preserves first-seen order", maps: []map[string]int{{"foo": 1}, {"bar": 3}}, expected: []int{1, 3}, exact: true},
+	}
 
-	r2 := slices.Collect(UniqValues(map[string]int{}))
-	is.Empty(r2)
-
-	r3 := slices.Collect(UniqValues(map[string]int{"foo": 1, "bar": 2}, map[string]int{"baz": 3}))
-	is.ElementsMatch(r3, []int{1, 2, 3})
-
-	r4 := slices.Collect(UniqValues[string, int]())
-	is.Empty(r4)
-
-	r5 := slices.Collect(UniqValues(map[string]int{"foo": 1, "bar": 2}, map[string]int{"foo": 1, "bar": 3}))
-	is.ElementsMatch(r5, []int{1, 2, 3})
-
-	r6 := slices.Collect(UniqValues(map[string]int{"foo": 1, "bar": 1}, map[string]int{"foo": 1, "bar": 3}))
-	is.ElementsMatch(r6, []int{1, 3})
-
-	// check order
-	r7 := slices.Collect(UniqValues(map[string]int{"foo": 1}, map[string]int{"bar": 3}))
-	is.Equal([]int{1, 3}, r7)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := slices.Collect(UniqValues(tt.maps...))
+			if tt.exact {
+				is.Equal(tt.expected, result)
+			} else {
+				is.ElementsMatch(tt.expected, result)
+			}
+		})
+	}
 }
 
 func TestEntries(t *testing.T) {
@@ -145,146 +169,264 @@ func TestInvert(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := Invert(maps.All(map[string]int{"a": 1, "b": 2}))
-	r2 := Invert(maps.All(map[string]int{"a": 1, "b": 2, "c": 1}))
+	t.Run("no collisions", func(t *testing.T) {
+		t.Parallel()
+		r1 := Invert(maps.All(map[string]int{"a": 1, "b": 2}))
+		is.Equal(map[int]string{1: "a", 2: "b"}, maps.Collect(r1))
+	})
 
-	is.Equal(map[int]string{1: "a", 2: "b"}, maps.Collect(r1))
-	is.Len(maps.Collect(r2), 2)
+	t.Run("colliding values keep one key", func(t *testing.T) {
+		t.Parallel()
+		r2 := Invert(maps.All(map[string]int{"a": 1, "b": 2, "c": 1}))
+		is.Len(maps.Collect(r2), 2)
+	})
 }
 
 func TestAssign(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Assign(values(map[string]int{"a": 1, "b": 2}, map[string]int{"b": 3, "c": 4}))
-	is.Equal(map[string]int{"a": 1, "b": 3, "c": 4}, result1)
+	t.Run("merges maps with later keys overriding earlier ones", func(t *testing.T) {
+		t.Parallel()
+		result1 := Assign(values(map[string]int{"a": 1, "b": 2}, map[string]int{"b": 3, "c": 4}))
+		is.Equal(map[string]int{"a": 1, "b": 3, "c": 4}, result1)
+	})
 
-	type myMap map[string]int
-	before := myMap{"": 0, "foobar": 6, "baz": 3}
-	after := Assign(values(before, before))
-	is.IsType(myMap{}, after, "type preserved")
+	t.Run("preserves custom map type", func(t *testing.T) {
+		t.Parallel()
+		type myMap map[string]int
+		before := myMap{"": 0, "foobar": 6, "baz": 3}
+		after := Assign(values(before, before))
+		is.IsType(myMap{}, after, "type preserved")
+	})
 }
 
 func TestChunkEntries(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := ChunkEntries(map[string]int{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}, 2)
-	result2 := ChunkEntries(map[string]int{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}, 3)
-	result3 := ChunkEntries(map[string]int{}, 2)
-	result4 := ChunkEntries(map[string]int{"a": 1}, 2)
-	result5 := ChunkEntries(map[string]int{"a": 1, "b": 2}, 1)
+	t.Run("chunk counts", func(t *testing.T) {
+		t.Parallel()
 
-	is.Len(slices.Collect(result1), 3)
-	is.Len(slices.Collect(result2), 2)
-	is.Empty(slices.Collect(result3))
-	is.Len(slices.Collect(result4), 1)
-	is.Len(slices.Collect(result5), 2)
+		tests := []struct {
+			name        string
+			input       map[string]int
+			size        int
+			expectedLen int
+		}{
+			{name: "5 entries chunked by 2", input: map[string]int{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}, size: 2, expectedLen: 3},
+			{name: "5 entries chunked by 3", input: map[string]int{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}, size: 3, expectedLen: 2},
+			{name: "empty map", input: map[string]int{}, size: 2, expectedLen: 0},
+			{name: "single entry chunked by 2", input: map[string]int{"a": 1}, size: 2, expectedLen: 1},
+			{name: "2 entries chunked by 1", input: map[string]int{"a": 1, "b": 2}, size: 1, expectedLen: 2},
+		}
 
-	is.PanicsWithValue("it.ChunkEntries: size must be greater than 0", func() {
-		ChunkEntries(map[string]int{"a": 1}, 0)
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				is.Len(slices.Collect(ChunkEntries(tt.input, tt.size)), tt.expectedLen)
+			})
+		}
 	})
-	is.PanicsWithValue("it.ChunkEntries: size must be greater than 0", func() {
-		ChunkEntries(map[string]int{"a": 1}, -1)
+
+	t.Run("panics on non-positive size", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name string
+			size int
+		}{
+			{name: "zero size", size: 0},
+			{name: "negative size", size: -1},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				is.PanicsWithValue("it.ChunkEntries: size must be greater than 0", func() {
+					ChunkEntries(map[string]int{"a": 1}, tt.size)
+				})
+			})
+		}
 	})
 
-	type myStruct struct {
-		Name  string
-		Value int
-	}
+	t.Run("chunks a map of struct values", func(t *testing.T) {
+		t.Parallel()
 
-	allStructs := []myStruct{{"one", 1}, {"two", 2}, {"three", 3}}
-	nonempty := ChunkEntries(map[string]myStruct{"a": allStructs[0], "b": allStructs[1], "c": allStructs[2]}, 2)
-	is.Len(slices.Collect(nonempty), 2)
+		type myStruct struct {
+			Name  string
+			Value int
+		}
 
-	originalMap := map[string]int{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}
-	result6 := slices.Collect(ChunkEntries(originalMap, 2))
-	for k := range result6[0] {
-		result6[0][k] = 10
-	}
-	is.Equal(map[string]int{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}, originalMap)
+		allStructs := []myStruct{{"one", 1}, {"two", 2}, {"three", 3}}
+		nonempty := ChunkEntries(map[string]myStruct{"a": allStructs[0], "b": allStructs[1], "c": allStructs[2]}, 2)
+		is.Len(slices.Collect(nonempty), 2)
+	})
+
+	t.Run("mutating a returned chunk does not affect the original map", func(t *testing.T) {
+		t.Parallel()
+
+		originalMap := map[string]int{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}
+		result := slices.Collect(ChunkEntries(originalMap, 2))
+		for k := range result[0] {
+			result[0][k] = 10
+		}
+		is.Equal(map[string]int{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}, originalMap)
+	})
 }
 
 func TestMapToSeq(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := MapToSeq(map[int]int{1: 5, 2: 6, 3: 7, 4: 8}, func(k, v int) string {
-		return fmt.Sprintf("%d_%d", k, v)
-	})
-	result2 := MapToSeq(map[int]int{1: 5, 2: 6, 3: 7, 4: 8}, func(k, _ int) string {
-		return strconv.FormatInt(int64(k), 10)
-	})
+	tests := []struct {
+		name      string
+		input     map[int]int
+		transform func(k, v int) string
+		expected  []string
+	}{
+		{
+			name:      "formats key and value",
+			input:     map[int]int{1: 5, 2: 6, 3: 7, 4: 8},
+			transform: func(k, v int) string { return fmt.Sprintf("%d_%d", k, v) },
+			expected:  []string{"1_5", "2_6", "3_7", "4_8"},
+		},
+		{
+			name:      "formats key only",
+			input:     map[int]int{1: 5, 2: 6, 3: 7, 4: 8},
+			transform: func(k, _ int) string { return strconv.FormatInt(int64(k), 10) },
+			expected:  []string{"1", "2", "3", "4"},
+		},
+	}
 
-	is.ElementsMatch(slices.Collect(result1), []string{"1_5", "2_6", "3_7", "4_8"})
-	is.ElementsMatch(slices.Collect(result2), []string{"1", "2", "3", "4"})
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.ElementsMatch(tt.expected, slices.Collect(MapToSeq(tt.input, tt.transform)))
+		})
+	}
 }
 
 func TestFilterMapToSeq(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := FilterMapToSeq(map[int]int{1: 5, 2: 6, 3: 7, 4: 8}, func(k, v int) (string, bool) {
-		return fmt.Sprintf("%d_%d", k, v), k%2 == 0
-	})
-	result2 := FilterMapToSeq(map[int]int{1: 5, 2: 6, 3: 7, 4: 8}, func(k, _ int) (string, bool) {
-		return strconv.FormatInt(int64(k), 10), k%2 == 0
-	})
+	tests := []struct {
+		name     string
+		input    map[int]int
+		filter   func(k, v int) (string, bool)
+		expected []string
+	}{
+		{
+			name:     "formats key and value for even keys",
+			input:    map[int]int{1: 5, 2: 6, 3: 7, 4: 8},
+			filter:   func(k, v int) (string, bool) { return fmt.Sprintf("%d_%d", k, v), k%2 == 0 },
+			expected: []string{"2_6", "4_8"},
+		},
+		{
+			name:     "formats key only for even keys",
+			input:    map[int]int{1: 5, 2: 6, 3: 7, 4: 8},
+			filter:   func(k, _ int) (string, bool) { return strconv.FormatInt(int64(k), 10), k%2 == 0 },
+			expected: []string{"2", "4"},
+		},
+	}
 
-	is.ElementsMatch(slices.Collect(result1), []string{"2_6", "4_8"})
-	is.ElementsMatch(slices.Collect(result2), []string{"2", "4"})
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.ElementsMatch(tt.expected, slices.Collect(FilterMapToSeq(tt.input, tt.filter)))
+		})
+	}
 }
 
 func TestFilterKeys(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := FilterKeys(map[int]string{1: "foo", 2: "bar", 3: "baz"}, func(k int, v string) bool {
-		return v == "foo"
+	t.Run("int keys filtered by matching string value", func(t *testing.T) {
+		t.Parallel()
+		result1 := FilterKeys(map[int]string{1: "foo", 2: "bar", 3: "baz"}, func(k int, v string) bool {
+			return v == "foo"
+		})
+		is.Equal([]int{1}, slices.Collect(result1))
 	})
-	is.Equal([]int{1}, slices.Collect(result1))
 
-	result2 := FilterKeys(map[string]int{"foo": 1, "bar": 2, "baz": 3}, func(k string, v int) bool {
-		return false
+	t.Run("string keys with predicate always false", func(t *testing.T) {
+		t.Parallel()
+		result2 := FilterKeys(map[string]int{"foo": 1, "bar": 2, "baz": 3}, func(k string, v int) bool {
+			return false
+		})
+		is.Empty(slices.Collect(result2))
 	})
-	is.Empty(slices.Collect(result2))
 }
 
 func TestFilterValues(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := FilterValues(map[int]string{1: "foo", 2: "bar", 3: "baz"}, func(k int, v string) bool {
-		return v == "foo"
+	t.Run("string values filtered by matching predicate", func(t *testing.T) {
+		t.Parallel()
+		result1 := FilterValues(map[int]string{1: "foo", 2: "bar", 3: "baz"}, func(k int, v string) bool {
+			return v == "foo"
+		})
+		is.Equal([]string{"foo"}, slices.Collect(result1))
 	})
-	is.Equal([]string{"foo"}, slices.Collect(result1))
 
-	result2 := FilterValues(map[string]int{"foo": 1, "bar": 2, "baz": 3}, func(k string, v int) bool {
-		return false
+	t.Run("int values with predicate always false", func(t *testing.T) {
+		t.Parallel()
+		result2 := FilterValues(map[string]int{"foo": 1, "bar": 2, "baz": 3}, func(k string, v int) bool {
+			return false
+		})
+		is.Empty(slices.Collect(result2))
 	})
-	is.Empty(slices.Collect(result2))
 }
 
 func TestSeq2KeyToSeq(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := slices.Collect(Seq2KeyToSeq(maps.All(map[string]int{"foo": 4, "bar": 5})))
-	is.ElementsMatch([]string{"foo", "bar"}, r1)
+	tests := []struct {
+		name     string
+		input    map[string]int
+		expected []string
+	}{
+		{name: "non-empty map", input: map[string]int{"foo": 4, "bar": 5}, expected: []string{"foo", "bar"}},
+		{name: "empty map", input: map[string]int{}, expected: []string{}},
+	}
 
-	r2 := slices.Collect(Seq2KeyToSeq(maps.All(map[string]int{})))
-	is.Empty(r2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.ElementsMatch(tt.expected, slices.Collect(Seq2KeyToSeq(maps.All(tt.input))))
+		})
+	}
 }
 
 func TestSeq2ValueToSeq(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := slices.Collect(Seq2ValueToSeq(maps.All(map[string]int{"foo": 4, "bar": 5})))
-	is.ElementsMatch([]int{4, 5}, r1)
+	tests := []struct {
+		name     string
+		input    map[string]int
+		expected []int
+	}{
+		{name: "non-empty map", input: map[string]int{"foo": 4, "bar": 5}, expected: []int{4, 5}},
+		{name: "empty map", input: map[string]int{}, expected: []int{}},
+	}
 
-	r2 := slices.Collect(Seq2ValueToSeq(maps.All(map[string]int{})))
-	is.Empty(r2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.ElementsMatch(tt.expected, slices.Collect(Seq2ValueToSeq(maps.All(tt.input))))
+		})
+	}
 }
 
 func BenchmarkAssign(b *testing.B) {

--- a/it/math_test.go
+++ b/it/math_test.go
@@ -13,184 +13,544 @@ func TestRange(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Range(4)
-	result2 := Range(-4)
-	result3 := Range(0)
-	is.Equal([]int{0, 1, 2, 3}, slices.Collect(result1))
-	is.Equal([]int{0, -1, -2, -3}, slices.Collect(result2))
-	is.Empty(slices.Collect(result3))
+	tests := []struct {
+		name     string
+		n        int
+		expected []int
+	}{
+		{name: "positive count", n: 4, expected: []int{0, 1, 2, 3}},
+		{name: "negative count", n: -4, expected: []int{0, -1, -2, -3}},
+		{name: "zero count", n: 0, expected: nil},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := slices.Collect(Range(tt.n))
+			if tt.expected == nil {
+				is.Empty(result)
+			} else {
+				is.Equal(tt.expected, result)
+			}
+		})
+	}
 }
 
 func TestRangeFrom(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1 := RangeFrom(1, 5)
-	result2 := RangeFrom(-1, -5)
-	result3 := RangeFrom(10, 0)
-	result4 := RangeFrom(2.0, 3)
-	result5 := RangeFrom(-2.0, -3)
-	result6 := RangeFrom(2.5, 3)
-	result7 := RangeFrom(-2.5, -3)
-	is.Equal([]int{1, 2, 3, 4, 5}, slices.Collect(result1))
-	is.Equal([]int{-1, -2, -3, -4, -5}, slices.Collect(result2))
-	is.Empty(slices.Collect(result3))
-	is.Equal([]float64{2.0, 3.0, 4.0}, slices.Collect(result4))
-	is.Equal([]float64{-2.0, -3.0, -4.0}, slices.Collect(result5))
-	is.Equal([]float64{2.5, 3.5, 4.5}, slices.Collect(result6))
-	is.Equal([]float64{-2.5, -3.5, -4.5}, slices.Collect(result7))
+	t.Run("int", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		tests := []struct {
+			name       string
+			start      int
+			elementNum int
+			expected   []int
+		}{
+			{name: "ascending", start: 1, elementNum: 5, expected: []int{1, 2, 3, 4, 5}},
+			{name: "descending", start: -1, elementNum: -5, expected: []int{-1, -2, -3, -4, -5}},
+			{name: "zero elements", start: 10, elementNum: 0, expected: nil},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result := slices.Collect(RangeFrom(tt.start, tt.elementNum))
+				if tt.expected == nil {
+					is.Empty(result)
+				} else {
+					is.Equal(tt.expected, result)
+				}
+			})
+		}
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		tests := []struct {
+			name       string
+			start      float64
+			elementNum int
+			expected   []float64
+		}{
+			{name: "positive integer step", start: 2.0, elementNum: 3, expected: []float64{2.0, 3.0, 4.0}},
+			{name: "negative integer step", start: -2.0, elementNum: -3, expected: []float64{-2.0, -3.0, -4.0}},
+			{name: "positive fractional step", start: 2.5, elementNum: 3, expected: []float64{2.5, 3.5, 4.5}},
+			{name: "negative fractional step", start: -2.5, elementNum: -3, expected: []float64{-2.5, -3.5, -4.5}},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				is.Equal(tt.expected, slices.Collect(RangeFrom(tt.start, tt.elementNum)))
+			})
+		}
+	})
 }
 
 func TestRangeWithSteps(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1 := RangeWithSteps(0, 20, 6)
-	result2 := RangeWithSteps(0, 3, -5)
-	result3 := RangeWithSteps(1, 1, 0)
-	result4 := RangeWithSteps(3, 2, 1)
-	result5 := RangeWithSteps(1.0, 4.0, 2.0)
-	result6 := RangeWithSteps[float32](-1.0, -4.0, -1.0)
-	result7 := RangeWithSteps(0.0, 0.5, 1.0)
-	result8 := RangeWithSteps(0.0, 0.3, 0.1)
-	result9 := RangeWithSteps(0.0, 5.5, 2.5)
+	t.Run("int", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	type f64 float64
-	result10 := RangeWithSteps[f64](0.0, 0.3, 0.1)
+		tests := []struct {
+			name             string
+			start, end, step int
+			expected         []int
+		}{
+			{name: "positive step", start: 0, end: 20, step: 6, expected: []int{0, 6, 12, 18}},
+			{name: "negative step on ascending range", start: 0, end: 3, step: -5, expected: nil},
+			{name: "zero step", start: 1, end: 1, step: 0, expected: nil},
+			{name: "positive step on descending range", start: 3, end: 2, step: 1, expected: nil},
+		}
 
-	is.Equal([]int{0, 6, 12, 18}, slices.Collect(result1))
-	is.Empty(slices.Collect(result2))
-	is.Empty(slices.Collect(result3))
-	is.Empty(slices.Collect(result4))
-	is.Equal([]float64{1.0, 3.0}, slices.Collect(result5))
-	is.Equal([]float32{-1.0, -2.0, -3.0}, slices.Collect(result6))
-	is.Equal([]float64{0.0}, slices.Collect(result7))
-	is.Equal([]float64{0.0, 0.1, 0.2}, slices.Collect(result8))
-	is.Equal([]float64{0.0, 2.5, 5.0}, slices.Collect(result9))
-	is.Equal([]f64{0.0, 0.1, 0.2}, slices.Collect(result10))
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result := slices.Collect(RangeWithSteps(tt.start, tt.end, tt.step))
+				if tt.expected == nil {
+					is.Empty(result)
+				} else {
+					is.Equal(tt.expected, result)
+				}
+			})
+		}
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		tests := []struct {
+			name             string
+			start, end, step float64
+			expected         []float64
+		}{
+			{name: "integer step", start: 1.0, end: 4.0, step: 2.0, expected: []float64{1.0, 3.0}},
+			{name: "step larger than range", start: 0.0, end: 0.5, step: 1.0, expected: []float64{0.0}},
+			{name: "fractional step", start: 0.0, end: 0.3, step: 0.1, expected: []float64{0.0, 0.1, 0.2}},
+			{name: "fractional step, larger range", start: 0.0, end: 5.5, step: 2.5, expected: []float64{0.0, 2.5, 5.0}},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				is.Equal(tt.expected, slices.Collect(RangeWithSteps(tt.start, tt.end, tt.step)))
+			})
+		}
+	})
+
+	t.Run("float32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := RangeWithSteps[float32](-1.0, -4.0, -1.0)
+		is.Equal([]float32{-1.0, -2.0, -3.0}, slices.Collect(result))
+	})
+
+	t.Run("custom float64-based type", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		type f64 float64
+
+		result := RangeWithSteps[f64](0.0, 0.3, 0.1)
+		is.Equal([]f64{0.0, 0.1, 0.2}, slices.Collect(result))
+	})
 }
 
 func TestSum(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1 := Sum(values[float32](2.3, 3.3, 4, 5.3))
-	result2 := Sum(values[int32](2, 3, 4, 5))
-	result3 := Sum(values[uint32](2, 3, 4, 5))
-	result4 := Sum(values[uint32]())
-	result5 := Sum(values[complex128](4_4, 2_2))
+	t.Run("float32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.InEpsilon(14.9, result1, 1e-7)
-	is.Equal(int32(14), result2)
-	is.Equal(uint32(14), result3)
-	is.Equal(uint32(0), result4)
-	is.Equal(complex128(6_6), result5)
+		result := Sum(values[float32](2.3, 3.3, 4, 5.3))
+		is.InEpsilon(14.9, result, 1e-7)
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := Sum(values[int32](2, 3, 4, 5))
+		is.Equal(int32(14), result)
+	})
+
+	t.Run("uint32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		tests := []struct {
+			name     string
+			input    []uint32
+			expected uint32
+		}{
+			{name: "non-empty", input: []uint32{2, 3, 4, 5}, expected: 14},
+			{name: "empty", input: []uint32{}, expected: 0},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				is.Equal(tt.expected, Sum(values(tt.input...)))
+			})
+		}
+	})
+
+	t.Run("complex128", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := Sum(values[complex128](4_4, 2_2))
+		is.Equal(complex128(6_6), result)
+	})
 }
 
 func TestSumBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1 := SumBy(values[float32](2.3, 3.3, 4, 5.3), func(n float32) float32 { return n })
-	result2 := SumBy(values[int32](2, 3, 4, 5), func(n int32) int32 { return n })
-	result3 := SumBy(values[uint32](2, 3, 4, 5), func(n uint32) uint32 { return n })
-	result4 := SumBy(values[uint32](), func(n uint32) uint32 { return n })
-	result5 := SumBy(values[complex128](4_4, 2_2), func(n complex128) complex128 { return n })
+	t.Run("float32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.InEpsilon(14.9, result1, 1e-7)
-	is.Equal(int32(14), result2)
-	is.Equal(uint32(14), result3)
-	is.Equal(uint32(0), result4)
-	is.Equal(complex128(6_6), result5)
+		result := SumBy(values[float32](2.3, 3.3, 4, 5.3), func(n float32) float32 { return n })
+		is.InEpsilon(14.9, result, 1e-7)
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := SumBy(values[int32](2, 3, 4, 5), func(n int32) int32 { return n })
+		is.Equal(int32(14), result)
+	})
+
+	t.Run("uint32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		tests := []struct {
+			name     string
+			input    []uint32
+			expected uint32
+		}{
+			{name: "non-empty", input: []uint32{2, 3, 4, 5}, expected: 14},
+			{name: "empty", input: []uint32{}, expected: 0},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				is.Equal(tt.expected, SumBy(values(tt.input...), func(n uint32) uint32 { return n }))
+			})
+		}
+	})
+
+	t.Run("complex128", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := SumBy(values[complex128](4_4, 2_2), func(n complex128) complex128 { return n })
+		is.Equal(complex128(6_6), result)
+	})
 }
 
 func TestProduct(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1 := Product(values[float32](2.3, 3.3, 4, 5.3))
-	result2 := Product(values[int32](2, 3, 4, 5))
-	result3 := Product(values[int32](7, 8, 9, 0))
-	result4 := Product(values[int32](7, -1, 9, 2))
-	result5 := Product(values[uint32](2, 3, 4, 5))
-	result6 := Product(values[uint32]())
-	result7 := Product(values[complex128](4_4, 2_2))
+	t.Run("float32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.InEpsilon(160.908, result1, 1e-7)
-	is.Equal(int32(120), result2)
-	is.Equal(int32(0), result3)
-	is.Equal(int32(-126), result4)
-	is.Equal(uint32(120), result5)
-	is.Equal(uint32(1), result6)
-	is.Equal(complex128(96_8), result7)
+		result := Product(values[float32](2.3, 3.3, 4, 5.3))
+		is.InEpsilon(160.908, result, 1e-7)
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		tests := []struct {
+			name     string
+			input    []int32
+			expected int32
+		}{
+			{name: "positive values", input: []int32{2, 3, 4, 5}, expected: 120},
+			{name: "contains zero", input: []int32{7, 8, 9, 0}, expected: 0},
+			{name: "contains negative", input: []int32{7, -1, 9, 2}, expected: -126},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				is.Equal(tt.expected, Product(values(tt.input...)))
+			})
+		}
+	})
+
+	t.Run("uint32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		tests := []struct {
+			name     string
+			input    []uint32
+			expected uint32
+		}{
+			{name: "non-empty", input: []uint32{2, 3, 4, 5}, expected: 120},
+			{name: "empty", input: []uint32{}, expected: 1},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				is.Equal(tt.expected, Product(values(tt.input...)))
+			})
+		}
+	})
+
+	t.Run("complex128", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := Product(values[complex128](4_4, 2_2))
+		is.Equal(complex128(96_8), result)
+	})
 }
 
 func TestProductBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1 := ProductBy(values[float32](2.3, 3.3, 4, 5.3), func(n float32) float32 { return n })
-	result2 := ProductBy(values[int32](2, 3, 4, 5), func(n int32) int32 { return n })
-	result3 := ProductBy(values[int32](7, 8, 9, 0), func(n int32) int32 { return n })
-	result4 := ProductBy(values[int32](7, -1, 9, 2), func(n int32) int32 { return n })
-	result5 := ProductBy(values[uint32](2, 3, 4, 5), func(n uint32) uint32 { return n })
-	result6 := ProductBy(values[uint32](), func(n uint32) uint32 { return n })
-	result7 := ProductBy(values[complex128](4_4, 2_2), func(n complex128) complex128 { return n })
+	t.Run("float32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.InEpsilon(160.908, result1, 1e-7)
-	is.Equal(int32(120), result2)
-	is.Equal(int32(0), result3)
-	is.Equal(int32(-126), result4)
-	is.Equal(uint32(120), result5)
-	is.Equal(uint32(1), result6)
-	is.Equal(complex128(96_8), result7)
+		result := ProductBy(values[float32](2.3, 3.3, 4, 5.3), func(n float32) float32 { return n })
+		is.InEpsilon(160.908, result, 1e-7)
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		tests := []struct {
+			name     string
+			input    []int32
+			expected int32
+		}{
+			{name: "positive values", input: []int32{2, 3, 4, 5}, expected: 120},
+			{name: "contains zero", input: []int32{7, 8, 9, 0}, expected: 0},
+			{name: "contains negative", input: []int32{7, -1, 9, 2}, expected: -126},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				is.Equal(tt.expected, ProductBy(values(tt.input...), func(n int32) int32 { return n }))
+			})
+		}
+	})
+
+	t.Run("uint32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		tests := []struct {
+			name     string
+			input    []uint32
+			expected uint32
+		}{
+			{name: "non-empty", input: []uint32{2, 3, 4, 5}, expected: 120},
+			{name: "empty", input: []uint32{}, expected: 1},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				is.Equal(tt.expected, ProductBy(values(tt.input...), func(n uint32) uint32 { return n }))
+			})
+		}
+	})
+
+	t.Run("complex128", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := ProductBy(values[complex128](4_4, 2_2), func(n complex128) complex128 { return n })
+		is.Equal(complex128(96_8), result)
+	})
 }
 
 func TestMean(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1 := Mean(values[float32](2.3, 3.3, 4, 5.3))
-	result2 := Mean(values[int32](2, 3, 4, 5))
-	result3 := Mean(values[uint32](2, 3, 4, 5))
-	result4 := Mean(values[uint32]())
+	t.Run("float32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.InEpsilon(3.725, result1, 1e-7)
-	is.Equal(int32(3), result2)
-	is.Equal(uint32(3), result3)
-	is.Equal(uint32(0), result4)
+		result := Mean(values[float32](2.3, 3.3, 4, 5.3))
+		is.InEpsilon(3.725, result, 1e-7)
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := Mean(values[int32](2, 3, 4, 5))
+		is.Equal(int32(3), result)
+	})
+
+	t.Run("uint32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		tests := []struct {
+			name     string
+			input    []uint32
+			expected uint32
+		}{
+			{name: "non-empty", input: []uint32{2, 3, 4, 5}, expected: 3},
+			{name: "empty", input: []uint32{}, expected: 0},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				is.Equal(tt.expected, Mean(values(tt.input...)))
+			})
+		}
+	})
 }
 
 func TestMeanBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1 := MeanBy(values[float32](2.3, 3.3, 4, 5.3), func(n float32) float32 { return n })
-	result2 := MeanBy(values[int32](2, 3, 4, 5), func(n int32) int32 { return n })
-	result3 := MeanBy(values[uint32](2, 3, 4, 5), func(n uint32) uint32 { return n })
-	result4 := MeanBy(values[uint32](), func(n uint32) uint32 { return n })
+	t.Run("float32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.InEpsilon(3.725, result1, 1e-7)
-	is.Equal(int32(3), result2)
-	is.Equal(uint32(3), result3)
-	is.Equal(uint32(0), result4)
+		result := MeanBy(values[float32](2.3, 3.3, 4, 5.3), func(n float32) float32 { return n })
+		is.InEpsilon(3.725, result, 1e-7)
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := MeanBy(values[int32](2, 3, 4, 5), func(n int32) int32 { return n })
+		is.Equal(int32(3), result)
+	})
+
+	t.Run("uint32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		tests := []struct {
+			name     string
+			input    []uint32
+			expected uint32
+		}{
+			{name: "non-empty", input: []uint32{2, 3, 4, 5}, expected: 3},
+			{name: "empty", input: []uint32{}, expected: 0},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				is.Equal(tt.expected, MeanBy(values(tt.input...), func(n uint32) uint32 { return n }))
+			})
+		}
+	})
 }
 
 func TestMode(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	result1 := Mode(values[float32](2.3, 3.3, 3.3, 5.3))
-	result2 := Mode(values[int32](2, 2, 3, 4))
-	result3 := Mode(values[uint32](2, 2, 3, 3))
-	result4 := Mode(values[uint32]())
-	result5 := Mode(values(1, 2, 3, 4, 5, 6, 7, 8, 9))
+	t.Run("float32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
 
-	is.Equal([]float32{3.3}, result1)
-	is.Equal([]int32{2}, result2)
-	is.Equal([]uint32{2, 3}, result3)
-	is.Empty(result4)
-	is.Equal([]int{1, 2, 3, 4, 5, 6, 7, 8, 9}, result5)
+		result := Mode(values[float32](2.3, 3.3, 3.3, 5.3))
+		is.Equal([]float32{3.3}, result)
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := Mode(values[int32](2, 2, 3, 4))
+		is.Equal([]int32{2}, result)
+	})
+
+	t.Run("uint32", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		tests := []struct {
+			name     string
+			input    []uint32
+			expected []uint32
+		}{
+			{name: "two-way tie", input: []uint32{2, 2, 3, 3}, expected: []uint32{2, 3}},
+			{name: "empty", input: []uint32{}, expected: nil},
+		}
+
+		for _, tt := range tests {
+			tt := tt //nolint:modernize
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result := Mode(values(tt.input...))
+				if tt.expected == nil {
+					is.Empty(result)
+				} else {
+					is.Equal(tt.expected, result)
+				}
+			})
+		}
+	})
+
+	t.Run("int, all unique", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		result := Mode(values(1, 2, 3, 4, 5, 6, 7, 8, 9))
+		is.Equal([]int{1, 2, 3, 4, 5, 6, 7, 8, 9}, result)
+	})
 }
 
 func TestMode_capacityConsistency(t *testing.T) {

--- a/it/math_test.go
+++ b/it/math_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestRange(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -27,6 +26,7 @@ func TestRange(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 
 			result := slices.Collect(Range(tt.n))
 			if tt.expected == nil {
@@ -43,7 +43,6 @@ func TestRangeFrom(t *testing.T) {
 
 	t.Run("int", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name       string
@@ -60,6 +59,7 @@ func TestRangeFrom(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 
 				result := slices.Collect(RangeFrom(tt.start, tt.elementNum))
 				if tt.expected == nil {
@@ -73,7 +73,6 @@ func TestRangeFrom(t *testing.T) {
 
 	t.Run("float64", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name       string
@@ -91,6 +90,7 @@ func TestRangeFrom(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 
 				is.Equal(tt.expected, slices.Collect(RangeFrom(tt.start, tt.elementNum)))
 			})
@@ -103,7 +103,6 @@ func TestRangeWithSteps(t *testing.T) {
 
 	t.Run("int", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name             string
@@ -120,6 +119,7 @@ func TestRangeWithSteps(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 
 				result := slices.Collect(RangeWithSteps(tt.start, tt.end, tt.step))
 				if tt.expected == nil {
@@ -133,7 +133,6 @@ func TestRangeWithSteps(t *testing.T) {
 
 	t.Run("float64", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name             string
@@ -150,6 +149,7 @@ func TestRangeWithSteps(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 
 				is.Equal(tt.expected, slices.Collect(RangeWithSteps(tt.start, tt.end, tt.step)))
 			})
@@ -196,7 +196,6 @@ func TestSum(t *testing.T) {
 
 	t.Run("uint32", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name     string
@@ -211,6 +210,7 @@ func TestSum(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 
 				is.Equal(tt.expected, Sum(values(tt.input...)))
 			})
@@ -247,7 +247,6 @@ func TestSumBy(t *testing.T) {
 
 	t.Run("uint32", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name     string
@@ -262,6 +261,7 @@ func TestSumBy(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 
 				is.Equal(tt.expected, SumBy(values(tt.input...), func(n uint32) uint32 { return n }))
 			})
@@ -290,7 +290,6 @@ func TestProduct(t *testing.T) {
 
 	t.Run("int32", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name     string
@@ -306,6 +305,7 @@ func TestProduct(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 
 				is.Equal(tt.expected, Product(values(tt.input...)))
 			})
@@ -314,7 +314,6 @@ func TestProduct(t *testing.T) {
 
 	t.Run("uint32", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name     string
@@ -329,6 +328,7 @@ func TestProduct(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 
 				is.Equal(tt.expected, Product(values(tt.input...)))
 			})
@@ -357,7 +357,6 @@ func TestProductBy(t *testing.T) {
 
 	t.Run("int32", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name     string
@@ -373,6 +372,7 @@ func TestProductBy(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 
 				is.Equal(tt.expected, ProductBy(values(tt.input...), func(n int32) int32 { return n }))
 			})
@@ -381,7 +381,6 @@ func TestProductBy(t *testing.T) {
 
 	t.Run("uint32", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name     string
@@ -396,6 +395,7 @@ func TestProductBy(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 
 				is.Equal(tt.expected, ProductBy(values(tt.input...), func(n uint32) uint32 { return n }))
 			})
@@ -432,7 +432,6 @@ func TestMean(t *testing.T) {
 
 	t.Run("uint32", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name     string
@@ -447,6 +446,7 @@ func TestMean(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 
 				is.Equal(tt.expected, Mean(values(tt.input...)))
 			})
@@ -475,7 +475,6 @@ func TestMeanBy(t *testing.T) {
 
 	t.Run("uint32", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name     string
@@ -490,6 +489,7 @@ func TestMeanBy(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 
 				is.Equal(tt.expected, MeanBy(values(tt.input...), func(n uint32) uint32 { return n }))
 			})
@@ -518,7 +518,6 @@ func TestMode(t *testing.T) {
 
 	t.Run("uint32", func(t *testing.T) {
 		t.Parallel()
-		is := assert.New(t)
 
 		tests := []struct {
 			name     string
@@ -533,6 +532,7 @@ func TestMode(t *testing.T) {
 			tt := tt //nolint:modernize
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				is := assert.New(t)
 
 				result := Mode(values(tt.input...))
 				if tt.expected == nil {

--- a/it/seq_test.go
+++ b/it/seq_test.go
@@ -19,11 +19,22 @@ func TestLength(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := Length(values[int]())
-	r2 := Length(values(1, 2, 3, 4))
+	tests := []struct {
+		name     string
+		input    []int
+		expected int
+	}{
+		{name: "empty", input: []int{}, expected: 0},
+		{name: "four elements", input: []int{1, 2, 3, 4}, expected: 4},
+	}
 
-	is.Zero(r1)
-	is.Equal(4, r2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, Length(values(tt.input...)))
+		})
+	}
 }
 
 func TestDrain(t *testing.T) {
@@ -46,74 +57,104 @@ func TestFilter(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := Filter(values(1, 2, 3, 4), func(x int) bool {
-		return x%2 == 0
+	t.Run("int evens", func(t *testing.T) {
+		t.Parallel()
+		r1 := Filter(values(1, 2, 3, 4), func(x int) bool {
+			return x%2 == 0
+		})
+		is.Equal([]int{2, 4}, slices.Collect(r1))
 	})
-	is.Equal([]int{2, 4}, slices.Collect(r1))
 
-	r2 := Filter(values("", "foo", "", "bar", ""), func(x string) bool {
-		return len(x) > 0
+	t.Run("non-empty strings", func(t *testing.T) {
+		t.Parallel()
+		r2 := Filter(values("", "foo", "", "bar", ""), func(x string) bool {
+			return len(x) > 0
+		})
+		is.Equal([]string{"foo", "bar"}, slices.Collect(r2))
 	})
-	is.Equal([]string{"foo", "bar"}, slices.Collect(r2))
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Filter(allStrings, func(x string) bool {
-		return len(x) > 0
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Filter(allStrings, func(x string) bool {
+			return len(x) > 0
+		})
+		is.IsType(nonempty, allStrings, "type preserved")
 	})
-	is.IsType(nonempty, allStrings, "type preserved")
 }
 
 func TestFilterI(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := FilterI(values(1, 2, 3, 4), func(x, _ int) bool {
-		return x%2 == 0
+	t.Run("int evens", func(t *testing.T) {
+		t.Parallel()
+		r1 := FilterI(values(1, 2, 3, 4), func(x, _ int) bool {
+			return x%2 == 0
+		})
+		is.Equal([]int{2, 4}, slices.Collect(r1))
 	})
-	is.Equal([]int{2, 4}, slices.Collect(r1))
 
-	r2 := FilterI(values("", "foo", "", "bar", ""), func(x string, _ int) bool {
-		return len(x) > 0
+	t.Run("non-empty strings", func(t *testing.T) {
+		t.Parallel()
+		r2 := FilterI(values("", "foo", "", "bar", ""), func(x string, _ int) bool {
+			return len(x) > 0
+		})
+		is.Equal([]string{"foo", "bar"}, slices.Collect(r2))
 	})
-	is.Equal([]string{"foo", "bar"}, slices.Collect(r2))
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := FilterI(allStrings, func(x string, _ int) bool {
-		return len(x) > 0
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := FilterI(allStrings, func(x string, _ int) bool {
+			return len(x) > 0
+		})
+		is.IsType(nonempty, allStrings, "type preserved")
 	})
-	is.IsType(nonempty, allStrings, "type preserved")
 }
 
 func TestMap(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Map(values(1, 2, 3, 4), func(x int) string {
-		return "Hello"
-	})
-	result2 := Map(values[int64](1, 2, 3, 4), func(x int64) string {
-		return strconv.FormatInt(x, 10)
+	t.Run("int to constant string", func(t *testing.T) {
+		t.Parallel()
+		result1 := Map(values(1, 2, 3, 4), func(x int) string {
+			return "Hello"
+		})
+		is.Equal([]string{"Hello", "Hello", "Hello", "Hello"}, slices.Collect(result1))
 	})
 
-	is.Equal([]string{"Hello", "Hello", "Hello", "Hello"}, slices.Collect(result1))
-	is.Equal([]string{"1", "2", "3", "4"}, slices.Collect(result2))
+	t.Run("int64 to formatted string", func(t *testing.T) {
+		t.Parallel()
+		result2 := Map(values[int64](1, 2, 3, 4), func(x int64) string {
+			return strconv.FormatInt(x, 10)
+		})
+		is.Equal([]string{"1", "2", "3", "4"}, slices.Collect(result2))
+	})
 }
 
 func TestMapI(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := MapI(values(1, 2, 3, 4), func(x, _ int) string {
-		return "Hello"
-	})
-	result2 := MapI(values[int64](1, 2, 3, 4), func(x int64, _ int) string {
-		return strconv.FormatInt(x, 10)
+	t.Run("int to constant string", func(t *testing.T) {
+		t.Parallel()
+		result1 := MapI(values(1, 2, 3, 4), func(x, _ int) string {
+			return "Hello"
+		})
+		is.Equal([]string{"Hello", "Hello", "Hello", "Hello"}, slices.Collect(result1))
 	})
 
-	is.Equal([]string{"Hello", "Hello", "Hello", "Hello"}, slices.Collect(result1))
-	is.Equal([]string{"1", "2", "3", "4"}, slices.Collect(result2))
+	t.Run("int64 to formatted string", func(t *testing.T) {
+		t.Parallel()
+		result2 := MapI(values[int64](1, 2, 3, 4), func(x int64, _ int) string {
+			return strconv.FormatInt(x, 10)
+		})
+		is.Equal([]string{"1", "2", "3", "4"}, slices.Collect(result2))
+	})
 }
 
 func TestUniqMap(t *testing.T) {
@@ -154,84 +195,108 @@ func TestFilterMap(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := FilterMap(values[int64](1, 2, 3, 4), func(x int64) (string, bool) {
-		if x%2 == 0 {
-			return strconv.FormatInt(x, 10), true
-		}
-		return "", false
-	})
-	r2 := FilterMap(values("cpu", "gpu", "mouse", "keyboard"), func(x string) (string, bool) {
-		if strings.HasSuffix(x, "pu") {
-			return "xpu", true
-		}
-		return "", false
+	t.Run("int64 evens formatted", func(t *testing.T) {
+		t.Parallel()
+		r1 := FilterMap(values[int64](1, 2, 3, 4), func(x int64) (string, bool) {
+			if x%2 == 0 {
+				return strconv.FormatInt(x, 10), true
+			}
+			return "", false
+		})
+		is.Equal([]string{"2", "4"}, slices.Collect(r1))
 	})
 
-	is.Equal([]string{"2", "4"}, slices.Collect(r1))
-	is.Equal([]string{"xpu", "xpu"}, slices.Collect(r2))
+	t.Run("string suffix match", func(t *testing.T) {
+		t.Parallel()
+		r2 := FilterMap(values("cpu", "gpu", "mouse", "keyboard"), func(x string) (string, bool) {
+			if strings.HasSuffix(x, "pu") {
+				return "xpu", true
+			}
+			return "", false
+		})
+		is.Equal([]string{"xpu", "xpu"}, slices.Collect(r2))
+	})
 }
 
 func TestFilterMapI(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := FilterMapI(values[int64](1, 2, 3, 4), func(x int64, _ int) (string, bool) {
-		if x%2 == 0 {
-			return strconv.FormatInt(x, 10), true
-		}
-		return "", false
-	})
-	r2 := FilterMapI(values("cpu", "gpu", "mouse", "keyboard"), func(x string, _ int) (string, bool) {
-		if strings.HasSuffix(x, "pu") {
-			return "xpu", true
-		}
-		return "", false
+	t.Run("int64 evens formatted", func(t *testing.T) {
+		t.Parallel()
+		r1 := FilterMapI(values[int64](1, 2, 3, 4), func(x int64, _ int) (string, bool) {
+			if x%2 == 0 {
+				return strconv.FormatInt(x, 10), true
+			}
+			return "", false
+		})
+		is.Equal([]string{"2", "4"}, slices.Collect(r1))
 	})
 
-	is.Equal([]string{"2", "4"}, slices.Collect(r1))
-	is.Equal([]string{"xpu", "xpu"}, slices.Collect(r2))
+	t.Run("string suffix match", func(t *testing.T) {
+		t.Parallel()
+		r2 := FilterMapI(values("cpu", "gpu", "mouse", "keyboard"), func(x string, _ int) (string, bool) {
+			if strings.HasSuffix(x, "pu") {
+				return "xpu", true
+			}
+			return "", false
+		})
+		is.Equal([]string{"xpu", "xpu"}, slices.Collect(r2))
+	})
 }
 
 func TestFlatMap(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := FlatMap(values(0, 1, 2, 3, 4), func(x int) iter.Seq[string] {
-		return values("Hello")
-	})
-	result2 := FlatMap(values[int64](0, 1, 2, 3, 4), func(x int64) iter.Seq[string] {
-		return func(yield func(string) bool) {
-			for range x {
-				if !yield(strconv.FormatInt(x, 10)) {
-					return
-				}
-			}
-		}
+	t.Run("int to constant string", func(t *testing.T) {
+		t.Parallel()
+		result1 := FlatMap(values(0, 1, 2, 3, 4), func(x int) iter.Seq[string] {
+			return values("Hello")
+		})
+		is.Equal([]string{"Hello", "Hello", "Hello", "Hello", "Hello"}, slices.Collect(result1))
 	})
 
-	is.Equal([]string{"Hello", "Hello", "Hello", "Hello", "Hello"}, slices.Collect(result1))
-	is.Equal([]string{"1", "2", "2", "3", "3", "3", "4", "4", "4", "4"}, slices.Collect(result2))
+	t.Run("int64 repeated by value", func(t *testing.T) {
+		t.Parallel()
+		result2 := FlatMap(values[int64](0, 1, 2, 3, 4), func(x int64) iter.Seq[string] {
+			return func(yield func(string) bool) {
+				for range x {
+					if !yield(strconv.FormatInt(x, 10)) {
+						return
+					}
+				}
+			}
+		})
+		is.Equal([]string{"1", "2", "2", "3", "3", "3", "4", "4", "4", "4"}, slices.Collect(result2))
+	})
 }
 
 func TestFlatMapI(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := FlatMapI(values(0, 1, 2, 3, 4), func(x, _ int) iter.Seq[string] {
-		return values("Hello")
-	})
-	result2 := FlatMapI(values[int64](0, 1, 2, 3, 4), func(x int64, _ int) iter.Seq[string] {
-		return func(yield func(string) bool) {
-			for range x {
-				if !yield(strconv.FormatInt(x, 10)) {
-					return
-				}
-			}
-		}
+	t.Run("int to constant string", func(t *testing.T) {
+		t.Parallel()
+		result1 := FlatMapI(values(0, 1, 2, 3, 4), func(x, _ int) iter.Seq[string] {
+			return values("Hello")
+		})
+		is.Equal([]string{"Hello", "Hello", "Hello", "Hello", "Hello"}, slices.Collect(result1))
 	})
 
-	is.Equal([]string{"Hello", "Hello", "Hello", "Hello", "Hello"}, slices.Collect(result1))
-	is.Equal([]string{"1", "2", "2", "3", "3", "3", "4", "4", "4", "4"}, slices.Collect(result2))
+	t.Run("int64 repeated by value", func(t *testing.T) {
+		t.Parallel()
+		result2 := FlatMapI(values[int64](0, 1, 2, 3, 4), func(x int64, _ int) iter.Seq[string] {
+			return func(yield func(string) bool) {
+				for range x {
+					if !yield(strconv.FormatInt(x, 10)) {
+						return
+					}
+				}
+			}
+		})
+		is.Equal([]string{"1", "2", "2", "3", "3", "3", "4", "4", "4", "4"}, slices.Collect(result2))
+	})
 }
 
 func TestTimes(t *testing.T) {
@@ -248,60 +313,92 @@ func TestReduce(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Reduce(values(1, 2, 3, 4), func(agg, item int) int {
-		return agg + item
-	}, 0)
-	result2 := Reduce(values(1, 2, 3, 4), func(agg, item int) int {
-		return agg + item
-	}, 10)
+	tests := []struct {
+		name     string
+		seed     int
+		expected int
+	}{
+		{name: "seed zero", seed: 0, expected: 10},
+		{name: "seed ten", seed: 10, expected: 20},
+	}
 
-	is.Equal(10, result1)
-	is.Equal(20, result2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := Reduce(values(1, 2, 3, 4), func(agg, item int) int {
+				return agg + item
+			}, tt.seed)
+			is.Equal(tt.expected, result)
+		})
+	}
 }
 
 func TestReduceI(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := ReduceI(values(1, 2, 3, 4), func(agg, item, _ int) int {
-		return agg + item
-	}, 0)
-	result2 := ReduceI(values(1, 2, 3, 4), func(agg, item, _ int) int {
-		return agg + item
-	}, 10)
+	tests := []struct {
+		name     string
+		seed     int
+		expected int
+	}{
+		{name: "seed zero", seed: 0, expected: 10},
+		{name: "seed ten", seed: 10, expected: 20},
+	}
 
-	is.Equal(10, result1)
-	is.Equal(20, result2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := ReduceI(values(1, 2, 3, 4), func(agg, item, _ int) int {
+				return agg + item
+			}, tt.seed)
+			is.Equal(tt.expected, result)
+		})
+	}
 }
 
 func TestReduceLast(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := ReduceLast(values([]int{0, 1}, []int{2, 3}, []int{4, 5}), func(agg, item []int) []int {
-		return append(agg, item...)
-	}, []int{})
-	is.Equal([]int{4, 5, 2, 3, 0, 1}, result1)
+	t.Run("slice concatenation", func(t *testing.T) {
+		t.Parallel()
+		result1 := ReduceLast(values([]int{0, 1}, []int{2, 3}, []int{4, 5}), func(agg, item []int) []int {
+			return append(agg, item...)
+		}, []int{})
+		is.Equal([]int{4, 5, 2, 3, 0, 1}, result1)
+	})
 
-	result2 := ReduceLast(values(1, 2, 3, 4), func(agg, item int) int {
-		return agg + item
-	}, 10)
-	is.Equal(20, result2)
+	t.Run("int sum", func(t *testing.T) {
+		t.Parallel()
+		result2 := ReduceLast(values(1, 2, 3, 4), func(agg, item int) int {
+			return agg + item
+		}, 10)
+		is.Equal(20, result2)
+	})
 }
 
 func TestReduceLastI(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := ReduceLastI(values([]int{0, 1}, []int{2, 3}, []int{4, 5}), func(agg, item []int, _ int) []int {
-		return append(agg, item...)
-	}, []int{})
-	is.Equal([]int{4, 5, 2, 3, 0, 1}, result1)
+	t.Run("slice concatenation", func(t *testing.T) {
+		t.Parallel()
+		result1 := ReduceLastI(values([]int{0, 1}, []int{2, 3}, []int{4, 5}), func(agg, item []int, _ int) []int {
+			return append(agg, item...)
+		}, []int{})
+		is.Equal([]int{4, 5, 2, 3, 0, 1}, result1)
+	})
 
-	result2 := ReduceLastI(values(1, 2, 3, 4), func(agg, item, _ int) int {
-		return agg + item
-	}, 10)
-	is.Equal(20, result2)
+	t.Run("int sum", func(t *testing.T) {
+		t.Parallel()
+		result2 := ReduceLastI(values(1, 2, 3, 4), func(agg, item, _ int) int {
+			return agg + item
+		}, 10)
+		is.Equal(20, result2)
+	})
 }
 
 func TestForEachI(t *testing.T) {
@@ -350,30 +447,42 @@ func TestUniq(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Uniq(values(1, 2, 2, 1))
-	is.Equal([]int{1, 2}, slices.Collect(result1))
+	t.Run("int dedup", func(t *testing.T) {
+		t.Parallel()
+		result1 := Uniq(values(1, 2, 2, 1))
+		is.Equal([]int{1, 2}, slices.Collect(result1))
+	})
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Uniq(allStrings)
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Uniq(allStrings)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestUniqBy(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := UniqBy(values(0, 1, 2, 3, 4, 5), func(i int) int {
-		return i % 3
+	t.Run("int mod dedup", func(t *testing.T) {
+		t.Parallel()
+		result1 := UniqBy(values(0, 1, 2, 3, 4, 5), func(i int) int {
+			return i % 3
+		})
+		is.Equal([]int{0, 1, 2}, slices.Collect(result1))
 	})
-	is.Equal([]int{0, 1, 2}, slices.Collect(result1))
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := UniqBy(allStrings, func(i string) string {
-		return i
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := UniqBy(allStrings, func(i string) string {
+			return i
+		})
+		is.IsType(nonempty, allStrings, "type preserved")
 	})
-	is.IsType(nonempty, allStrings, "type preserved")
 }
 
 func TestGroupBy(t *testing.T) {
@@ -394,61 +503,84 @@ func TestGroupByMap(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := GroupByMap(values(0, 1, 2, 3, 4, 5), func(i int) (int, string) {
-		return i % 3, strconv.Itoa(i)
+	t.Run("int keys", func(t *testing.T) {
+		t.Parallel()
+		result1 := GroupByMap(values(0, 1, 2, 3, 4, 5), func(i int) (int, string) {
+			return i % 3, strconv.Itoa(i)
+		})
+		is.Equal(map[int][]string{
+			0: {"0", "3"},
+			1: {"1", "4"},
+			2: {"2", "5"},
+		}, result1)
 	})
-	is.Equal(map[int][]string{
-		0: {"0", "3"},
-		1: {"1", "4"},
-		2: {"2", "5"},
-	}, result1)
 
-	type myInt int
-	result2 := GroupByMap(values[myInt](1, 0, 2, 3, 4, 5), func(i myInt) (int, string) {
-		return int(i % 3), strconv.Itoa(int(i))
+	t.Run("named int type keys", func(t *testing.T) {
+		t.Parallel()
+		type myInt int
+		result2 := GroupByMap(values[myInt](1, 0, 2, 3, 4, 5), func(i myInt) (int, string) {
+			return int(i % 3), strconv.Itoa(int(i))
+		})
+		is.Equal(map[int][]string{
+			0: {"0", "3"},
+			1: {"1", "4"},
+			2: {"2", "5"},
+		}, result2)
 	})
-	is.Equal(map[int][]string{
-		0: {"0", "3"},
-		1: {"1", "4"},
-		2: {"2", "5"},
-	}, result2)
 
-	type product struct {
-		ID         int64
-		CategoryID int64
-	}
-	products := values(
-		product{ID: 1, CategoryID: 1},
-		product{ID: 2, CategoryID: 1},
-		product{ID: 3, CategoryID: 2},
-		product{ID: 4, CategoryID: 3},
-		product{ID: 5, CategoryID: 3},
-	)
-	result3 := GroupByMap(products, func(item product) (int64, string) {
-		return item.CategoryID, "Product " + strconv.FormatInt(item.ID, 10)
+	t.Run("struct keys", func(t *testing.T) {
+		t.Parallel()
+		type product struct {
+			ID         int64
+			CategoryID int64
+		}
+		products := values(
+			product{ID: 1, CategoryID: 1},
+			product{ID: 2, CategoryID: 1},
+			product{ID: 3, CategoryID: 2},
+			product{ID: 4, CategoryID: 3},
+			product{ID: 5, CategoryID: 3},
+		)
+		result3 := GroupByMap(products, func(item product) (int64, string) {
+			return item.CategoryID, "Product " + strconv.FormatInt(item.ID, 10)
+		})
+		is.Equal(map[int64][]string{
+			1: {"Product 1", "Product 2"},
+			2: {"Product 3"},
+			3: {"Product 4", "Product 5"},
+		}, result3)
 	})
-	is.Equal(map[int64][]string{
-		1: {"Product 1", "Product 2"},
-		2: {"Product 3"},
-		3: {"Product 4", "Product 5"},
-	}, result3)
 }
 
 func TestChunk(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Chunk(values(0, 1, 2, 3, 4, 5), 2)
-	result2 := Chunk(values(0, 1, 2, 3, 4, 5, 6), 2)
-	result3 := Chunk(values[int](), 2)
-	result4 := Chunk(values(0), 2)
+	tests := []struct {
+		name     string
+		input    []int
+		size     int
+		expected [][]int
+	}{
+		{name: "even split", input: []int{0, 1, 2, 3, 4, 5}, size: 2, expected: [][]int{{0, 1}, {2, 3}, {4, 5}}},
+		{name: "uneven split", input: []int{0, 1, 2, 3, 4, 5, 6}, size: 2, expected: [][]int{{0, 1}, {2, 3}, {4, 5}, {6}}},
+		{name: "empty", input: []int{}, size: 2, expected: nil},
+		{name: "single element", input: []int{0}, size: 2, expected: [][]int{{0}}},
+	}
 
-	is.Equal([][]int{{0, 1}, {2, 3}, {4, 5}}, slices.Collect(result1))
-	is.Equal([][]int{{0, 1}, {2, 3}, {4, 5}, {6}}, slices.Collect(result2))
-	is.Empty(slices.Collect(result3))
-	is.Equal([][]int{{0}}, slices.Collect(result4))
-	is.PanicsWithValue("it.Chunk: size must be greater than 0", func() {
-		Chunk(values(0), 0)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(Chunk(values(tt.input...), tt.size)))
+		})
+	}
+
+	t.Run("panics on non-positive size", func(t *testing.T) {
+		t.Parallel()
+		is.PanicsWithValue("it.Chunk: size must be greater than 0", func() {
+			Chunk(values(0), 0)
+		})
 	})
 }
 
@@ -456,24 +588,39 @@ func TestWindow(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Window(values(1, 2, 3, 4, 5), 3)
-	result2 := Window(values(1, 2, 3, 4, 5, 6), 3)
-	result3 := Window(values(1, 2), 3)
-	result4 := Window(values(1, 2, 3), 3)
-	result5 := Window(values(1, 2, 3, 4), 1)
+	tests := []struct {
+		name     string
+		input    []int
+		size     int
+		expected [][]int
+	}{
+		{name: "five elements size three", input: []int{1, 2, 3, 4, 5}, size: 3, expected: [][]int{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}}},
+		{name: "six elements size three", input: []int{1, 2, 3, 4, 5, 6}, size: 3, expected: [][]int{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}, {4, 5, 6}}},
+		{name: "shorter than size", input: []int{1, 2}, size: 3, expected: nil},
+		{name: "exactly size", input: []int{1, 2, 3}, size: 3, expected: [][]int{{1, 2, 3}}},
+		{name: "size one", input: []int{1, 2, 3, 4}, size: 1, expected: [][]int{{1}, {2}, {3}, {4}}},
+	}
 
-	is.Equal([][]int{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}}, slices.Collect(result1))
-	is.Equal([][]int{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}, {4, 5, 6}}, slices.Collect(result2))
-	is.Empty(slices.Collect(result3))
-	is.Equal([][]int{{1, 2, 3}}, slices.Collect(result4))
-	is.Equal([][]int{{1}, {2}, {3}, {4}}, slices.Collect(result5))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(Window(values(tt.input...), tt.size)))
+		})
+	}
 
-	is.PanicsWithValue("it.Window: size must be greater than 0", func() {
-		Window(values(1, 2, 3), 0)
+	t.Run("panics on zero size", func(t *testing.T) {
+		t.Parallel()
+		is.PanicsWithValue("it.Window: size must be greater than 0", func() {
+			Window(values(1, 2, 3), 0)
+		})
 	})
 
-	is.PanicsWithValue("it.Window: size must be greater than 0", func() {
-		Window(values(1, 2, 3), -1)
+	t.Run("panics on negative size", func(t *testing.T) {
+		t.Parallel()
+		is.PanicsWithValue("it.Window: size must be greater than 0", func() {
+			Window(values(1, 2, 3), -1)
+		})
 	})
 }
 
@@ -481,172 +628,141 @@ func TestSliding(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Sliding(values(1, 2, 3, 4, 5, 6), 3, 1)
-	is.Equal([][]int{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}, {4, 5, 6}}, slices.Collect(result1))
-
-	result2 := Sliding(values(1, 2, 3, 4, 5, 6), 3, 3)
-	is.Equal([][]int{{1, 2, 3}, {4, 5, 6}}, slices.Collect(result2))
-
-	result3 := Sliding(values(1, 2, 3, 4, 5, 6, 7, 8), 2, 3)
-	is.Equal([][]int{{1, 2}, {4, 5}, {7, 8}}, slices.Collect(result3))
-
-	result4 := Sliding(values(1, 2, 3, 4), 1, 1)
-	is.Equal([][]int{{1}, {2}, {3}, {4}}, slices.Collect(result4))
-
-	result5 := Sliding(values(1, 2), 3, 1)
-	is.Empty(slices.Collect(result5))
-
-	result6 := Sliding(values(1, 2, 3, 4, 5, 6), 2, 2)
-	is.Equal([][]int{{1, 2}, {3, 4}, {5, 6}}, slices.Collect(result6))
-
-	is.PanicsWithValue("it.Sliding: size must be greater than 0", func() {
-		Sliding(values(1, 2, 3), 0, 1)
-	})
-
-	is.PanicsWithValue("it.Sliding: step must be greater than 0", func() {
-		Sliding(values(1, 2, 3), 2, 0)
-	})
-
-	is.PanicsWithValue("it.Sliding: step must be greater than 0", func() {
-		Sliding(values(1, 2, 3), 2, -1)
-	})
-
-	// Test overlapping windows (step < size)
-	result7 := Sliding(values(1, 2, 3, 4, 5), 3, 2)
-	is.Equal([][]int{{1, 2, 3}, {3, 4, 5}}, slices.Collect(result7))
-
-	// Test with step > size (non-overlapping with gaps)
-	result8 := Sliding(values(1, 2, 3, 4, 5, 6, 7, 8), 2, 4)
-	is.Equal([][]int{{1, 2}, {5, 6}}, slices.Collect(result8))
-
-	// Test empty collection
-	result9 := Sliding(values[int](), 2, 1)
-	is.Empty(slices.Collect(result9))
-
-	// Test collection exactly equal to size (one window)
-	result10 := Sliding(values(1, 2, 3), 3, 1)
-	is.Equal([][]int{{1, 2, 3}}, slices.Collect(result10))
-
-	// Test collection exactly equal to size with step=3
-	result11 := Sliding(values(1, 2, 3), 3, 3)
-	is.Equal([][]int{{1, 2, 3}}, slices.Collect(result11))
-
-	// Test collection just larger than size (two windows)
-	result12 := Sliding(values(1, 2, 3, 4), 3, 1)
-	is.Equal([][]int{{1, 2, 3}, {2, 3, 4}}, slices.Collect(result12))
-
-	// Test size=1 with different steps
-	result13 := Sliding(values(1, 2, 3, 4, 5), 1, 2)
-	is.Equal([][]int{{1}, {3}, {5}}, slices.Collect(result13))
-
-	result14 := Sliding(values(1, 2, 3, 4, 5), 1, 3)
-	is.Equal([][]int{{1}, {4}}, slices.Collect(result14))
-
-	// Test very large step (only first window)
-	result15 := Sliding(values(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2, 100)
-	is.Equal([][]int{{1, 2}}, slices.Collect(result15))
-
-	// Test step=1 with large size (maximum overlap)
-	result16 := Sliding(values(1, 2, 3, 4, 5), 4, 1)
-	is.Equal([][]int{{1, 2, 3, 4}, {2, 3, 4, 5}}, slices.Collect(result16))
-
-	// Test with strings
-	result17 := Sliding(values("a", "b", "c", "d"), 2, 1)
-	is.Equal([][]string{{"a", "b"}, {"b", "c"}, {"c", "d"}}, slices.Collect(result17))
-
-	// Test with structs
-	type Person struct {
-		Name string
-		Age  int
+	tests := []struct {
+		name     string
+		input    []int
+		size     int
+		step     int
+		expected [][]int
+	}{
+		{name: "step less than size (overlap)", input: []int{1, 2, 3, 4, 5, 6}, size: 3, step: 1, expected: [][]int{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}, {4, 5, 6}}},
+		{name: "step equals size (no overlap)", input: []int{1, 2, 3, 4, 5, 6}, size: 3, step: 3, expected: [][]int{{1, 2, 3}, {4, 5, 6}}},
+		{name: "step greater than size (gaps)", input: []int{1, 2, 3, 4, 5, 6, 7, 8}, size: 2, step: 3, expected: [][]int{{1, 2}, {4, 5}, {7, 8}}},
+		{name: "size one step one", input: []int{1, 2, 3, 4}, size: 1, step: 1, expected: [][]int{{1}, {2}, {3}, {4}}},
+		{name: "collection shorter than size", input: []int{1, 2}, size: 3, step: 1, expected: nil},
+		{name: "size equals step two", input: []int{1, 2, 3, 4, 5, 6}, size: 2, step: 2, expected: [][]int{{1, 2}, {3, 4}, {5, 6}}},
+		{name: "overlapping windows step less than size", input: []int{1, 2, 3, 4, 5}, size: 3, step: 2, expected: [][]int{{1, 2, 3}, {3, 4, 5}}},
+		{name: "step greater than size with gaps", input: []int{1, 2, 3, 4, 5, 6, 7, 8}, size: 2, step: 4, expected: [][]int{{1, 2}, {5, 6}}},
+		{name: "empty collection", input: []int{}, size: 2, step: 1, expected: nil},
+		{name: "collection exactly equal to size step 1", input: []int{1, 2, 3}, size: 3, step: 1, expected: [][]int{{1, 2, 3}}},
+		{name: "collection exactly equal to size step 3", input: []int{1, 2, 3}, size: 3, step: 3, expected: [][]int{{1, 2, 3}}},
+		{name: "collection just larger than size", input: []int{1, 2, 3, 4}, size: 3, step: 1, expected: [][]int{{1, 2, 3}, {2, 3, 4}}},
+		{name: "size one step two", input: []int{1, 2, 3, 4, 5}, size: 1, step: 2, expected: [][]int{{1}, {3}, {5}}},
+		{name: "size one step three", input: []int{1, 2, 3, 4, 5}, size: 1, step: 3, expected: [][]int{{1}, {4}}},
+		{name: "very large step (only first window)", input: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, size: 2, step: 100, expected: [][]int{{1, 2}}},
+		{name: "step one large size (maximum overlap)", input: []int{1, 2, 3, 4, 5}, size: 4, step: 1, expected: [][]int{{1, 2, 3, 4}, {2, 3, 4, 5}}},
+		{name: "size equals collection length with step greater than size", input: []int{1, 2, 3}, size: 3, step: 5, expected: [][]int{{1, 2, 3}}},
+		{name: "step one size two on single element", input: []int{1}, size: 2, step: 1, expected: nil},
+		{name: "large collection with small windows", input: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, size: 2, step: 2, expected: [][]int{{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}}},
+		{name: "overlapping step two size four (only full windows)", input: []int{1, 2, 3, 4, 5, 6, 7}, size: 4, step: 2, expected: [][]int{{1, 2, 3, 4}, {3, 4, 5, 6}}},
+		{name: "size five step three on seven elements (only full windows)", input: []int{1, 2, 3, 4, 5, 6, 7}, size: 5, step: 3, expected: [][]int{{1, 2, 3, 4, 5}}},
+		{name: "collection size exactly size+step-1 (two overlapping windows)", input: []int{1, 2, 3, 4, 5}, size: 3, step: 2, expected: [][]int{{1, 2, 3}, {3, 4, 5}}},
+		{name: "large size small step large collection (only full windows)", input: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, size: 5, step: 3, expected: [][]int{{1, 2, 3, 4, 5}, {4, 5, 6, 7, 8}, {7, 8, 9, 10, 11}}},
+		{name: "size equals step equals one", input: []int{1, 2, 3, 4, 5}, size: 1, step: 1, expected: [][]int{{1}, {2}, {3}, {4}, {5}}},
+		{name: "zero elements in collection", input: []int{}, size: 1, step: 1, expected: nil},
+		{name: "last window exactly size elements", input: []int{1, 2, 3, 4, 5, 6}, size: 3, step: 3, expected: [][]int{{1, 2, 3}, {4, 5, 6}}},
 	}
-	people := values(
-		Person{"Alice", 25},
-		Person{"Bob", 30},
-		Person{"Charlie", 35},
-		Person{"Diana", 40},
-	)
-	result18 := Sliding(people, 2, 1)
-	collected := slices.Collect(result18)
-	is.Len(collected, 3)
-	is.Equal(Person{"Alice", 25}, collected[0][0])
-	is.Equal(Person{"Bob", 30}, collected[0][1])
-	is.Equal(Person{"Bob", 30}, collected[1][0])
-	is.Equal(Person{"Charlie", 35}, collected[1][1])
 
-	// Test size equals collection length with step > size (only one window)
-	result19 := Sliding(values(1, 2, 3), 3, 5)
-	is.Equal([][]int{{1, 2, 3}}, slices.Collect(result19))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(Sliding(values(tt.input...), tt.size, tt.step)))
+		})
+	}
 
-	// Test step=1 with size=2 on single element
-	result20 := Sliding(values(1), 2, 1)
-	is.Empty(slices.Collect(result20))
-
-	// Test large collection with small windows
-	result21 := Sliding(values(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 2, 2)
-	is.Equal([][]int{{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}}, slices.Collect(result21))
-
-	// Test overlapping with step=2, size=4 (only full windows are returned)
-	result22 := Sliding(values(1, 2, 3, 4, 5, 6, 7), 4, 2)
-	is.Equal([][]int{{1, 2, 3, 4}, {3, 4, 5, 6}}, slices.Collect(result22))
-
-	// Test with float64
-	result23 := Sliding(values(1.1, 2.2, 3.3, 4.4), 2, 1)
-	is.Equal([][]float64{{1.1, 2.2}, {2.2, 3.3}, {3.3, 4.4}}, slices.Collect(result23))
-
-	// Test with bool
-	result24 := Sliding(values(true, false, true, false, true), 3, 2)
-	is.Equal([][]bool{{true, false, true}, {true, false, true}}, slices.Collect(result24))
-
-	// Test size=5, step=3 on collection of 7 elements (only full windows are returned)
-	result25 := Sliding(values(1, 2, 3, 4, 5, 6, 7), 5, 3)
-	is.Equal([][]int{{1, 2, 3, 4, 5}}, slices.Collect(result25))
-
-	// Test when collection size is exactly size + step - 1 (two windows with overlap)
-	result26 := Sliding(values(1, 2, 3, 4, 5), 3, 2)
-	is.Equal([][]int{{1, 2, 3}, {3, 4, 5}}, slices.Collect(result26))
-
-	// Test with negative size should panic
-	is.PanicsWithValue("it.Sliding: size must be greater than 0", func() {
-		Sliding(values(1, 2, 3), -1, 1)
+	t.Run("panics on zero size", func(t *testing.T) {
+		t.Parallel()
+		is.PanicsWithValue("it.Sliding: size must be greater than 0", func() {
+			Sliding(values(1, 2, 3), 0, 1)
+		})
 	})
 
-	// Test multiple early termination (stop yielding)
-	result27 := Sliding(values(1, 2, 3, 4, 5, 6), 2, 1)
-	count := 0
-	for window := range result27 {
-		count++
-		if count == 2 {
-			break
+	t.Run("panics on zero step", func(t *testing.T) {
+		t.Parallel()
+		is.PanicsWithValue("it.Sliding: step must be greater than 0", func() {
+			Sliding(values(1, 2, 3), 2, 0)
+		})
+	})
+
+	t.Run("panics on negative step", func(t *testing.T) {
+		t.Parallel()
+		is.PanicsWithValue("it.Sliding: step must be greater than 0", func() {
+			Sliding(values(1, 2, 3), 2, -1)
+		})
+	})
+
+	t.Run("panics on negative size", func(t *testing.T) {
+		t.Parallel()
+		is.PanicsWithValue("it.Sliding: size must be greater than 0", func() {
+			Sliding(values(1, 2, 3), -1, 1)
+		})
+	})
+
+	t.Run("strings", func(t *testing.T) {
+		t.Parallel()
+		result17 := Sliding(values("a", "b", "c", "d"), 2, 1)
+		is.Equal([][]string{{"a", "b"}, {"b", "c"}, {"c", "d"}}, slices.Collect(result17))
+	})
+
+	t.Run("structs", func(t *testing.T) {
+		t.Parallel()
+		type Person struct {
+			Name string
+			Age  int
 		}
-		_ = window
-	}
-	is.Equal(2, count)
+		people := values(
+			Person{"Alice", 25},
+			Person{"Bob", 30},
+			Person{"Charlie", 35},
+			Person{"Diana", 40},
+		)
+		result18 := Sliding(people, 2, 1)
+		collected := slices.Collect(result18)
+		is.Len(collected, 3)
+		is.Equal(Person{"Alice", 25}, collected[0][0])
+		is.Equal(Person{"Bob", 30}, collected[0][1])
+		is.Equal(Person{"Bob", 30}, collected[1][0])
+		is.Equal(Person{"Charlie", 35}, collected[1][1])
+	})
 
-	// Test with large size, small step, large collection (only full windows are returned)
-	result28 := Sliding(values(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), 5, 3)
-	is.Equal([][]int{{1, 2, 3, 4, 5}, {4, 5, 6, 7, 8}, {7, 8, 9, 10, 11}}, slices.Collect(result28))
+	t.Run("float64", func(t *testing.T) {
+		t.Parallel()
+		result23 := Sliding(values(1.1, 2.2, 3.3, 4.4), 2, 1)
+		is.Equal([][]float64{{1.1, 2.2}, {2.2, 3.3}, {3.3, 4.4}}, slices.Collect(result23))
+	})
 
-	// Test size equals step equals 1
-	result29 := Sliding(values(1, 2, 3, 4, 5), 1, 1)
-	is.Equal([][]int{{1}, {2}, {3}, {4}, {5}}, slices.Collect(result29))
+	t.Run("bool", func(t *testing.T) {
+		t.Parallel()
+		result24 := Sliding(values(true, false, true, false, true), 3, 2)
+		is.Equal([][]bool{{true, false, true}, {true, false, true}}, slices.Collect(result24))
+	})
 
-	// Test with zero elements in collection
-	result30 := Sliding(values[int](), 1, 1)
-	is.Empty(slices.Collect(result30))
+	t.Run("early termination", func(t *testing.T) {
+		t.Parallel()
+		result27 := Sliding(values(1, 2, 3, 4, 5, 6), 2, 1)
+		count := 0
+		for window := range result27 {
+			count++
+			if count == 2 {
+				break
+			}
+			_ = window
+		}
+		is.Equal(2, count)
+	})
 
-	// Test when last window is exactly size elements
-	result31 := Sliding(values(1, 2, 3, 4, 5, 6), 3, 3)
-	is.Equal([][]int{{1, 2, 3}, {4, 5, 6}}, slices.Collect(result31))
-
-	// Test with pointers
-	x, y, z := 1, 2, 3
-	result32 := Sliding(values(&x, &y, &z), 2, 1)
-	collected32 := slices.Collect(result32)
-	is.Len(collected32, 2)
-	is.Equal(&x, collected32[0][0])
-	is.Equal(&y, collected32[0][1])
-	is.Equal(&y, collected32[1][0])
-	is.Equal(&z, collected32[1][1])
+	t.Run("pointers", func(t *testing.T) {
+		t.Parallel()
+		x, y, z := 1, 2, 3
+		result32 := Sliding(values(&x, &y, &z), 2, 1)
+		collected32 := slices.Collect(result32)
+		is.Len(collected32, 2)
+		is.Equal(&x, collected32[0][0])
+		is.Equal(&y, collected32[0][1])
+		is.Equal(&y, collected32[1][0])
+		is.Equal(&z, collected32[1][1])
+	})
 }
 
 func TestPartitionBy(t *testing.T) {
@@ -662,38 +778,60 @@ func TestPartitionBy(t *testing.T) {
 		return "odd"
 	}
 
-	result1 := PartitionBy(values(-2, -1, 0, 1, 2, 3, 4, 5), oddEven)
-	result2 := PartitionBy(values[int](), oddEven)
+	tests := []struct {
+		name     string
+		input    []int
+		expected [][]int
+	}{
+		{name: "mixed values", input: []int{-2, -1, 0, 1, 2, 3, 4, 5}, expected: [][]int{{-2, -1}, {0, 2, 4}, {1, 3, 5}}},
+		{name: "empty", input: []int{}, expected: nil},
+	}
 
-	is.Equal([][]int{{-2, -1}, {0, 2, 4}, {1, 3, 5}}, result1)
-	is.Empty(result2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, PartitionBy(values(tt.input...), oddEven))
+		})
+	}
 }
 
 func TestFlatten(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Flatten([]iter.Seq[int]{values(0, 1), values(2, 3, 4, 5)})
+	t.Run("int sequences", func(t *testing.T) {
+		t.Parallel()
+		result1 := Flatten([]iter.Seq[int]{values(0, 1), values(2, 3, 4, 5)})
+		is.Equal([]int{0, 1, 2, 3, 4, 5}, slices.Collect(result1))
+	})
 
-	is.Equal([]int{0, 1, 2, 3, 4, 5}, slices.Collect(result1))
-
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Flatten([]myStrings{allStrings})
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Flatten([]myStrings{allStrings})
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestConcat(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Concat(values(0, 1), values(2, 3, 4, 5))
-	is.Equal([]int{0, 1, 2, 3, 4, 5}, slices.Collect(result1))
+	t.Run("int sequences", func(t *testing.T) {
+		t.Parallel()
+		result1 := Concat(values(0, 1), values(2, 3, 4, 5))
+		is.Equal([]int{0, 1, 2, 3, 4, 5}, slices.Collect(result1))
+	})
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Concat(allStrings, allStrings)
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Concat(allStrings, allStrings)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestInterleave(t *testing.T) {
@@ -743,58 +881,104 @@ func TestShuffle(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Shuffle(values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
-	result2 := Shuffle(values[int]())
+	t.Run("non-empty shuffle preserves elements", func(t *testing.T) {
+		t.Parallel()
+		result1 := Shuffle(values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+		slice1 := slices.Collect(result1)
+		is.NotEqual([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, slice1)
+		is.ElementsMatch([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, slice1)
+	})
 
-	slice1 := slices.Collect(result1)
-	is.NotEqual([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, slice1)
-	is.ElementsMatch([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, slice1)
-	is.Empty(slices.Collect(result2))
+	t.Run("empty input", func(t *testing.T) {
+		t.Parallel()
+		result2 := Shuffle(values[int]())
+		is.Empty(slices.Collect(result2))
+	})
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Shuffle(allStrings)
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Shuffle(allStrings)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestReverse(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Reverse(values(0, 1, 2, 3, 4, 5))
-	result2 := Reverse(values(0, 1, 2, 3, 4, 5, 6))
-	result3 := Reverse(values[int]())
+	tests := []struct {
+		name     string
+		input    []int
+		expected []int
+	}{
+		{name: "six elements", input: []int{0, 1, 2, 3, 4, 5}, expected: []int{5, 4, 3, 2, 1, 0}},
+		{name: "seven elements", input: []int{0, 1, 2, 3, 4, 5, 6}, expected: []int{6, 5, 4, 3, 2, 1, 0}},
+		{name: "empty", input: []int{}, expected: nil},
+	}
 
-	is.Equal([]int{5, 4, 3, 2, 1, 0}, slices.Collect(result1))
-	is.Equal([]int{6, 5, 4, 3, 2, 1, 0}, slices.Collect(result2))
-	is.Empty(slices.Collect(result3))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(Reverse(values(tt.input...))))
+		})
+	}
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Reverse(allStrings)
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Reverse(allStrings)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestFill(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Fill(values(foo{"a"}, foo{"a"}), foo{"b"})
-	result2 := Fill(values[foo](), foo{"a"})
+	tests := []struct {
+		name     string
+		input    []foo
+		fillWith foo
+		expected []foo
+	}{
+		{name: "two elements", input: []foo{{"a"}, {"a"}}, fillWith: foo{"b"}, expected: []foo{{"b"}, {"b"}}},
+		{name: "empty", input: []foo{}, fillWith: foo{"a"}, expected: nil},
+	}
 
-	is.Equal([]foo{{"b"}, {"b"}}, slices.Collect(result1))
-	is.Empty(slices.Collect(result2))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(Fill(values(tt.input...), tt.fillWith)))
+		})
+	}
 }
 
 func TestRepeat(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Repeat(2, foo{"a"})
-	result2 := Repeat(0, foo{"a"})
+	tests := []struct {
+		name     string
+		count    int
+		value    foo
+		expected []foo
+	}{
+		{name: "two repeats", count: 2, value: foo{"a"}, expected: []foo{{"a"}, {"a"}}},
+		{name: "zero repeats", count: 0, value: foo{"a"}, expected: nil},
+	}
 
-	is.Equal([]foo{{"a"}, {"a"}}, slices.Collect(result1))
-	is.Empty(slices.Collect(result2))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(Repeat(tt.count, tt.value)))
+		})
+	}
 }
 
 func TestRepeatBy(t *testing.T) {
@@ -805,13 +989,23 @@ func TestRepeatBy(t *testing.T) {
 		return int(math.Pow(float64(i), 2))
 	}
 
-	result1 := RepeatBy(0, cb)
-	result2 := RepeatBy(2, cb)
-	result3 := RepeatBy(5, cb)
+	tests := []struct {
+		name     string
+		count    int
+		expected []int
+	}{
+		{name: "zero", count: 0, expected: nil},
+		{name: "two", count: 2, expected: []int{0, 1}},
+		{name: "five", count: 5, expected: []int{0, 1, 4, 9, 16}},
+	}
 
-	is.Empty(slices.Collect(result1))
-	is.Equal([]int{0, 1}, slices.Collect(result2))
-	is.Equal([]int{0, 1, 4, 9, 16}, slices.Collect(result3))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(RepeatBy(tt.count, cb)))
+		})
+	}
 }
 
 func TestKeyBy(t *testing.T) {
@@ -1033,213 +1227,357 @@ func TestKeyify(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := Keyify(values(1, 2, 3, 4))
-	result2 := Keyify(values(1, 1, 1, 2))
-	result3 := Keyify(values[int]())
-	is.Equal(map[int]struct{}{1: {}, 2: {}, 3: {}, 4: {}}, result1)
-	is.Equal(map[int]struct{}{1: {}, 2: {}}, result2)
-	is.Empty(result3)
+	tests := []struct {
+		name     string
+		input    []int
+		expected map[int]struct{}
+	}{
+		{name: "distinct values", input: []int{1, 2, 3, 4}, expected: map[int]struct{}{1: {}, 2: {}, 3: {}, 4: {}}},
+		{name: "duplicate values", input: []int{1, 1, 1, 2}, expected: map[int]struct{}{1: {}, 2: {}}},
+		{name: "empty", input: []int{}, expected: map[int]struct{}{}},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, Keyify(values(tt.input...)))
+		})
+	}
 }
 
 func TestDrop(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.Equal([]int{0, 1, 2, 3, 4}, slices.Collect(Drop(values(0, 1, 2, 3, 4), 0)))
-	is.Equal([]int{1, 2, 3, 4}, slices.Collect(Drop(values(0, 1, 2, 3, 4), 1)))
-	is.Equal([]int{2, 3, 4}, slices.Collect(Drop(values(0, 1, 2, 3, 4), 2)))
-	is.Equal([]int{3, 4}, slices.Collect(Drop(values(0, 1, 2, 3, 4), 3)))
-	is.Equal([]int{4}, slices.Collect(Drop(values(0, 1, 2, 3, 4), 4)))
-	is.Empty(slices.Collect(Drop(values(0, 1, 2, 3, 4), 5)))
-	is.Empty(slices.Collect(Drop(values(0, 1, 2, 3, 4), 6)))
+	tests := []struct {
+		name     string
+		n        int
+		expected []int
+	}{
+		{name: "drop none", n: 0, expected: []int{0, 1, 2, 3, 4}},
+		{name: "drop one", n: 1, expected: []int{1, 2, 3, 4}},
+		{name: "drop two", n: 2, expected: []int{2, 3, 4}},
+		{name: "drop three", n: 3, expected: []int{3, 4}},
+		{name: "drop four", n: 4, expected: []int{4}},
+		{name: "drop all", n: 5, expected: nil},
+		{name: "drop more than length", n: 6, expected: nil},
+	}
 
-	is.PanicsWithValue("it.Drop: n must not be negative", func() {
-		Drop(values(0, 1, 2, 3, 4), -1)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(Drop(values(0, 1, 2, 3, 4), tt.n)))
+		})
+	}
+
+	t.Run("panics on negative n", func(t *testing.T) {
+		t.Parallel()
+		is.PanicsWithValue("it.Drop: n must not be negative", func() {
+			Drop(values(0, 1, 2, 3, 4), -1)
+		})
 	})
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Drop(allStrings, 2)
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Drop(allStrings, 2)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestDropLast(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.Equal([]int{0, 1, 2, 3, 4}, slices.Collect(DropLast(values(0, 1, 2, 3, 4), 0)))
-	is.Equal([]int{0, 1, 2, 3}, slices.Collect(DropLast(values(0, 1, 2, 3, 4), 1)))
-	is.Equal([]int{0, 1, 2}, slices.Collect(DropLast(values(0, 1, 2, 3, 4), 2)))
-	is.Equal([]int{0, 1}, slices.Collect(DropLast(values(0, 1, 2, 3, 4), 3)))
-	is.Equal([]int{0}, slices.Collect(DropLast(values(0, 1, 2, 3, 4), 4)))
-	is.Empty(slices.Collect(DropLast(values(0, 1, 2, 3, 4), 5)))
-	is.Empty(slices.Collect(DropLast(values(0, 1, 2, 3, 4), 6)))
+	tests := []struct {
+		name     string
+		n        int
+		expected []int
+	}{
+		{name: "drop none", n: 0, expected: []int{0, 1, 2, 3, 4}},
+		{name: "drop one", n: 1, expected: []int{0, 1, 2, 3}},
+		{name: "drop two", n: 2, expected: []int{0, 1, 2}},
+		{name: "drop three", n: 3, expected: []int{0, 1}},
+		{name: "drop four", n: 4, expected: []int{0}},
+		{name: "drop all", n: 5, expected: nil},
+		{name: "drop more than length", n: 6, expected: nil},
+	}
 
-	is.PanicsWithValue("it.DropLast: n must not be negative", func() {
-		DropLast(values(0, 1, 2, 3, 4), -1)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(DropLast(values(0, 1, 2, 3, 4), tt.n)))
+		})
+	}
+
+	t.Run("panics on negative n", func(t *testing.T) {
+		t.Parallel()
+		is.PanicsWithValue("it.DropLast: n must not be negative", func() {
+			DropLast(values(0, 1, 2, 3, 4), -1)
+		})
 	})
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := DropLast(allStrings, 2)
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := DropLast(allStrings, 2)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestDropWhile(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.Equal([]int{4, 5, 6}, slices.Collect(DropWhile(values(0, 1, 2, 3, 4, 5, 6), func(t int) bool {
-		return t != 4
-	})))
+	tests := []struct {
+		name      string
+		predicate func(int) bool
+		expected  []int
+	}{
+		{name: "drop until value found", predicate: func(t int) bool { return t != 4 }, expected: []int{4, 5, 6}},
+		{name: "predicate always true", predicate: func(t int) bool { return true }, expected: nil},
+		{name: "predicate never true", predicate: func(t int) bool { return t == 10 }, expected: []int{0, 1, 2, 3, 4, 5, 6}},
+	}
 
-	is.Empty(slices.Collect(DropWhile(values(0, 1, 2, 3, 4, 5, 6), func(t int) bool {
-		return true
-	})))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(DropWhile(values(0, 1, 2, 3, 4, 5, 6), tt.predicate)))
+		})
+	}
 
-	is.Equal([]int{0, 1, 2, 3, 4, 5, 6}, slices.Collect(DropWhile(values(0, 1, 2, 3, 4, 5, 6), func(t int) bool {
-		return t == 10
-	})))
-
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := DropWhile(allStrings, func(t string) bool {
-		return t != "foo"
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := DropWhile(allStrings, func(t string) bool {
+			return t != "foo"
+		})
+		is.IsType(nonempty, allStrings, "type preserved")
 	})
-	is.IsType(nonempty, allStrings, "type preserved")
 }
 
 func TestDropLastWhile(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.Equal([]int{0, 1, 2, 3}, slices.Collect(DropLastWhile(values(0, 1, 2, 3, 4, 5, 6), func(t int) bool {
-		return t != 3
-	})))
+	tests := []struct {
+		name      string
+		predicate func(int) bool
+		expected  []int
+	}{
+		{name: "drop trailing until value found", predicate: func(t int) bool { return t != 3 }, expected: []int{0, 1, 2, 3}},
+		{name: "drop trailing until earlier value found", predicate: func(t int) bool { return t != 1 }, expected: []int{0, 1}},
+		{name: "predicate never true", predicate: func(t int) bool { return t == 10 }, expected: []int{0, 1, 2, 3, 4, 5, 6}},
+		{name: "predicate always true", predicate: func(t int) bool { return t != 10 }, expected: nil},
+	}
 
-	is.Equal([]int{0, 1}, slices.Collect(DropLastWhile(values(0, 1, 2, 3, 4, 5, 6), func(t int) bool {
-		return t != 1
-	})))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(DropLastWhile(values(0, 1, 2, 3, 4, 5, 6), tt.predicate)))
+		})
+	}
 
-	is.Equal([]int{0, 1, 2, 3, 4, 5, 6}, slices.Collect(DropLastWhile(values(0, 1, 2, 3, 4, 5, 6), func(t int) bool {
-		return t == 10
-	})))
-
-	is.Empty(slices.Collect(DropLastWhile(values(0, 1, 2, 3, 4, 5, 6), func(t int) bool {
-		return t != 10
-	})))
-
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := DropLastWhile(allStrings, func(t string) bool {
-		return t != "foo"
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := DropLastWhile(allStrings, func(t string) bool {
+			return t != "foo"
+		})
+		is.IsType(nonempty, allStrings, "type preserved")
 	})
-	is.IsType(nonempty, allStrings, "type preserved")
 }
 
 func TestTake(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.Equal([]int{0, 1, 2}, slices.Collect(Take(values(0, 1, 2, 3, 4), 3)))
-	is.Equal([]int{0, 1}, slices.Collect(Take(values(0, 1, 2, 3, 4), 2)))
-	is.Equal([]int{0}, slices.Collect(Take(values(0, 1, 2, 3, 4), 1)))
-	is.Empty(slices.Collect(Take(values(0, 1, 2, 3, 4), 0)))
-	is.Equal([]int{0, 1, 2, 3, 4}, slices.Collect(Take(values(0, 1, 2, 3, 4), 5)))
-	is.Equal([]int{0, 1, 2, 3, 4}, slices.Collect(Take(values(0, 1, 2, 3, 4), 10)))
+	tests := []struct {
+		name     string
+		n        int
+		expected []int
+	}{
+		{name: "take three", n: 3, expected: []int{0, 1, 2}},
+		{name: "take two", n: 2, expected: []int{0, 1}},
+		{name: "take one", n: 1, expected: []int{0}},
+		{name: "take none", n: 0, expected: nil},
+		{name: "take exactly all", n: 5, expected: []int{0, 1, 2, 3, 4}},
+		{name: "take more than length", n: 10, expected: []int{0, 1, 2, 3, 4}},
+	}
 
-	is.PanicsWithValue("it.Take: n must not be negative", func() {
-		Take(values(0, 1, 2, 3, 4), -1)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(Take(values(0, 1, 2, 3, 4), tt.n)))
+		})
+	}
+
+	t.Run("panics on negative n", func(t *testing.T) {
+		t.Parallel()
+		is.PanicsWithValue("it.Take: n must not be negative", func() {
+			Take(values(0, 1, 2, 3, 4), -1)
+		})
 	})
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Take(allStrings, 2)
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Take(allStrings, 2)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestTakeWhile(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.Equal([]int{0, 1, 2, 3}, slices.Collect(TakeWhile(values(0, 1, 2, 3, 4, 5, 6), func(t int) bool {
-		return t != 4
-	})))
+	tests := []struct {
+		name      string
+		predicate func(int) bool
+		expected  []int
+	}{
+		{name: "take until value found", predicate: func(t int) bool { return t != 4 }, expected: []int{0, 1, 2, 3}},
+		{name: "predicate always true", predicate: func(t int) bool { return true }, expected: []int{0, 1, 2, 3, 4, 5, 6}},
+		{name: "predicate always false", predicate: func(t int) bool { return false }, expected: nil},
+		{name: "predicate on threshold", predicate: func(t int) bool { return t < 3 }, expected: []int{0, 1, 2}},
+	}
 
-	is.Equal([]int{0, 1, 2, 3, 4, 5, 6}, slices.Collect(TakeWhile(values(0, 1, 2, 3, 4, 5, 6), func(t int) bool {
-		return true
-	})))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(TakeWhile(values(0, 1, 2, 3, 4, 5, 6), tt.predicate)))
+		})
+	}
 
-	is.Empty(slices.Collect(TakeWhile(values(0, 1, 2, 3, 4, 5, 6), func(t int) bool {
-		return false
-	})))
-
-	is.Equal([]int{0, 1, 2}, slices.Collect(TakeWhile(values(0, 1, 2, 3, 4, 5, 6), func(t int) bool {
-		return t < 3
-	})))
-
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := TakeWhile(allStrings, func(t string) bool {
-		return t != "bar"
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := TakeWhile(allStrings, func(t string) bool {
+			return t != "bar"
+		})
+		is.IsType(nonempty, allStrings, "type preserved")
 	})
-	is.IsType(nonempty, allStrings, "type preserved")
 }
 
 func TestTakeFilter(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.Equal([]int{2, 4}, slices.Collect(TakeFilter(values(1, 2, 3, 4, 5, 6), 2, func(item int) bool {
+	isEven := func(item int) bool {
 		return item%2 == 0
-	})))
+	}
 
-	is.Empty(slices.Collect(TakeFilter(values(1, 2, 3, 4, 5, 6), 0, func(item int) bool {
-		return item%2 == 0
-	})))
+	tests := []struct {
+		name     string
+		input    []int
+		n        int
+		expected []int
+	}{
+		{name: "take two evens", input: []int{1, 2, 3, 4, 5, 6}, n: 2, expected: []int{2, 4}},
+		{name: "take zero", input: []int{1, 2, 3, 4, 5, 6}, n: 0, expected: nil},
+		{name: "no matches", input: []int{1, 3, 5}, n: 2, expected: nil},
+	}
 
-	is.Empty(slices.Collect(TakeFilter(values(1, 3, 5), 2, func(item int) bool {
-		return item%2 == 0
-	})))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(TakeFilter(values(tt.input...), tt.n, isEven)))
+		})
+	}
 
-	is.PanicsWithValue("it.TakeFilterI: n must not be negative", func() {
-		TakeFilter(values(1, 2, 3), -1, func(item int) bool { return true })
+	t.Run("panics on negative n", func(t *testing.T) {
+		t.Parallel()
+		is.PanicsWithValue("it.TakeFilterI: n must not be negative", func() {
+			TakeFilter(values(1, 2, 3), -1, func(item int) bool { return true })
+		})
 	})
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar", "baz"))
-	nonempty := TakeFilter(allStrings, 2, func(item string) bool {
-		return item != ""
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar", "baz"))
+		nonempty := TakeFilter(allStrings, 2, func(item string) bool {
+			return item != ""
+		})
+		is.IsType(nonempty, allStrings, "type preserved")
 	})
-	is.IsType(nonempty, allStrings, "type preserved")
 }
 
 func TestTakeFilterI(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.Equal([]int{2, 4}, slices.Collect(TakeFilterI(values(1, 2, 3, 4, 5, 6), 2, func(item, index int) bool {
-		return item%2 == 0 && index < 4
-	})))
+	tests := []struct {
+		name      string
+		input     []int
+		n         int
+		predicate func(int, int) bool
+		expected  []int
+	}{
+		{
+			name:      "take two evens with index bound",
+			input:     []int{1, 2, 3, 4, 5, 6},
+			n:         2,
+			predicate: func(item, index int) bool { return item%2 == 0 && index < 4 },
+			expected:  []int{2, 4},
+		},
+		{
+			name:      "take more than matches available",
+			input:     []int{1, 2, 3, 4, 5, 6},
+			n:         10,
+			predicate: func(item, _ int) bool { return item%2 == 0 },
+			expected:  []int{2, 4, 6},
+		},
+		{
+			name:      "take zero",
+			input:     []int{1, 2, 3, 4, 5, 6},
+			n:         0,
+			predicate: func(item, index int) bool { return item%2 == 0 && index < 4 },
+			expected:  nil,
+		},
+		{
+			name:      "no matches",
+			input:     []int{1, 3, 5},
+			n:         2,
+			predicate: func(item, _ int) bool { return item%2 == 0 },
+			expected:  nil,
+		},
+		{
+			name:      "take one odd",
+			input:     []int{1, 2, 3, 4, 5},
+			n:         1,
+			predicate: func(item, _ int) bool { return item%2 != 0 },
+			expected:  []int{1},
+		},
+	}
 
-	is.Equal([]int{2, 4, 6}, slices.Collect(TakeFilterI(values(1, 2, 3, 4, 5, 6), 10, func(item, _ int) bool {
-		return item%2 == 0
-	})))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(TakeFilterI(values(tt.input...), tt.n, tt.predicate)))
+		})
+	}
 
-	is.Empty(slices.Collect(TakeFilterI(values(1, 2, 3, 4, 5, 6), 0, func(item, index int) bool {
-		return item%2 == 0 && index < 4
-	})))
-
-	is.Empty(slices.Collect(TakeFilterI(values(1, 3, 5), 2, func(item, _ int) bool {
-		return item%2 == 0
-	})))
-
-	is.Equal([]int{1}, slices.Collect(TakeFilterI(values(1, 2, 3, 4, 5), 1, func(item, _ int) bool {
-		return item%2 != 0
-	})))
-
-	is.PanicsWithValue("it.TakeFilterI: n must not be negative", func() {
-		TakeFilterI(values(1, 2, 3), -1, func(item, _ int) bool { return true })
+	t.Run("panics on negative n", func(t *testing.T) {
+		t.Parallel()
+		is.PanicsWithValue("it.TakeFilterI: n must not be negative", func() {
+			TakeFilterI(values(1, 2, 3), -1, func(item, _ int) bool { return true })
+		})
 	})
 }
 
@@ -1247,156 +1585,223 @@ func TestDropByIndex(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.Equal([]int{1, 2, 3, 4}, slices.Collect(DropByIndex(values(0, 1, 2, 3, 4), 0)))
-	is.Equal([]int{3, 4}, slices.Collect(DropByIndex(values(0, 1, 2, 3, 4), 0, 1, 2)))
-	is.Equal([]int{2, 4}, slices.Collect(DropByIndex(values(0, 1, 2, 3, 4), 3, 1, 0)))
-	is.Equal([]int{0, 1, 3, 4}, slices.Collect(DropByIndex(values(0, 1, 2, 3, 4), 2)))
-	is.Equal([]int{0, 1, 2, 3}, slices.Collect(DropByIndex(values(0, 1, 2, 3, 4), 4)))
-	is.Equal([]int{0, 1, 2, 3, 4}, slices.Collect(DropByIndex(values(0, 1, 2, 3, 4), 5)))
-	is.Equal([]int{0, 1, 2, 3, 4}, slices.Collect(DropByIndex(values(0, 1, 2, 3, 4), 100)))
-	is.Empty(slices.Collect(DropByIndex(values[int](), 0, 1)))
-	is.Empty(slices.Collect(DropByIndex(values(42), 0, 1)))
-	is.Empty(slices.Collect(DropByIndex(values(42), 1, 0)))
-	is.Empty(slices.Collect(DropByIndex(values[int](), 1)))
-	is.Empty(slices.Collect(DropByIndex(values(1), 0)))
+	tests := []struct {
+		name     string
+		input    []int
+		indices  []int
+		expected []int
+	}{
+		{name: "drop first", input: []int{0, 1, 2, 3, 4}, indices: []int{0}, expected: []int{1, 2, 3, 4}},
+		{name: "drop first three in order", input: []int{0, 1, 2, 3, 4}, indices: []int{0, 1, 2}, expected: []int{3, 4}},
+		{name: "drop three indices out of order", input: []int{0, 1, 2, 3, 4}, indices: []int{3, 1, 0}, expected: []int{2, 4}},
+		{name: "drop middle", input: []int{0, 1, 2, 3, 4}, indices: []int{2}, expected: []int{0, 1, 3, 4}},
+		{name: "drop last", input: []int{0, 1, 2, 3, 4}, indices: []int{4}, expected: []int{0, 1, 2, 3}},
+		{name: "drop out of range index", input: []int{0, 1, 2, 3, 4}, indices: []int{5}, expected: []int{0, 1, 2, 3, 4}},
+		{name: "drop far out of range index", input: []int{0, 1, 2, 3, 4}, indices: []int{100}, expected: []int{0, 1, 2, 3, 4}},
+		{name: "empty collection", input: []int{}, indices: []int{0, 1}, expected: nil},
+		{name: "single element drop first and second", input: []int{42}, indices: []int{0, 1}, expected: nil},
+		{name: "single element drop second and first", input: []int{42}, indices: []int{1, 0}, expected: nil},
+		{name: "empty collection drop one index", input: []int{}, indices: []int{1}, expected: nil},
+		{name: "single element drop it", input: []int{1}, indices: []int{0}, expected: nil},
+	}
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := DropByIndex(allStrings)
-	is.IsType(nonempty, allStrings, "type preserved")
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(DropByIndex(values(tt.input...), tt.indices...)))
+		})
+	}
+
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := DropByIndex(allStrings)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestReject(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := Reject(values(1, 2, 3, 4), func(x int) bool {
-		return x%2 == 0
+	t.Run("int evens rejected", func(t *testing.T) {
+		t.Parallel()
+		r1 := Reject(values(1, 2, 3, 4), func(x int) bool {
+			return x%2 == 0
+		})
+		is.Equal([]int{1, 3}, slices.Collect(r1))
 	})
 
-	is.Equal([]int{1, 3}, slices.Collect(r1))
-
-	r2 := Reject(values("Smith", "foo", "Domin", "bar", "Olivia"), func(x string) bool {
-		return len(x) > 3
+	t.Run("long names rejected", func(t *testing.T) {
+		t.Parallel()
+		r2 := Reject(values("Smith", "foo", "Domin", "bar", "Olivia"), func(x string) bool {
+			return len(x) > 3
+		})
+		is.Equal([]string{"foo", "bar"}, slices.Collect(r2))
 	})
 
-	is.Equal([]string{"foo", "bar"}, slices.Collect(r2))
-
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Reject(allStrings, func(x string) bool {
-		return len(x) > 0
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Reject(allStrings, func(x string) bool {
+			return len(x) > 0
+		})
+		is.IsType(nonempty, allStrings, "type preserved")
 	})
-	is.IsType(nonempty, allStrings, "type preserved")
 }
 
 func TestRejectI(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := RejectI(values(1, 2, 3, 4), func(x, _ int) bool {
-		return x%2 == 0
+	t.Run("int evens rejected", func(t *testing.T) {
+		t.Parallel()
+		r1 := RejectI(values(1, 2, 3, 4), func(x, _ int) bool {
+			return x%2 == 0
+		})
+		is.Equal([]int{1, 3}, slices.Collect(r1))
 	})
 
-	is.Equal([]int{1, 3}, slices.Collect(r1))
-
-	r2 := RejectI(values("Smith", "foo", "Domin", "bar", "Olivia"), func(x string, _ int) bool {
-		return len(x) > 3
+	t.Run("long names rejected", func(t *testing.T) {
+		t.Parallel()
+		r2 := RejectI(values("Smith", "foo", "Domin", "bar", "Olivia"), func(x string, _ int) bool {
+			return len(x) > 3
+		})
+		is.Equal([]string{"foo", "bar"}, slices.Collect(r2))
 	})
 
-	is.Equal([]string{"foo", "bar"}, slices.Collect(r2))
-
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := RejectI(allStrings, func(x string, _ int) bool {
-		return len(x) > 0
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := RejectI(allStrings, func(x string, _ int) bool {
+			return len(x) > 0
+		})
+		is.IsType(nonempty, allStrings, "type preserved")
 	})
-	is.IsType(nonempty, allStrings, "type preserved")
 }
 
 func TestRejectMap(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := RejectMap(values[int64](1, 2, 3, 4), func(x int64) (string, bool) {
-		if x%2 == 0 {
-			return strconv.FormatInt(x, 10), false
-		}
-		return "", true
-	})
-	r2 := RejectMap(values("cpu", "gpu", "mouse", "keyboard"), func(x string) (string, bool) {
-		if strings.HasSuffix(x, "pu") {
-			return "xpu", false
-		}
-		return "", true
+	t.Run("int64 evens kept", func(t *testing.T) {
+		t.Parallel()
+		r1 := RejectMap(values[int64](1, 2, 3, 4), func(x int64) (string, bool) {
+			if x%2 == 0 {
+				return strconv.FormatInt(x, 10), false
+			}
+			return "", true
+		})
+		is.Equal([]string{"2", "4"}, slices.Collect(r1))
 	})
 
-	is.Equal([]string{"2", "4"}, slices.Collect(r1))
-	is.Equal([]string{"xpu", "xpu"}, slices.Collect(r2))
+	t.Run("string suffix kept", func(t *testing.T) {
+		t.Parallel()
+		r2 := RejectMap(values("cpu", "gpu", "mouse", "keyboard"), func(x string) (string, bool) {
+			if strings.HasSuffix(x, "pu") {
+				return "xpu", false
+			}
+			return "", true
+		})
+		is.Equal([]string{"xpu", "xpu"}, slices.Collect(r2))
+	})
 }
 
 func TestRejectMapI(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := RejectMapI(values[int64](1, 2, 3, 4), func(x int64, _ int) (string, bool) {
-		if x%2 == 0 {
-			return strconv.FormatInt(x, 10), false
-		}
-		return "", true
-	})
-	r2 := RejectMapI(values("cpu", "gpu", "mouse", "keyboard"), func(x string, _ int) (string, bool) {
-		if strings.HasSuffix(x, "pu") {
-			return "xpu", false
-		}
-		return "", true
+	t.Run("int64 evens kept", func(t *testing.T) {
+		t.Parallel()
+		r1 := RejectMapI(values[int64](1, 2, 3, 4), func(x int64, _ int) (string, bool) {
+			if x%2 == 0 {
+				return strconv.FormatInt(x, 10), false
+			}
+			return "", true
+		})
+		is.Equal([]string{"2", "4"}, slices.Collect(r1))
 	})
 
-	is.Equal([]string{"2", "4"}, slices.Collect(r1))
-	is.Equal([]string{"xpu", "xpu"}, slices.Collect(r2))
+	t.Run("string suffix kept", func(t *testing.T) {
+		t.Parallel()
+		r2 := RejectMapI(values("cpu", "gpu", "mouse", "keyboard"), func(x string, _ int) (string, bool) {
+			if strings.HasSuffix(x, "pu") {
+				return "xpu", false
+			}
+			return "", true
+		})
+		is.Equal([]string{"xpu", "xpu"}, slices.Collect(r2))
+	})
 }
 
 func TestCount(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	count1 := Count(values(1, 2, 1), 1)
-	count2 := Count(values(1, 2, 1), 3)
-	count3 := Count(values[int](), 1)
+	tests := []struct {
+		name     string
+		input    []int
+		needle   int
+		expected int
+	}{
+		{name: "value present twice", input: []int{1, 2, 1}, needle: 1, expected: 2},
+		{name: "value absent", input: []int{1, 2, 1}, needle: 3, expected: 0},
+		{name: "empty collection", input: []int{}, needle: 1, expected: 0},
+	}
 
-	is.Equal(2, count1)
-	is.Zero(count2)
-	is.Zero(count3)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, Count(values(tt.input...), tt.needle))
+		})
+	}
 }
 
 func TestCountBy(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	count1 := CountBy(values(1, 2, 1), func(i int) bool {
-		return i < 2
-	})
-	count2 := CountBy(values(1, 2, 1), func(i int) bool {
-		return i > 2
-	})
-	count3 := CountBy(values[int](), func(i int) bool {
-		return i <= 2
-	})
+	tests := []struct {
+		name      string
+		input     []int
+		predicate func(int) bool
+		expected  int
+	}{
+		{name: "matches found", input: []int{1, 2, 1}, predicate: func(i int) bool { return i < 2 }, expected: 2},
+		{name: "no matches", input: []int{1, 2, 1}, predicate: func(i int) bool { return i > 2 }, expected: 0},
+		{name: "empty collection", input: []int{}, predicate: func(i int) bool { return i <= 2 }, expected: 0},
+	}
 
-	is.Equal(2, count1)
-	is.Zero(count2)
-	is.Zero(count3)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, CountBy(values(tt.input...), tt.predicate))
+		})
+	}
 }
 
 func TestCountValues(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.Empty(CountValues(values[int]()))
-	is.Equal(map[int]int{1: 1, 2: 1}, CountValues(values(1, 2)))
-	is.Equal(map[int]int{1: 1, 2: 2}, CountValues(values(1, 2, 2)))
-	is.Equal(map[string]int{"": 1, "foo": 1, "bar": 1}, CountValues(values("foo", "bar", "")))
-	is.Equal(map[string]int{"foo": 1, "bar": 2}, CountValues(values("foo", "bar", "bar")))
+	t.Run("ints", func(t *testing.T) {
+		t.Parallel()
+		is.Empty(CountValues(values[int]()))
+		is.Equal(map[int]int{1: 1, 2: 1}, CountValues(values(1, 2)))
+		is.Equal(map[int]int{1: 1, 2: 2}, CountValues(values(1, 2, 2)))
+	})
+
+	t.Run("strings", func(t *testing.T) {
+		t.Parallel()
+		is.Equal(map[string]int{"": 1, "foo": 1, "bar": 1}, CountValues(values("foo", "bar", "")))
+		is.Equal(map[string]int{"foo": 1, "bar": 2}, CountValues(values("foo", "bar", "bar")))
+	})
 }
 
 func TestCountValuesBy(t *testing.T) {
@@ -1410,425 +1815,571 @@ func TestCountValuesBy(t *testing.T) {
 		return len(v)
 	}
 
-	result1 := CountValuesBy(values[int](), oddEven)
-	result2 := CountValuesBy(values(1, 2), oddEven)
-	result3 := CountValuesBy(values(1, 2, 2), oddEven)
-	result4 := CountValuesBy(values("foo", "bar", ""), length)
-	result5 := CountValuesBy(values("foo", "bar", "bar"), length)
+	t.Run("ints by oddEven", func(t *testing.T) {
+		t.Parallel()
+		is.Empty(CountValuesBy(values[int](), oddEven))
+		is.Equal(map[bool]int{true: 1, false: 1}, CountValuesBy(values(1, 2), oddEven))
+		is.Equal(map[bool]int{true: 2, false: 1}, CountValuesBy(values(1, 2, 2), oddEven))
+	})
 
-	is.Empty(result1)
-	is.Equal(map[bool]int{true: 1, false: 1}, result2)
-	is.Equal(map[bool]int{true: 2, false: 1}, result3)
-	is.Equal(map[int]int{0: 1, 3: 2}, result4)
-	is.Equal(map[int]int{3: 3}, result5)
+	t.Run("strings by length", func(t *testing.T) {
+		t.Parallel()
+		is.Equal(map[int]int{0: 1, 3: 2}, CountValuesBy(values("foo", "bar", ""), length))
+		is.Equal(map[int]int{3: 3}, CountValuesBy(values("foo", "bar", "bar"), length))
+	})
 }
 
 func TestSubset(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	in := values(0, 1, 2, 3, 4)
+	tests := []struct {
+		name     string
+		offset   int
+		length   int
+		expected []int
+	}{
+		{name: "zero length", offset: 0, length: 0, expected: nil},
+		{name: "offset beyond collection", offset: 10, length: 2, expected: nil},
+		{name: "length beyond collection", offset: 0, length: 10, expected: []int{0, 1, 2, 3, 4}},
+		{name: "beginning slice", offset: 0, length: 2, expected: []int{0, 1}},
+		{name: "middle slice exact length", offset: 2, length: 2, expected: []int{2, 3}},
+		{name: "middle to end length exceeds", offset: 2, length: 5, expected: []int{2, 3, 4}},
+		{name: "middle to end exact remaining", offset: 2, length: 3, expected: []int{2, 3, 4}},
+		{name: "middle to end length larger than remaining", offset: 2, length: 4, expected: []int{2, 3, 4}},
+	}
 
-	out1 := Subset(in, 0, 0)
-	out2 := Subset(in, 10, 2)
-	out4 := Subset(in, 0, 10)
-	out5 := Subset(in, 0, 2)
-	out6 := Subset(in, 2, 2)
-	out7 := Subset(in, 2, 5)
-	out8 := Subset(in, 2, 3)
-	out9 := Subset(in, 2, 4)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(Subset(values(0, 1, 2, 3, 4), tt.offset, tt.length)))
+		})
+	}
 
-	is.Empty(slices.Collect(out1))
-	is.Empty(slices.Collect(out2))
-	is.Equal([]int{0, 1, 2, 3, 4}, slices.Collect(out4))
-	is.Equal([]int{0, 1}, slices.Collect(out5))
-	is.Equal([]int{2, 3}, slices.Collect(out6))
-	is.Equal([]int{2, 3, 4}, slices.Collect(out7))
-	is.Equal([]int{2, 3, 4}, slices.Collect(out8))
-	is.Equal([]int{2, 3, 4}, slices.Collect(out9))
-
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Subset(allStrings, 0, 2)
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Subset(allStrings, 0, 2)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestSlice(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	in := values(0, 1, 2, 3, 4)
+	tests := []struct {
+		name     string
+		start    int
+		end      int
+		expected []int
+	}{
+		{name: "empty range at start", start: 0, end: 0, expected: nil},
+		{name: "single element at start", start: 0, end: 1, expected: []int{0}},
+		{name: "full range", start: 0, end: 5, expected: []int{0, 1, 2, 3, 4}},
+		{name: "end beyond collection", start: 0, end: 6, expected: []int{0, 1, 2, 3, 4}},
+		{name: "empty range in middle", start: 1, end: 1, expected: nil},
+		{name: "from middle to end", start: 1, end: 5, expected: []int{1, 2, 3, 4}},
+		{name: "from middle beyond end", start: 1, end: 6, expected: []int{1, 2, 3, 4}},
+		{name: "last element", start: 4, end: 5, expected: []int{4}},
+		{name: "empty range at end", start: 5, end: 5, expected: nil},
+		{name: "start beyond collection end before", start: 6, end: 5, expected: nil},
+		{name: "start and end beyond collection", start: 6, end: 6, expected: nil},
+		{name: "start after end", start: 1, end: 0, expected: nil},
+		{name: "start after end both large", start: 5, end: 0, expected: nil},
+		{name: "start beyond collection end within", start: 6, end: 4, expected: nil},
+		{name: "start and end both beyond collection", start: 6, end: 7, expected: nil},
+	}
 
-	out1 := Slice(in, 0, 0)
-	out2 := Slice(in, 0, 1)
-	out3 := Slice(in, 0, 5)
-	out4 := Slice(in, 0, 6)
-	out5 := Slice(in, 1, 1)
-	out6 := Slice(in, 1, 5)
-	out7 := Slice(in, 1, 6)
-	out8 := Slice(in, 4, 5)
-	out9 := Slice(in, 5, 5)
-	out10 := Slice(in, 6, 5)
-	out11 := Slice(in, 6, 6)
-	out12 := Slice(in, 1, 0)
-	out13 := Slice(in, 5, 0)
-	out14 := Slice(in, 6, 4)
-	out15 := Slice(in, 6, 7)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(Slice(values(0, 1, 2, 3, 4), tt.start, tt.end)))
+		})
+	}
 
-	is.Empty(slices.Collect(out1))
-	is.Equal([]int{0}, slices.Collect(out2))
-	is.Equal([]int{0, 1, 2, 3, 4}, slices.Collect(out3))
-	is.Equal([]int{0, 1, 2, 3, 4}, slices.Collect(out4))
-	is.Empty(slices.Collect(out5))
-	is.Equal([]int{1, 2, 3, 4}, slices.Collect(out6))
-	is.Equal([]int{1, 2, 3, 4}, slices.Collect(out7))
-	is.Equal([]int{4}, slices.Collect(out8))
-	is.Empty(slices.Collect(out9))
-	is.Empty(slices.Collect(out10))
-	is.Empty(slices.Collect(out11))
-	is.Empty(slices.Collect(out12))
-	is.Empty(slices.Collect(out13))
-	is.Empty(slices.Collect(out14))
-	is.Empty(slices.Collect(out15))
-
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Slice(allStrings, 0, 2)
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Slice(allStrings, 0, 2)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestReplace(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	in := values(0, 1, 0, 1, 2, 3, 0)
+	tests := []struct {
+		name     string
+		old      int
+		new      int
+		n        int
+		expected []int
+	}{
+		{name: "replace first two occurrences", old: 0, new: 42, n: 2, expected: []int{42, 1, 42, 1, 2, 3, 0}},
+		{name: "replace first occurrence", old: 0, new: 42, n: 1, expected: []int{42, 1, 0, 1, 2, 3, 0}},
+		{name: "replace zero occurrences (n=0)", old: 0, new: 42, n: 0, expected: []int{0, 1, 0, 1, 2, 3, 0}},
+		{name: "replace all occurrences (n=-1) call one", old: 0, new: 42, n: -1, expected: []int{42, 1, 42, 1, 2, 3, 42}},
+		{name: "replace all occurrences (n=-1) call two (stateless)", old: 0, new: 42, n: -1, expected: []int{42, 1, 42, 1, 2, 3, 42}},
+		{name: "old value not present n=2", old: -1, new: 42, n: 2, expected: []int{0, 1, 0, 1, 2, 3, 0}},
+		{name: "old value not present n=1", old: -1, new: 42, n: 1, expected: []int{0, 1, 0, 1, 2, 3, 0}},
+		{name: "old value not present n=0", old: -1, new: 42, n: 0, expected: []int{0, 1, 0, 1, 2, 3, 0}},
+		{name: "old value not present n=-1 call one", old: -1, new: 42, n: -1, expected: []int{0, 1, 0, 1, 2, 3, 0}},
+		{name: "old value not present n=-1 call two (stateless)", old: -1, new: 42, n: -1, expected: []int{0, 1, 0, 1, 2, 3, 0}},
+	}
 
-	out1 := Replace(in, 0, 42, 2)
-	out2 := Replace(in, 0, 42, 1)
-	out3 := Replace(in, 0, 42, 0)
-	out4 := Replace(in, 0, 42, -1)
-	out5 := Replace(in, 0, 42, -1)
-	out6 := Replace(in, -1, 42, 2)
-	out7 := Replace(in, -1, 42, 1)
-	out8 := Replace(in, -1, 42, 0)
-	out9 := Replace(in, -1, 42, -1)
-	out10 := Replace(in, -1, 42, -1)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			in := values(0, 1, 0, 1, 2, 3, 0)
+			is.Equal(tt.expected, slices.Collect(Replace(in, tt.old, tt.new, tt.n)))
+		})
+	}
 
-	is.Equal([]int{42, 1, 42, 1, 2, 3, 0}, slices.Collect(out1))
-	is.Equal([]int{42, 1, 42, 1, 2, 3, 0}, slices.Collect(out1)) // check no counter mutation
-	is.Equal([]int{42, 1, 0, 1, 2, 3, 0}, slices.Collect(out2))
-	is.Equal([]int{0, 1, 0, 1, 2, 3, 0}, slices.Collect(out3))
-	is.Equal([]int{42, 1, 42, 1, 2, 3, 42}, slices.Collect(out4))
-	is.Equal([]int{42, 1, 42, 1, 2, 3, 42}, slices.Collect(out5))
-	is.Equal([]int{0, 1, 0, 1, 2, 3, 0}, slices.Collect(out6))
-	is.Equal([]int{0, 1, 0, 1, 2, 3, 0}, slices.Collect(out7))
-	is.Equal([]int{0, 1, 0, 1, 2, 3, 0}, slices.Collect(out8))
-	is.Equal([]int{0, 1, 0, 1, 2, 3, 0}, slices.Collect(out9))
-	is.Equal([]int{0, 1, 0, 1, 2, 3, 0}, slices.Collect(out10))
+	t.Run("repeated iteration yields consistent results", func(t *testing.T) {
+		t.Parallel()
+		in := values(0, 1, 0, 1, 2, 3, 0)
+		out1 := Replace(in, 0, 42, 2)
+		is.Equal([]int{42, 1, 42, 1, 2, 3, 0}, slices.Collect(out1))
+		is.Equal([]int{42, 1, 42, 1, 2, 3, 0}, slices.Collect(out1)) // check no counter mutation
+	})
 
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Replace(allStrings, "0", "2", 1)
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Replace(allStrings, "0", "2", 1)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestReplaceAll(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	in := values(0, 1, 0, 1, 2, 3, 0)
+	tests := []struct {
+		name     string
+		old      int
+		new      int
+		expected []int
+	}{
+		{name: "old value present", old: 0, new: 42, expected: []int{42, 1, 42, 1, 2, 3, 42}},
+		{name: "old value absent", old: -1, new: 42, expected: []int{0, 1, 0, 1, 2, 3, 0}},
+	}
 
-	out1 := ReplaceAll(in, 0, 42)
-	out2 := ReplaceAll(in, -1, 42)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			in := values(0, 1, 0, 1, 2, 3, 0)
+			is.Equal(tt.expected, slices.Collect(ReplaceAll(in, tt.old, tt.new)))
+		})
+	}
 
-	is.Equal([]int{42, 1, 42, 1, 2, 3, 42}, slices.Collect(out1))
-	is.Equal([]int{0, 1, 0, 1, 2, 3, 0}, slices.Collect(out2))
-
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := ReplaceAll(allStrings, "0", "2")
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := ReplaceAll(allStrings, "0", "2")
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestCompact(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := Compact(values(2, 0, 4, 0))
+	t.Run("ints", func(t *testing.T) {
+		t.Parallel()
+		r1 := Compact(values(2, 0, 4, 0))
+		is.Equal([]int{2, 4}, slices.Collect(r1))
+	})
 
-	is.Equal([]int{2, 4}, slices.Collect(r1))
+	t.Run("strings", func(t *testing.T) {
+		t.Parallel()
+		r2 := Compact(values("", "foo", "", "bar", ""))
+		is.Equal([]string{"foo", "bar"}, slices.Collect(r2))
+	})
 
-	r2 := Compact(values("", "foo", "", "bar", ""))
+	t.Run("bools", func(t *testing.T) {
+		t.Parallel()
+		r3 := Compact(values(true, false, true, false))
+		is.Equal([]bool{true, true}, slices.Collect(r3))
+	})
 
-	is.Equal([]string{"foo", "bar"}, slices.Collect(r2))
+	t.Run("structs", func(t *testing.T) {
+		t.Parallel()
+		type foo struct {
+			bar int
+			baz string
+		}
 
-	r3 := Compact(values(true, false, true, false))
+		// sequence of structs
+		// If all fields of an element are zero values, Compact removes it.
 
-	is.Equal([]bool{true, true}, slices.Collect(r3))
+		r4 := Compact(values(
+			foo{bar: 1, baz: "a"}, // all fields are non-zero values
+			foo{bar: 0, baz: ""},  // all fields are zero values
+			foo{bar: 2, baz: ""},  // bar is non-zero
+		))
 
-	type foo struct {
-		bar int
-		baz string
-	}
+		is.Equal([]foo{{bar: 1, baz: "a"}, {bar: 2, baz: ""}}, slices.Collect(r4))
+	})
 
-	// sequence of structs
-	// If all fields of an element are zero values, Compact removes it.
+	t.Run("pointers to structs", func(t *testing.T) {
+		t.Parallel()
+		type foo struct {
+			bar int
+			baz string
+		}
 
-	r4 := Compact(values(
-		foo{bar: 1, baz: "a"}, // all fields are non-zero values
-		foo{bar: 0, baz: ""},  // all fields are zero values
-		foo{bar: 2, baz: ""},  // bar is non-zero
-	))
+		// sequence of pointers to structs
+		// If an element is nil, Compact removes it.
 
-	is.Equal([]foo{{bar: 1, baz: "a"}, {bar: 2, baz: ""}}, slices.Collect(r4))
+		e1, e2, e3 := foo{bar: 1, baz: "a"}, foo{bar: 0, baz: ""}, foo{bar: 2, baz: ""}
+		// NOTE: e2 is a zero value of foo, but its pointer &e2 is not a zero value of *foo.
+		r5 := Compact(values(&e1, &e2, nil, &e3))
 
-	// sequence of pointers to structs
-	// If an element is nil, Compact removes it.
+		is.Equal([]*foo{&e1, &e2, &e3}, slices.Collect(r5))
+	})
 
-	e1, e2, e3 := foo{bar: 1, baz: "a"}, foo{bar: 0, baz: ""}, foo{bar: 2, baz: ""}
-	// NOTE: e2 is a zero value of foo, but its pointer &e2 is not a zero value of *foo.
-	r5 := Compact(values(&e1, &e2, nil, &e3))
-
-	is.Equal([]*foo{&e1, &e2, &e3}, slices.Collect(r5))
-
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Compact(allStrings)
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Compact(allStrings)
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestIsSorted(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.True(IsSorted(values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)))
-	is.True(IsSorted(values("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")))
+	t.Run("ints", func(t *testing.T) {
+		t.Parallel()
+		is.True(IsSorted(values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)))
+		is.False(IsSorted(values(0, 1, 4, 3, 2, 5, 6, 7, 8, 9, 10)))
+	})
 
-	is.False(IsSorted(values(0, 1, 4, 3, 2, 5, 6, 7, 8, 9, 10)))
-	is.False(IsSorted(values("a", "b", "d", "c", "e", "f", "g", "h", "i", "j")))
+	t.Run("strings", func(t *testing.T) {
+		t.Parallel()
+		is.True(IsSorted(values("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")))
+		is.False(IsSorted(values("a", "b", "d", "c", "e", "f", "g", "h", "i", "j")))
+	})
 }
 
 func TestIsSortedBy(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.True(IsSortedBy(values("a", "bb", "ccc"), func(s string) int {
-		return len(s)
-	}))
+	tests := []struct {
+		name      string
+		input     []string
+		transform func(string) int
+		expected  bool
+	}{
+		{name: "sorted by length", input: []string{"a", "bb", "ccc"}, transform: func(s string) int { return len(s) }, expected: true},
+		{name: "not sorted by length", input: []string{"aa", "b", "ccc"}, transform: func(s string) int { return len(s) }, expected: false},
+		{name: "sorted by numeric value", input: []string{"1", "2", "3", "11"}, transform: func(s string) int {
+			ret, _ := strconv.Atoi(s)
+			return ret
+		}, expected: true},
+	}
 
-	is.False(IsSortedBy(values("aa", "b", "ccc"), func(s string) int {
-		return len(s)
-	}))
-
-	is.True(IsSortedBy(values("1", "2", "3", "11"), func(s string) int {
-		ret, _ := strconv.Atoi(s)
-		return ret
-	}))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, IsSortedBy(values(tt.input...), tt.transform))
+		})
+	}
 }
 
 func TestSplice(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	sample := values("a", "b", "c", "d", "e", "f", "g")
+	t.Run("normal case", func(t *testing.T) {
+		t.Parallel()
+		sample := values("a", "b", "c", "d", "e", "f", "g")
+		results := slices.Collect(Splice(sample, 1, "1", "2"))
+		is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(sample))
+		is.Equal([]string{"a", "1", "2", "b", "c", "d", "e", "f", "g"}, results)
+	})
 
-	// normal case
-	results := slices.Collect(Splice(sample, 1, "1", "2"))
-	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(sample))
-	is.Equal([]string{"a", "1", "2", "b", "c", "d", "e", "f", "g"}, results)
+	t.Run("positive overflow", func(t *testing.T) {
+		t.Parallel()
+		sample := values("a", "b", "c", "d", "e", "f", "g")
+		results := slices.Collect(Splice(sample, 42, "1", "2"))
+		is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(sample))
+		is.Equal([]string{"a", "b", "c", "d", "e", "f", "g", "1", "2"}, results)
+	})
 
-	// positive overflow
-	results = slices.Collect(Splice(sample, 42, "1", "2"))
-	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(sample))
-	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g", "1", "2"}, results)
+	t.Run("other cases", func(t *testing.T) {
+		t.Parallel()
+		is.Equal([]string{"1", "2"}, slices.Collect(Splice(values[string](), 0, "1", "2")))
+		is.Equal([]string{"1", "2"}, slices.Collect(Splice(values[string](), 1, "1", "2")))
+		is.Equal([]string{"1", "2", "0"}, slices.Collect(Splice(values("0"), 0, "1", "2")))
+		is.Equal([]string{"0", "1", "2"}, slices.Collect(Splice(values("0"), 1, "1", "2")))
+	})
 
-	// other
-	is.Equal([]string{"1", "2"}, slices.Collect(Splice(values[string](), 0, "1", "2")))
-	is.Equal([]string{"1", "2"}, slices.Collect(Splice(values[string](), 1, "1", "2")))
-	is.Equal([]string{"1", "2", "0"}, slices.Collect(Splice(values("0"), 0, "1", "2")))
-	is.Equal([]string{"0", "1", "2"}, slices.Collect(Splice(values("0"), 1, "1", "2")))
-
-	// type preserved
-	type myStrings iter.Seq[string]
-	allStrings := myStrings(values("", "foo", "bar"))
-	nonempty := Splice(allStrings, 1, "1", "2")
-	is.IsType(nonempty, allStrings, "type preserved")
+	t.Run("type preserved", func(t *testing.T) {
+		t.Parallel()
+		type myStrings iter.Seq[string]
+		allStrings := myStrings(values("", "foo", "bar"))
+		nonempty := Splice(allStrings, 1, "1", "2")
+		is.IsType(nonempty, allStrings, "type preserved")
+	})
 }
 
 func TestCutPrefix(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	actual, result := CutPrefix(values("a", "a", "b"), []string{"a"})
-	is.True(result)
-	is.Equal([]string{"a", "b"}, slices.Collect(actual))
+	tests := []struct {
+		name          string
+		input         []string
+		prefix        []string
+		expectedFound bool
+		expectedAfter []string
+	}{
+		{name: "prefix matches", input: []string{"a", "a", "b"}, prefix: []string{"a"}, expectedFound: true, expectedAfter: []string{"a", "b"}},
+		{name: "prefix matches (stateless repeat)", input: []string{"a", "a", "b"}, prefix: []string{"a"}, expectedFound: true, expectedAfter: []string{"a", "b"}},
+		{name: "prefix does not match", input: []string{"a", "a", "b"}, prefix: []string{"b"}, expectedFound: false, expectedAfter: []string{"a", "a", "b"}},
+		{name: "empty collection", input: []string{}, prefix: []string{"b"}, expectedFound: false, expectedAfter: nil},
+		{name: "empty prefix", input: []string{"a", "a", "b"}, prefix: []string{}, expectedFound: true, expectedAfter: []string{"a", "a", "b"}},
+		{name: "prefix longer than collection", input: []string{"a", "a", "b"}, prefix: []string{"a", "a", "b", "b"}, expectedFound: false, expectedAfter: []string{"a", "a", "b"}},
+		{name: "prefix mismatched in the middle", input: []string{"a", "a", "b"}, prefix: []string{"a", "b"}, expectedFound: false, expectedAfter: []string{"a", "a", "b"}},
+	}
 
-	actual, result = CutPrefix(values("a", "a", "b"), []string{"a"})
-	is.True(result)
-	is.Equal([]string{"a", "b"}, slices.Collect(actual))
-
-	actual, result = CutPrefix(values("a", "a", "b"), []string{"b"})
-	is.False(result)
-	is.Equal([]string{"a", "a", "b"}, slices.Collect(actual))
-
-	actual, result = CutPrefix(values[string](), []string{"b"})
-	is.False(result)
-	is.Empty(slices.Collect(actual))
-
-	actual, result = CutPrefix(values("a", "a", "b"), []string{})
-	is.True(result)
-	is.Equal([]string{"a", "a", "b"}, slices.Collect(actual))
-
-	actual, result = CutPrefix(values("a", "a", "b"), []string{"a", "a", "b", "b"})
-	is.False(result)
-	is.Equal([]string{"a", "a", "b"}, slices.Collect(actual))
-
-	actual, result = CutPrefix(values("a", "a", "b"), []string{"a", "b"})
-	is.False(result)
-	is.Equal([]string{"a", "a", "b"}, slices.Collect(actual))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual, result := CutPrefix(values(tt.input...), tt.prefix)
+			is.Equal(tt.expectedFound, result)
+			is.Equal(tt.expectedAfter, slices.Collect(actual))
+		})
+	}
 }
 
 func TestCutSuffix(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	actual, result := CutSuffix(values("a", "a", "b"), []string{"c"})
-	is.False(result)
-	is.Equal([]string{"a", "a", "b"}, slices.Collect(actual))
+	tests := []struct {
+		name          string
+		suffix        []string
+		expectedFound bool
+		expectedAfter []string
+	}{
+		{name: "suffix does not match", suffix: []string{"c"}, expectedFound: false, expectedAfter: []string{"a", "a", "b"}},
+		{name: "suffix matches", suffix: []string{"b"}, expectedFound: true, expectedAfter: []string{"a", "a"}},
+		{name: "empty suffix", suffix: []string{}, expectedFound: true, expectedAfter: []string{"a", "a", "b"}},
+		{name: "suffix mismatched", suffix: []string{"a"}, expectedFound: false, expectedAfter: []string{"a", "a", "b"}},
+		{name: "empty suffix (stateless repeat)", suffix: []string{}, expectedFound: true, expectedAfter: []string{"a", "a", "b"}},
+	}
 
-	actual, result = CutSuffix(values("a", "a", "b"), []string{"b"})
-	is.True(result)
-	is.Equal([]string{"a", "a"}, slices.Collect(actual))
-
-	actual, result = CutSuffix(values("a", "a", "b"), []string{})
-	is.True(result)
-	is.Equal([]string{"a", "a", "b"}, slices.Collect(actual))
-
-	actual, result = CutSuffix(values("a", "a", "b"), []string{"a"})
-	is.False(result)
-	is.Equal([]string{"a", "a", "b"}, slices.Collect(actual))
-
-	actual, result = CutSuffix(values("a", "a", "b"), []string{})
-	is.True(result)
-	is.Equal([]string{"a", "a", "b"}, slices.Collect(actual))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual, result := CutSuffix(values("a", "a", "b"), tt.suffix)
+			is.Equal(tt.expectedFound, result)
+			is.Equal(tt.expectedAfter, slices.Collect(actual))
+		})
+	}
 }
 
 func TestTrim(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	actual := Trim(values("a", "b", "c", "d", "e", "f", "g"), "a", "b")
-	is.Equal([]string{"c", "d", "e", "f", "g"}, slices.Collect(actual))
-	actual = Trim(values("a", "b", "c", "d", "e", "f", "g"), "g", "f")
-	is.Equal([]string{"a", "b", "c", "d", "e"}, slices.Collect(actual))
-	actual = Trim(values("a", "b", "c", "d", "e", "f", "g"), "a", "b", "c", "d", "e", "f", "g")
-	is.Empty(slices.Collect(actual))
-	actual = Trim(values("a", "b", "c", "d", "e", "f", "g"), "a", "b", "c", "d", "e", "f", "g", "h")
-	is.Empty(slices.Collect(actual))
-	actual = Trim(values("a", "b", "c", "d", "e", "f", "g"))
-	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(actual))
+	tests := []struct {
+		name     string
+		cutset   []string
+		expected []string
+	}{
+		{name: "trim leading a b", cutset: []string{"a", "b"}, expected: []string{"c", "d", "e", "f", "g"}},
+		{name: "trim trailing g f", cutset: []string{"g", "f"}, expected: []string{"a", "b", "c", "d", "e"}},
+		{name: "trim all elements", cutset: []string{"a", "b", "c", "d", "e", "f", "g"}, expected: nil},
+		{name: "cutset superset of elements", cutset: []string{"a", "b", "c", "d", "e", "f", "g", "h"}, expected: nil},
+		{name: "empty cutset", cutset: nil, expected: []string{"a", "b", "c", "d", "e", "f", "g"}},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(Trim(values("a", "b", "c", "d", "e", "f", "g"), tt.cutset...)))
+		})
+	}
 }
 
 func TestTrimFirst(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	actual := TrimFirst(values("a", "a", "b", "c", "d", "e", "f", "g"), "a", "b")
-	is.Equal([]string{"c", "d", "e", "f", "g"}, slices.Collect(actual))
-	actual = TrimFirst(values("a", "b", "c", "d", "e", "f", "g"), "b", "a")
-	is.Equal([]string{"c", "d", "e", "f", "g"}, slices.Collect(actual))
-	actual = TrimFirst(values("a", "b", "c", "d", "e", "f", "g"), "g", "f")
-	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(actual))
-	actual = TrimFirst(values("a", "b", "c", "d", "e", "f", "g"), "a", "b", "c", "d", "e", "f", "g")
-	is.Empty(slices.Collect(actual))
-	actual = TrimFirst(values("a", "b", "c", "d", "e", "f", "g"), "a", "b", "c", "d", "e", "f", "g", "h")
-	is.Empty(slices.Collect(actual))
-	actual = TrimFirst(values("a", "b", "c", "d", "e", "f", "g"))
-	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(actual))
+	tests := []struct {
+		name     string
+		input    []string
+		cutset   []string
+		expected []string
+	}{
+		{name: "trim first two matching leading elements", input: []string{"a", "a", "b", "c", "d", "e", "f", "g"}, cutset: []string{"a", "b"}, expected: []string{"c", "d", "e", "f", "g"}},
+		{name: "trim leading b a", input: []string{"a", "b", "c", "d", "e", "f", "g"}, cutset: []string{"b", "a"}, expected: []string{"c", "d", "e", "f", "g"}},
+		{name: "cutset does not match leading elements", input: []string{"a", "b", "c", "d", "e", "f", "g"}, cutset: []string{"g", "f"}, expected: []string{"a", "b", "c", "d", "e", "f", "g"}},
+		{name: "trim all elements", input: []string{"a", "b", "c", "d", "e", "f", "g"}, cutset: []string{"a", "b", "c", "d", "e", "f", "g"}, expected: nil},
+		{name: "cutset superset of elements", input: []string{"a", "b", "c", "d", "e", "f", "g"}, cutset: []string{"a", "b", "c", "d", "e", "f", "g", "h"}, expected: nil},
+		{name: "empty cutset", input: []string{"a", "b", "c", "d", "e", "f", "g"}, cutset: nil, expected: []string{"a", "b", "c", "d", "e", "f", "g"}},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(TrimFirst(values(tt.input...), tt.cutset...)))
+		})
+	}
 }
 
 func TestTrimPrefix(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	actual := TrimPrefix(values("a", "b", "a", "b", "c", "d", "e", "f", "g"), []string{"a", "b"})
-	is.Equal([]string{"c", "d", "e", "f", "g"}, slices.Collect(actual))
-	actual = TrimPrefix(values("a", "b", "c", "d", "e", "f", "g"), []string{"b", "a"})
-	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(actual))
-	actual = TrimPrefix(values("a", "b", "c", "d", "e", "f", "g"), []string{"g", "f"})
-	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(actual))
-	actual = TrimPrefix(values("a", "b", "c", "d", "e", "f", "g"), []string{"a", "b", "c", "d", "e", "f", "g"})
-	is.Empty(slices.Collect(actual))
-	actual = TrimPrefix(values("a", "b", "c", "d", "e", "f", "g"), []string{"a", "b", "c", "d", "e", "f", "g", "h"})
-	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(actual))
-	actual = TrimPrefix(values("a", "b", "c", "d", "e", "f", "g"), []string{})
-	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(actual))
+	tests := []struct {
+		name     string
+		input    []string
+		prefix   []string
+		expected []string
+	}{
+		{name: "prefix matches leading elements", input: []string{"a", "b", "a", "b", "c", "d", "e", "f", "g"}, prefix: []string{"a", "b"}, expected: []string{"c", "d", "e", "f", "g"}},
+		{name: "prefix order mismatch", input: []string{"a", "b", "c", "d", "e", "f", "g"}, prefix: []string{"b", "a"}, expected: []string{"a", "b", "c", "d", "e", "f", "g"}},
+		{name: "prefix does not match leading elements", input: []string{"a", "b", "c", "d", "e", "f", "g"}, prefix: []string{"g", "f"}, expected: []string{"a", "b", "c", "d", "e", "f", "g"}},
+		{name: "prefix equals entire collection", input: []string{"a", "b", "c", "d", "e", "f", "g"}, prefix: []string{"a", "b", "c", "d", "e", "f", "g"}, expected: nil},
+		{name: "prefix longer than collection", input: []string{"a", "b", "c", "d", "e", "f", "g"}, prefix: []string{"a", "b", "c", "d", "e", "f", "g", "h"}, expected: []string{"a", "b", "c", "d", "e", "f", "g"}},
+		{name: "empty prefix", input: []string{"a", "b", "c", "d", "e", "f", "g"}, prefix: []string{}, expected: []string{"a", "b", "c", "d", "e", "f", "g"}},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(TrimPrefix(values(tt.input...), tt.prefix)))
+		})
+	}
 }
 
 func TestTrimLast(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	actual := TrimLast(values("a", "b", "c", "d", "e", "f", "g"), "a", "b")
-	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(actual))
-	actual = TrimLast(values("a", "b", "c", "d", "e", "f", "g", "g"), "g", "f")
-	is.Equal([]string{"a", "b", "c", "d", "e"}, slices.Collect(actual))
-	actual = TrimLast(values("a", "b", "c", "d", "e", "f", "g"), "a", "b", "c", "d", "e", "f", "g")
-	is.Empty(slices.Collect(actual))
-	actual = TrimLast(values("a", "b", "c", "d", "e", "f", "g"), "a", "b", "c", "d", "e", "f", "g", "h")
-	is.Empty(slices.Collect(actual))
-	actual = TrimLast(values("a", "b", "c", "d", "e", "f", "g"))
-	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(actual))
+	tests := []struct {
+		name     string
+		input    []string
+		cutset   []string
+		expected []string
+	}{
+		{name: "cutset does not match trailing elements", input: []string{"a", "b", "c", "d", "e", "f", "g"}, cutset: []string{"a", "b"}, expected: []string{"a", "b", "c", "d", "e", "f", "g"}},
+		{name: "trim trailing g f", input: []string{"a", "b", "c", "d", "e", "f", "g", "g"}, cutset: []string{"g", "f"}, expected: []string{"a", "b", "c", "d", "e"}},
+		{name: "trim all elements", input: []string{"a", "b", "c", "d", "e", "f", "g"}, cutset: []string{"a", "b", "c", "d", "e", "f", "g"}, expected: nil},
+		{name: "cutset superset of elements", input: []string{"a", "b", "c", "d", "e", "f", "g"}, cutset: []string{"a", "b", "c", "d", "e", "f", "g", "h"}, expected: nil},
+		{name: "empty cutset", input: []string{"a", "b", "c", "d", "e", "f", "g"}, cutset: nil, expected: []string{"a", "b", "c", "d", "e", "f", "g"}},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(TrimLast(values(tt.input...), tt.cutset...)))
+		})
+	}
 }
 
 func TestTrimSuffix(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	actual := TrimSuffix(values("a", "b", "c", "d", "e", "f", "g"), []string{"a", "b"})
-	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(actual))
-	actual = TrimSuffix(values("a", "b", "c", "d", "e", "f", "g", "f", "g"), []string{"f", "g"})
-	is.Equal([]string{"a", "b", "c", "d", "e"}, slices.Collect(actual))
-	actual = TrimSuffix(values("a", "b", "c", "d", "e", "f", "g", "f", "g"), []string{"g", "f"})
-	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g", "f", "g"}, slices.Collect(actual))
-	actual = TrimSuffix(values("a", "b", "c", "d", "e", "f", "f", "g"), []string{"f", "g"})
-	is.Equal([]string{"a", "b", "c", "d", "e", "f"}, slices.Collect(actual))
-	actual = TrimSuffix(values("a", "b", "c", "d", "e", "f", "g"), []string{"a", "b", "c", "d", "e", "f", "g"})
-	is.Empty(slices.Collect(actual))
-	actual = TrimSuffix(values("a", "b", "c", "d", "e", "f", "g"), []string{"a", "b", "c", "d", "e", "f", "g", "h"})
-	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(actual))
-	actual = TrimSuffix(values("a", "b", "c", "d", "e", "f", "g"), []string{})
-	is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(actual))
+	tests := []struct {
+		name     string
+		input    []string
+		suffix   []string
+		expected []string
+	}{
+		{name: "suffix does not match trailing elements", input: []string{"a", "b", "c", "d", "e", "f", "g"}, suffix: []string{"a", "b"}, expected: []string{"a", "b", "c", "d", "e", "f", "g"}},
+		{name: "suffix matches trailing elements", input: []string{"a", "b", "c", "d", "e", "f", "g", "f", "g"}, suffix: []string{"f", "g"}, expected: []string{"a", "b", "c", "d", "e"}},
+		{name: "suffix order mismatch", input: []string{"a", "b", "c", "d", "e", "f", "g", "f", "g"}, suffix: []string{"g", "f"}, expected: []string{"a", "b", "c", "d", "e", "f", "g", "f", "g"}},
+		{name: "suffix matches with repeated element earlier", input: []string{"a", "b", "c", "d", "e", "f", "f", "g"}, suffix: []string{"f", "g"}, expected: []string{"a", "b", "c", "d", "e", "f"}},
+		{name: "suffix equals entire collection", input: []string{"a", "b", "c", "d", "e", "f", "g"}, suffix: []string{"a", "b", "c", "d", "e", "f", "g"}, expected: nil},
+		{name: "suffix longer than collection", input: []string{"a", "b", "c", "d", "e", "f", "g"}, suffix: []string{"a", "b", "c", "d", "e", "f", "g", "h"}, expected: []string{"a", "b", "c", "d", "e", "f", "g"}},
+		{name: "empty suffix", input: []string{"a", "b", "c", "d", "e", "f", "g"}, suffix: []string{}, expected: []string{"a", "b", "c", "d", "e", "f", "g"}},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(TrimSuffix(values(tt.input...), tt.suffix)))
+		})
+	}
 }
 
 func TestBuffer(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	// full batches
-	batches := slices.Collect(Buffer(RangeFrom(1, 6), 2))
-	is.Equal([][]int{{1, 2}, {3, 4}, {5, 6}}, batches)
+	tests := []struct {
+		name     string
+		from     int
+		to       int
+		size     int
+		expected [][]int
+	}{
+		{name: "full batches", from: 1, to: 6, size: 2, expected: [][]int{{1, 2}, {3, 4}, {5, 6}}},
+		{name: "partial last batch", from: 1, to: 5, size: 2, expected: [][]int{{1, 2}, {3, 4}, {5}}},
+		{name: "empty channel", from: 1, to: 0, size: 2, expected: nil},
+	}
 
-	// partial last batch
-	batches2 := slices.Collect(Buffer(RangeFrom(1, 5), 2))
-	is.Equal([][]int{{1, 2}, {3, 4}, {5}}, batches2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(Buffer(RangeFrom(tt.from, tt.to), tt.size)))
+		})
+	}
 
-	// empty channel
-	batches3 := slices.Collect(Buffer(RangeFrom(1, 0), 2))
-	is.Empty(batches3)
-
-	// stop after first batch (early termination)
-	batches4 := slices.Collect(Take(Buffer(RangeFrom(1, 6), 2), 1))
-	is.Equal([][]int{{1, 2}}, batches4)
+	t.Run("early termination", func(t *testing.T) {
+		t.Parallel()
+		batches4 := slices.Collect(Take(Buffer(RangeFrom(1, 6), 2), 1))
+		is.Equal([][]int{{1, 2}}, batches4)
+	})
 }
 
 func TestSeqToSeq2(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := maps.Collect(SeqToSeq2(values("foo", "bar")))
-	is.Equal(map[int]string{0: "foo", 1: "bar"}, r1)
+	tests := []struct {
+		name     string
+		input    []string
+		expected map[int]string
+	}{
+		{name: "two elements", input: []string{"foo", "bar"}, expected: map[int]string{0: "foo", 1: "bar"}},
+		{name: "empty", input: []string{}, expected: map[int]string{}},
+	}
 
-	r2 := maps.Collect(SeqToSeq2(values[string]()))
-	is.Empty(r2)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, maps.Collect(SeqToSeq2(values(tt.input...))))
+		})
+	}
 }

--- a/it/seq_test.go
+++ b/it/seq_test.go
@@ -17,8 +17,6 @@ import (
 
 func TestLength(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		input    []int
@@ -32,6 +30,7 @@ func TestLength(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, Length(values(tt.input...)))
 		})
 	}
@@ -55,10 +54,9 @@ func TestDrain(t *testing.T) {
 
 func TestFilter(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int evens", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r1 := Filter(values(1, 2, 3, 4), func(x int) bool {
 			return x%2 == 0
 		})
@@ -67,6 +65,7 @@ func TestFilter(t *testing.T) {
 
 	t.Run("non-empty strings", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r2 := Filter(values("", "foo", "", "bar", ""), func(x string) bool {
 			return len(x) > 0
 		})
@@ -75,6 +74,7 @@ func TestFilter(t *testing.T) {
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := Filter(allStrings, func(x string) bool {
@@ -86,10 +86,9 @@ func TestFilter(t *testing.T) {
 
 func TestFilterI(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int evens", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r1 := FilterI(values(1, 2, 3, 4), func(x, _ int) bool {
 			return x%2 == 0
 		})
@@ -98,6 +97,7 @@ func TestFilterI(t *testing.T) {
 
 	t.Run("non-empty strings", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r2 := FilterI(values("", "foo", "", "bar", ""), func(x string, _ int) bool {
 			return len(x) > 0
 		})
@@ -106,6 +106,7 @@ func TestFilterI(t *testing.T) {
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := FilterI(allStrings, func(x string, _ int) bool {
@@ -117,10 +118,9 @@ func TestFilterI(t *testing.T) {
 
 func TestMap(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int to constant string", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result1 := Map(values(1, 2, 3, 4), func(x int) string {
 			return "Hello"
 		})
@@ -129,6 +129,7 @@ func TestMap(t *testing.T) {
 
 	t.Run("int64 to formatted string", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result2 := Map(values[int64](1, 2, 3, 4), func(x int64) string {
 			return strconv.FormatInt(x, 10)
 		})
@@ -138,10 +139,9 @@ func TestMap(t *testing.T) {
 
 func TestMapI(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int to constant string", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result1 := MapI(values(1, 2, 3, 4), func(x, _ int) string {
 			return "Hello"
 		})
@@ -150,6 +150,7 @@ func TestMapI(t *testing.T) {
 
 	t.Run("int64 to formatted string", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result2 := MapI(values[int64](1, 2, 3, 4), func(x int64, _ int) string {
 			return strconv.FormatInt(x, 10)
 		})
@@ -193,10 +194,9 @@ func TestUniqMapI(t *testing.T) {
 
 func TestFilterMap(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int64 evens formatted", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r1 := FilterMap(values[int64](1, 2, 3, 4), func(x int64) (string, bool) {
 			if x%2 == 0 {
 				return strconv.FormatInt(x, 10), true
@@ -208,6 +208,7 @@ func TestFilterMap(t *testing.T) {
 
 	t.Run("string suffix match", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r2 := FilterMap(values("cpu", "gpu", "mouse", "keyboard"), func(x string) (string, bool) {
 			if strings.HasSuffix(x, "pu") {
 				return "xpu", true
@@ -220,10 +221,9 @@ func TestFilterMap(t *testing.T) {
 
 func TestFilterMapI(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int64 evens formatted", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r1 := FilterMapI(values[int64](1, 2, 3, 4), func(x int64, _ int) (string, bool) {
 			if x%2 == 0 {
 				return strconv.FormatInt(x, 10), true
@@ -235,6 +235,7 @@ func TestFilterMapI(t *testing.T) {
 
 	t.Run("string suffix match", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r2 := FilterMapI(values("cpu", "gpu", "mouse", "keyboard"), func(x string, _ int) (string, bool) {
 			if strings.HasSuffix(x, "pu") {
 				return "xpu", true
@@ -247,10 +248,9 @@ func TestFilterMapI(t *testing.T) {
 
 func TestFlatMap(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int to constant string", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result1 := FlatMap(values(0, 1, 2, 3, 4), func(x int) iter.Seq[string] {
 			return values("Hello")
 		})
@@ -259,6 +259,7 @@ func TestFlatMap(t *testing.T) {
 
 	t.Run("int64 repeated by value", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result2 := FlatMap(values[int64](0, 1, 2, 3, 4), func(x int64) iter.Seq[string] {
 			return func(yield func(string) bool) {
 				for range x {
@@ -274,10 +275,9 @@ func TestFlatMap(t *testing.T) {
 
 func TestFlatMapI(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int to constant string", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result1 := FlatMapI(values(0, 1, 2, 3, 4), func(x, _ int) iter.Seq[string] {
 			return values("Hello")
 		})
@@ -286,6 +286,7 @@ func TestFlatMapI(t *testing.T) {
 
 	t.Run("int64 repeated by value", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result2 := FlatMapI(values[int64](0, 1, 2, 3, 4), func(x int64, _ int) iter.Seq[string] {
 			return func(yield func(string) bool) {
 				for range x {
@@ -311,8 +312,6 @@ func TestTimes(t *testing.T) {
 
 func TestReduce(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		seed     int
@@ -326,6 +325,7 @@ func TestReduce(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := Reduce(values(1, 2, 3, 4), func(agg, item int) int {
 				return agg + item
 			}, tt.seed)
@@ -336,8 +336,6 @@ func TestReduce(t *testing.T) {
 
 func TestReduceI(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		seed     int
@@ -351,6 +349,7 @@ func TestReduceI(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			result := ReduceI(values(1, 2, 3, 4), func(agg, item, _ int) int {
 				return agg + item
 			}, tt.seed)
@@ -361,10 +360,9 @@ func TestReduceI(t *testing.T) {
 
 func TestReduceLast(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("slice concatenation", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result1 := ReduceLast(values([]int{0, 1}, []int{2, 3}, []int{4, 5}), func(agg, item []int) []int {
 			return append(agg, item...)
 		}, []int{})
@@ -373,6 +371,7 @@ func TestReduceLast(t *testing.T) {
 
 	t.Run("int sum", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result2 := ReduceLast(values(1, 2, 3, 4), func(agg, item int) int {
 			return agg + item
 		}, 10)
@@ -382,10 +381,9 @@ func TestReduceLast(t *testing.T) {
 
 func TestReduceLastI(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("slice concatenation", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result1 := ReduceLastI(values([]int{0, 1}, []int{2, 3}, []int{4, 5}), func(agg, item []int, _ int) []int {
 			return append(agg, item...)
 		}, []int{})
@@ -394,6 +392,7 @@ func TestReduceLastI(t *testing.T) {
 
 	t.Run("int sum", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result2 := ReduceLastI(values(1, 2, 3, 4), func(agg, item, _ int) int {
 			return agg + item
 		}, 10)
@@ -445,16 +444,16 @@ func TestForEachWhileI(t *testing.T) {
 
 func TestUniq(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int dedup", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result1 := Uniq(values(1, 2, 2, 1))
 		is.Equal([]int{1, 2}, slices.Collect(result1))
 	})
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := Uniq(allStrings)
@@ -464,10 +463,9 @@ func TestUniq(t *testing.T) {
 
 func TestUniqBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int mod dedup", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result1 := UniqBy(values(0, 1, 2, 3, 4, 5), func(i int) int {
 			return i % 3
 		})
@@ -476,6 +474,7 @@ func TestUniqBy(t *testing.T) {
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := UniqBy(allStrings, func(i string) string {
@@ -501,10 +500,9 @@ func TestGroupBy(t *testing.T) {
 
 func TestGroupByMap(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int keys", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result1 := GroupByMap(values(0, 1, 2, 3, 4, 5), func(i int) (int, string) {
 			return i % 3, strconv.Itoa(i)
 		})
@@ -517,6 +515,7 @@ func TestGroupByMap(t *testing.T) {
 
 	t.Run("named int type keys", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myInt int
 		result2 := GroupByMap(values[myInt](1, 0, 2, 3, 4, 5), func(i myInt) (int, string) {
 			return int(i % 3), strconv.Itoa(int(i))
@@ -530,6 +529,7 @@ func TestGroupByMap(t *testing.T) {
 
 	t.Run("struct keys", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type product struct {
 			ID         int64
 			CategoryID int64
@@ -554,8 +554,6 @@ func TestGroupByMap(t *testing.T) {
 
 func TestChunk(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		input    []int
@@ -572,12 +570,14 @@ func TestChunk(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(Chunk(values(tt.input...), tt.size)))
 		})
 	}
 
 	t.Run("panics on non-positive size", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.PanicsWithValue("it.Chunk: size must be greater than 0", func() {
 			Chunk(values(0), 0)
 		})
@@ -586,8 +586,6 @@ func TestChunk(t *testing.T) {
 
 func TestWindow(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		input    []int
@@ -605,12 +603,14 @@ func TestWindow(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(Window(values(tt.input...), tt.size)))
 		})
 	}
 
 	t.Run("panics on zero size", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.PanicsWithValue("it.Window: size must be greater than 0", func() {
 			Window(values(1, 2, 3), 0)
 		})
@@ -618,6 +618,7 @@ func TestWindow(t *testing.T) {
 
 	t.Run("panics on negative size", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.PanicsWithValue("it.Window: size must be greater than 0", func() {
 			Window(values(1, 2, 3), -1)
 		})
@@ -626,8 +627,6 @@ func TestWindow(t *testing.T) {
 
 func TestSliding(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		input    []int
@@ -667,12 +666,14 @@ func TestSliding(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(Sliding(values(tt.input...), tt.size, tt.step)))
 		})
 	}
 
 	t.Run("panics on zero size", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.PanicsWithValue("it.Sliding: size must be greater than 0", func() {
 			Sliding(values(1, 2, 3), 0, 1)
 		})
@@ -680,6 +681,7 @@ func TestSliding(t *testing.T) {
 
 	t.Run("panics on zero step", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.PanicsWithValue("it.Sliding: step must be greater than 0", func() {
 			Sliding(values(1, 2, 3), 2, 0)
 		})
@@ -687,6 +689,7 @@ func TestSliding(t *testing.T) {
 
 	t.Run("panics on negative step", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.PanicsWithValue("it.Sliding: step must be greater than 0", func() {
 			Sliding(values(1, 2, 3), 2, -1)
 		})
@@ -694,6 +697,7 @@ func TestSliding(t *testing.T) {
 
 	t.Run("panics on negative size", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.PanicsWithValue("it.Sliding: size must be greater than 0", func() {
 			Sliding(values(1, 2, 3), -1, 1)
 		})
@@ -701,12 +705,14 @@ func TestSliding(t *testing.T) {
 
 	t.Run("strings", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result17 := Sliding(values("a", "b", "c", "d"), 2, 1)
 		is.Equal([][]string{{"a", "b"}, {"b", "c"}, {"c", "d"}}, slices.Collect(result17))
 	})
 
 	t.Run("structs", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type Person struct {
 			Name string
 			Age  int
@@ -728,18 +734,21 @@ func TestSliding(t *testing.T) {
 
 	t.Run("float64", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result23 := Sliding(values(1.1, 2.2, 3.3, 4.4), 2, 1)
 		is.Equal([][]float64{{1.1, 2.2}, {2.2, 3.3}, {3.3, 4.4}}, slices.Collect(result23))
 	})
 
 	t.Run("bool", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result24 := Sliding(values(true, false, true, false, true), 3, 2)
 		is.Equal([][]bool{{true, false, true}, {true, false, true}}, slices.Collect(result24))
 	})
 
 	t.Run("early termination", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result27 := Sliding(values(1, 2, 3, 4, 5, 6), 2, 1)
 		count := 0
 		for window := range result27 {
@@ -754,6 +763,7 @@ func TestSliding(t *testing.T) {
 
 	t.Run("pointers", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		x, y, z := 1, 2, 3
 		result32 := Sliding(values(&x, &y, &z), 2, 1)
 		collected32 := slices.Collect(result32)
@@ -767,8 +777,6 @@ func TestSliding(t *testing.T) {
 
 func TestPartitionBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	oddEven := func(x int) string {
 		if x < 0 {
 			return "negative"
@@ -791,6 +799,7 @@ func TestPartitionBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, PartitionBy(values(tt.input...), oddEven))
 		})
 	}
@@ -798,16 +807,16 @@ func TestPartitionBy(t *testing.T) {
 
 func TestFlatten(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result1 := Flatten([]iter.Seq[int]{values(0, 1), values(2, 3, 4, 5)})
 		is.Equal([]int{0, 1, 2, 3, 4, 5}, slices.Collect(result1))
 	})
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := Flatten([]myStrings{allStrings})
@@ -817,16 +826,16 @@ func TestFlatten(t *testing.T) {
 
 func TestConcat(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result1 := Concat(values(0, 1), values(2, 3, 4, 5))
 		is.Equal([]int{0, 1, 2, 3, 4, 5}, slices.Collect(result1))
 	})
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := Concat(allStrings, allStrings)
@@ -879,10 +888,9 @@ func TestInterleave(t *testing.T) {
 
 func TestShuffle(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("non-empty shuffle preserves elements", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result1 := Shuffle(values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
 		slice1 := slices.Collect(result1)
 		is.NotEqual([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, slice1)
@@ -891,12 +899,14 @@ func TestShuffle(t *testing.T) {
 
 	t.Run("empty input", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		result2 := Shuffle(values[int]())
 		is.Empty(slices.Collect(result2))
 	})
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := Shuffle(allStrings)
@@ -906,8 +916,6 @@ func TestShuffle(t *testing.T) {
 
 func TestReverse(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		input    []int
@@ -922,12 +930,14 @@ func TestReverse(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(Reverse(values(tt.input...))))
 		})
 	}
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := Reverse(allStrings)
@@ -937,8 +947,6 @@ func TestReverse(t *testing.T) {
 
 func TestFill(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		input    []foo
@@ -953,6 +961,7 @@ func TestFill(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(Fill(values(tt.input...), tt.fillWith)))
 		})
 	}
@@ -960,8 +969,6 @@ func TestFill(t *testing.T) {
 
 func TestRepeat(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		count    int
@@ -976,6 +983,7 @@ func TestRepeat(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(Repeat(tt.count, tt.value)))
 		})
 	}
@@ -983,8 +991,6 @@ func TestRepeat(t *testing.T) {
 
 func TestRepeatBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	cb := func(i int) int {
 		return int(math.Pow(float64(i), 2))
 	}
@@ -1003,6 +1009,7 @@ func TestRepeatBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(RepeatBy(tt.count, cb)))
 		})
 	}
@@ -1225,8 +1232,6 @@ func TestFilterSeqToMapI(t *testing.T) {
 
 func TestKeyify(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		input    []int
@@ -1241,6 +1246,7 @@ func TestKeyify(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, Keyify(values(tt.input...)))
 		})
 	}
@@ -1248,8 +1254,6 @@ func TestKeyify(t *testing.T) {
 
 func TestDrop(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		n        int
@@ -1268,12 +1272,14 @@ func TestDrop(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(Drop(values(0, 1, 2, 3, 4), tt.n)))
 		})
 	}
 
 	t.Run("panics on negative n", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.PanicsWithValue("it.Drop: n must not be negative", func() {
 			Drop(values(0, 1, 2, 3, 4), -1)
 		})
@@ -1281,6 +1287,7 @@ func TestDrop(t *testing.T) {
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := Drop(allStrings, 2)
@@ -1290,8 +1297,6 @@ func TestDrop(t *testing.T) {
 
 func TestDropLast(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		n        int
@@ -1310,12 +1315,14 @@ func TestDropLast(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(DropLast(values(0, 1, 2, 3, 4), tt.n)))
 		})
 	}
 
 	t.Run("panics on negative n", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.PanicsWithValue("it.DropLast: n must not be negative", func() {
 			DropLast(values(0, 1, 2, 3, 4), -1)
 		})
@@ -1323,6 +1330,7 @@ func TestDropLast(t *testing.T) {
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := DropLast(allStrings, 2)
@@ -1332,8 +1340,6 @@ func TestDropLast(t *testing.T) {
 
 func TestDropWhile(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name      string
 		predicate func(int) bool
@@ -1348,12 +1354,14 @@ func TestDropWhile(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(DropWhile(values(0, 1, 2, 3, 4, 5, 6), tt.predicate)))
 		})
 	}
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := DropWhile(allStrings, func(t string) bool {
@@ -1365,8 +1373,6 @@ func TestDropWhile(t *testing.T) {
 
 func TestDropLastWhile(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name      string
 		predicate func(int) bool
@@ -1382,12 +1388,14 @@ func TestDropLastWhile(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(DropLastWhile(values(0, 1, 2, 3, 4, 5, 6), tt.predicate)))
 		})
 	}
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := DropLastWhile(allStrings, func(t string) bool {
@@ -1399,8 +1407,6 @@ func TestDropLastWhile(t *testing.T) {
 
 func TestTake(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		n        int
@@ -1418,12 +1424,14 @@ func TestTake(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(Take(values(0, 1, 2, 3, 4), tt.n)))
 		})
 	}
 
 	t.Run("panics on negative n", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.PanicsWithValue("it.Take: n must not be negative", func() {
 			Take(values(0, 1, 2, 3, 4), -1)
 		})
@@ -1431,6 +1439,7 @@ func TestTake(t *testing.T) {
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := Take(allStrings, 2)
@@ -1440,8 +1449,6 @@ func TestTake(t *testing.T) {
 
 func TestTakeWhile(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name      string
 		predicate func(int) bool
@@ -1457,12 +1464,14 @@ func TestTakeWhile(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(TakeWhile(values(0, 1, 2, 3, 4, 5, 6), tt.predicate)))
 		})
 	}
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := TakeWhile(allStrings, func(t string) bool {
@@ -1474,8 +1483,6 @@ func TestTakeWhile(t *testing.T) {
 
 func TestTakeFilter(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	isEven := func(item int) bool {
 		return item%2 == 0
 	}
@@ -1495,12 +1502,14 @@ func TestTakeFilter(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(TakeFilter(values(tt.input...), tt.n, isEven)))
 		})
 	}
 
 	t.Run("panics on negative n", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.PanicsWithValue("it.TakeFilterI: n must not be negative", func() {
 			TakeFilter(values(1, 2, 3), -1, func(item int) bool { return true })
 		})
@@ -1508,6 +1517,7 @@ func TestTakeFilter(t *testing.T) {
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar", "baz"))
 		nonempty := TakeFilter(allStrings, 2, func(item string) bool {
@@ -1519,8 +1529,6 @@ func TestTakeFilter(t *testing.T) {
 
 func TestTakeFilterI(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name      string
 		input     []int
@@ -1569,12 +1577,14 @@ func TestTakeFilterI(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(TakeFilterI(values(tt.input...), tt.n, tt.predicate)))
 		})
 	}
 
 	t.Run("panics on negative n", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.PanicsWithValue("it.TakeFilterI: n must not be negative", func() {
 			TakeFilterI(values(1, 2, 3), -1, func(item, _ int) bool { return true })
 		})
@@ -1583,8 +1593,6 @@ func TestTakeFilterI(t *testing.T) {
 
 func TestDropByIndex(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		input    []int
@@ -1609,12 +1617,14 @@ func TestDropByIndex(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(DropByIndex(values(tt.input...), tt.indices...)))
 		})
 	}
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := DropByIndex(allStrings)
@@ -1624,10 +1634,9 @@ func TestDropByIndex(t *testing.T) {
 
 func TestReject(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int evens rejected", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r1 := Reject(values(1, 2, 3, 4), func(x int) bool {
 			return x%2 == 0
 		})
@@ -1636,6 +1645,7 @@ func TestReject(t *testing.T) {
 
 	t.Run("long names rejected", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r2 := Reject(values("Smith", "foo", "Domin", "bar", "Olivia"), func(x string) bool {
 			return len(x) > 3
 		})
@@ -1644,6 +1654,7 @@ func TestReject(t *testing.T) {
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := Reject(allStrings, func(x string) bool {
@@ -1655,10 +1666,9 @@ func TestReject(t *testing.T) {
 
 func TestRejectI(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int evens rejected", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r1 := RejectI(values(1, 2, 3, 4), func(x, _ int) bool {
 			return x%2 == 0
 		})
@@ -1667,6 +1677,7 @@ func TestRejectI(t *testing.T) {
 
 	t.Run("long names rejected", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r2 := RejectI(values("Smith", "foo", "Domin", "bar", "Olivia"), func(x string, _ int) bool {
 			return len(x) > 3
 		})
@@ -1675,6 +1686,7 @@ func TestRejectI(t *testing.T) {
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := RejectI(allStrings, func(x string, _ int) bool {
@@ -1686,10 +1698,9 @@ func TestRejectI(t *testing.T) {
 
 func TestRejectMap(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int64 evens kept", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r1 := RejectMap(values[int64](1, 2, 3, 4), func(x int64) (string, bool) {
 			if x%2 == 0 {
 				return strconv.FormatInt(x, 10), false
@@ -1701,6 +1712,7 @@ func TestRejectMap(t *testing.T) {
 
 	t.Run("string suffix kept", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r2 := RejectMap(values("cpu", "gpu", "mouse", "keyboard"), func(x string) (string, bool) {
 			if strings.HasSuffix(x, "pu") {
 				return "xpu", false
@@ -1713,10 +1725,9 @@ func TestRejectMap(t *testing.T) {
 
 func TestRejectMapI(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("int64 evens kept", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r1 := RejectMapI(values[int64](1, 2, 3, 4), func(x int64, _ int) (string, bool) {
 			if x%2 == 0 {
 				return strconv.FormatInt(x, 10), false
@@ -1728,6 +1739,7 @@ func TestRejectMapI(t *testing.T) {
 
 	t.Run("string suffix kept", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r2 := RejectMapI(values("cpu", "gpu", "mouse", "keyboard"), func(x string, _ int) (string, bool) {
 			if strings.HasSuffix(x, "pu") {
 				return "xpu", false
@@ -1740,8 +1752,6 @@ func TestRejectMapI(t *testing.T) {
 
 func TestCount(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		input    []int
@@ -1757,6 +1767,7 @@ func TestCount(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, Count(values(tt.input...), tt.needle))
 		})
 	}
@@ -1764,8 +1775,6 @@ func TestCount(t *testing.T) {
 
 func TestCountBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name      string
 		input     []int
@@ -1781,6 +1790,7 @@ func TestCountBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, CountBy(values(tt.input...), tt.predicate))
 		})
 	}
@@ -1788,10 +1798,9 @@ func TestCountBy(t *testing.T) {
 
 func TestCountValues(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("ints", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.Empty(CountValues(values[int]()))
 		is.Equal(map[int]int{1: 1, 2: 1}, CountValues(values(1, 2)))
 		is.Equal(map[int]int{1: 1, 2: 2}, CountValues(values(1, 2, 2)))
@@ -1799,6 +1808,7 @@ func TestCountValues(t *testing.T) {
 
 	t.Run("strings", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.Equal(map[string]int{"": 1, "foo": 1, "bar": 1}, CountValues(values("foo", "bar", "")))
 		is.Equal(map[string]int{"foo": 1, "bar": 2}, CountValues(values("foo", "bar", "bar")))
 	})
@@ -1806,8 +1816,6 @@ func TestCountValues(t *testing.T) {
 
 func TestCountValuesBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	oddEven := func(v int) bool {
 		return v%2 == 0
 	}
@@ -1817,6 +1825,7 @@ func TestCountValuesBy(t *testing.T) {
 
 	t.Run("ints by oddEven", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.Empty(CountValuesBy(values[int](), oddEven))
 		is.Equal(map[bool]int{true: 1, false: 1}, CountValuesBy(values(1, 2), oddEven))
 		is.Equal(map[bool]int{true: 2, false: 1}, CountValuesBy(values(1, 2, 2), oddEven))
@@ -1824,6 +1833,7 @@ func TestCountValuesBy(t *testing.T) {
 
 	t.Run("strings by length", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.Equal(map[int]int{0: 1, 3: 2}, CountValuesBy(values("foo", "bar", ""), length))
 		is.Equal(map[int]int{3: 3}, CountValuesBy(values("foo", "bar", "bar"), length))
 	})
@@ -1831,8 +1841,6 @@ func TestCountValuesBy(t *testing.T) {
 
 func TestSubset(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		offset   int
@@ -1853,12 +1861,14 @@ func TestSubset(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(Subset(values(0, 1, 2, 3, 4), tt.offset, tt.length)))
 		})
 	}
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := Subset(allStrings, 0, 2)
@@ -1868,8 +1878,6 @@ func TestSubset(t *testing.T) {
 
 func TestSlice(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		start    int
@@ -1897,12 +1905,14 @@ func TestSlice(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(Slice(values(0, 1, 2, 3, 4), tt.start, tt.end)))
 		})
 	}
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := Slice(allStrings, 0, 2)
@@ -1912,8 +1922,6 @@ func TestSlice(t *testing.T) {
 
 func TestReplace(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		old      int
@@ -1937,6 +1945,7 @@ func TestReplace(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			in := values(0, 1, 0, 1, 2, 3, 0)
 			is.Equal(tt.expected, slices.Collect(Replace(in, tt.old, tt.new, tt.n)))
 		})
@@ -1944,6 +1953,7 @@ func TestReplace(t *testing.T) {
 
 	t.Run("repeated iteration yields consistent results", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		in := values(0, 1, 0, 1, 2, 3, 0)
 		out1 := Replace(in, 0, 42, 2)
 		is.Equal([]int{42, 1, 42, 1, 2, 3, 0}, slices.Collect(out1))
@@ -1952,6 +1962,7 @@ func TestReplace(t *testing.T) {
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := Replace(allStrings, "0", "2", 1)
@@ -1961,8 +1972,6 @@ func TestReplace(t *testing.T) {
 
 func TestReplaceAll(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		old      int
@@ -1977,6 +1986,7 @@ func TestReplaceAll(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			in := values(0, 1, 0, 1, 2, 3, 0)
 			is.Equal(tt.expected, slices.Collect(ReplaceAll(in, tt.old, tt.new)))
 		})
@@ -1984,6 +1994,7 @@ func TestReplaceAll(t *testing.T) {
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := ReplaceAll(allStrings, "0", "2")
@@ -1993,28 +2004,30 @@ func TestReplaceAll(t *testing.T) {
 
 func TestCompact(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("ints", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r1 := Compact(values(2, 0, 4, 0))
 		is.Equal([]int{2, 4}, slices.Collect(r1))
 	})
 
 	t.Run("strings", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r2 := Compact(values("", "foo", "", "bar", ""))
 		is.Equal([]string{"foo", "bar"}, slices.Collect(r2))
 	})
 
 	t.Run("bools", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		r3 := Compact(values(true, false, true, false))
 		is.Equal([]bool{true, true}, slices.Collect(r3))
 	})
 
 	t.Run("structs", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type foo struct {
 			bar int
 			baz string
@@ -2034,6 +2047,7 @@ func TestCompact(t *testing.T) {
 
 	t.Run("pointers to structs", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type foo struct {
 			bar int
 			baz string
@@ -2051,6 +2065,7 @@ func TestCompact(t *testing.T) {
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := Compact(allStrings)
@@ -2060,16 +2075,16 @@ func TestCompact(t *testing.T) {
 
 func TestIsSorted(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("ints", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.True(IsSorted(values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)))
 		is.False(IsSorted(values(0, 1, 4, 3, 2, 5, 6, 7, 8, 9, 10)))
 	})
 
 	t.Run("strings", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.True(IsSorted(values("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")))
 		is.False(IsSorted(values("a", "b", "d", "c", "e", "f", "g", "h", "i", "j")))
 	})
@@ -2077,8 +2092,6 @@ func TestIsSorted(t *testing.T) {
 
 func TestIsSortedBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name      string
 		input     []string
@@ -2097,6 +2110,7 @@ func TestIsSortedBy(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, IsSortedBy(values(tt.input...), tt.transform))
 		})
 	}
@@ -2104,10 +2118,9 @@ func TestIsSortedBy(t *testing.T) {
 
 func TestSplice(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	t.Run("normal case", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		sample := values("a", "b", "c", "d", "e", "f", "g")
 		results := slices.Collect(Splice(sample, 1, "1", "2"))
 		is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(sample))
@@ -2116,6 +2129,7 @@ func TestSplice(t *testing.T) {
 
 	t.Run("positive overflow", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		sample := values("a", "b", "c", "d", "e", "f", "g")
 		results := slices.Collect(Splice(sample, 42, "1", "2"))
 		is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(sample))
@@ -2124,6 +2138,7 @@ func TestSplice(t *testing.T) {
 
 	t.Run("other cases", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		is.Equal([]string{"1", "2"}, slices.Collect(Splice(values[string](), 0, "1", "2")))
 		is.Equal([]string{"1", "2"}, slices.Collect(Splice(values[string](), 1, "1", "2")))
 		is.Equal([]string{"1", "2", "0"}, slices.Collect(Splice(values("0"), 0, "1", "2")))
@@ -2132,6 +2147,7 @@ func TestSplice(t *testing.T) {
 
 	t.Run("type preserved", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		type myStrings iter.Seq[string]
 		allStrings := myStrings(values("", "foo", "bar"))
 		nonempty := Splice(allStrings, 1, "1", "2")
@@ -2141,8 +2157,6 @@ func TestSplice(t *testing.T) {
 
 func TestCutPrefix(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name          string
 		input         []string
@@ -2163,6 +2177,7 @@ func TestCutPrefix(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			actual, result := CutPrefix(values(tt.input...), tt.prefix)
 			is.Equal(tt.expectedFound, result)
 			is.Equal(tt.expectedAfter, slices.Collect(actual))
@@ -2172,8 +2187,6 @@ func TestCutPrefix(t *testing.T) {
 
 func TestCutSuffix(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name          string
 		suffix        []string
@@ -2191,6 +2204,7 @@ func TestCutSuffix(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			actual, result := CutSuffix(values("a", "a", "b"), tt.suffix)
 			is.Equal(tt.expectedFound, result)
 			is.Equal(tt.expectedAfter, slices.Collect(actual))
@@ -2200,8 +2214,6 @@ func TestCutSuffix(t *testing.T) {
 
 func TestTrim(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		cutset   []string
@@ -2218,6 +2230,7 @@ func TestTrim(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(Trim(values("a", "b", "c", "d", "e", "f", "g"), tt.cutset...)))
 		})
 	}
@@ -2225,8 +2238,6 @@ func TestTrim(t *testing.T) {
 
 func TestTrimFirst(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		input    []string
@@ -2245,6 +2256,7 @@ func TestTrimFirst(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(TrimFirst(values(tt.input...), tt.cutset...)))
 		})
 	}
@@ -2252,8 +2264,6 @@ func TestTrimFirst(t *testing.T) {
 
 func TestTrimPrefix(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		input    []string
@@ -2272,6 +2282,7 @@ func TestTrimPrefix(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(TrimPrefix(values(tt.input...), tt.prefix)))
 		})
 	}
@@ -2279,8 +2290,6 @@ func TestTrimPrefix(t *testing.T) {
 
 func TestTrimLast(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		input    []string
@@ -2298,6 +2307,7 @@ func TestTrimLast(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(TrimLast(values(tt.input...), tt.cutset...)))
 		})
 	}
@@ -2305,8 +2315,6 @@ func TestTrimLast(t *testing.T) {
 
 func TestTrimSuffix(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		input    []string
@@ -2326,6 +2334,7 @@ func TestTrimSuffix(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(TrimSuffix(values(tt.input...), tt.suffix)))
 		})
 	}
@@ -2333,8 +2342,6 @@ func TestTrimSuffix(t *testing.T) {
 
 func TestBuffer(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		from     int
@@ -2351,12 +2358,14 @@ func TestBuffer(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(Buffer(RangeFrom(tt.from, tt.to), tt.size)))
 		})
 	}
 
 	t.Run("early termination", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 		batches4 := slices.Collect(Take(Buffer(RangeFrom(1, 6), 2), 1))
 		is.Equal([][]int{{1, 2}}, batches4)
 	})
@@ -2364,8 +2373,6 @@ func TestBuffer(t *testing.T) {
 
 func TestSeqToSeq2(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
-
 	tests := []struct {
 		name     string
 		input    []string
@@ -2379,6 +2386,7 @@ func TestSeqToSeq2(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, maps.Collect(SeqToSeq2(values(tt.input...))))
 		})
 	}

--- a/it/string_test.go
+++ b/it/string_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestChunkString(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -61,6 +60,7 @@ func TestChunkString(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 
 			result := ChunkString(tt.input, tt.size)
 			is.Equal(tt.expected, slices.Collect(result))
@@ -69,6 +69,7 @@ func TestChunkString(t *testing.T) {
 
 	t.Run("panics on non-positive size", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		is.PanicsWithValue("it.ChunkString: size must be greater than 0", func() {
 			ChunkString("12345", 0)

--- a/it/string_test.go
+++ b/it/string_test.go
@@ -13,25 +13,65 @@ func TestChunkString(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	result1 := ChunkString("12345", 2)
-	is.Equal([]string{"12", "34", "5"}, slices.Collect(result1))
+	tests := []struct {
+		name     string
+		input    string
+		size     int
+		expected []string
+	}{
+		{
+			name:     "size smaller than length, remainder",
+			input:    "12345",
+			size:     2,
+			expected: []string{"12", "34", "5"},
+		},
+		{
+			name:     "size smaller than length, exact",
+			input:    "123456",
+			size:     2,
+			expected: []string{"12", "34", "56"},
+		},
+		{
+			name:     "size equal to length",
+			input:    "123456",
+			size:     6,
+			expected: []string{"123456"},
+		},
+		{
+			name:     "size greater than length",
+			input:    "123456",
+			size:     10,
+			expected: []string{"123456"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			size:     2,
+			expected: []string{""}, // @TODO: should be [] - see https://github.com/samber/lo/issues/788
+		},
+		{
+			name:     "multi-byte runes",
+			input:    "明1好休2林森",
+			size:     2,
+			expected: []string{"明1", "好休", "2林", "森"},
+		},
+	}
 
-	result2 := ChunkString("123456", 2)
-	is.Equal([]string{"12", "34", "56"}, slices.Collect(result2))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	result3 := ChunkString("123456", 6)
-	is.Equal([]string{"123456"}, slices.Collect(result3))
+			result := ChunkString(tt.input, tt.size)
+			is.Equal(tt.expected, slices.Collect(result))
+		})
+	}
 
-	result4 := ChunkString("123456", 10)
-	is.Equal([]string{"123456"}, slices.Collect(result4))
+	t.Run("panics on non-positive size", func(t *testing.T) {
+		t.Parallel()
 
-	result5 := ChunkString("", 2)
-	is.Equal([]string{""}, slices.Collect(result5)) // @TODO: should be [] - see https://github.com/samber/lo/issues/788
-
-	result6 := ChunkString("明1好休2林森", 2)
-	is.Equal([]string{"明1", "好休", "2林", "森"}, slices.Collect(result6))
-
-	is.PanicsWithValue("it.ChunkString: size must be greater than 0", func() {
-		ChunkString("12345", 0)
+		is.PanicsWithValue("it.ChunkString: size must be greater than 0", func() {
+			ChunkString("12345", 0)
+		})
 	})
 }

--- a/it/tuples_test.go
+++ b/it/tuples_test.go
@@ -13,10 +13,10 @@ import (
 
 func TestZip(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	t.Run("2 sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		r := Zip2(
 			values("a", "b"),
@@ -33,6 +33,7 @@ func TestZip(t *testing.T) {
 
 	t.Run("3 sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		r := Zip3(
 			values("a", "b", "c"),
@@ -51,6 +52,7 @@ func TestZip(t *testing.T) {
 
 	t.Run("4 sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		r := Zip4(
 			values("a", "b", "c", "d"),
@@ -71,6 +73,7 @@ func TestZip(t *testing.T) {
 
 	t.Run("5 sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		r := Zip5(
 			values("a", "b", "c", "d", "e"),
@@ -93,6 +96,7 @@ func TestZip(t *testing.T) {
 
 	t.Run("6 sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		r := Zip6(
 			values("a", "b", "c", "d", "e", "f"),
@@ -117,6 +121,7 @@ func TestZip(t *testing.T) {
 
 	t.Run("7 sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		r := Zip7(
 			values("a", "b", "c", "d", "e", "f", "g"),
@@ -143,6 +148,7 @@ func TestZip(t *testing.T) {
 
 	t.Run("8 sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		r := Zip8(
 			values("a", "b", "c", "d", "e", "f", "g", "h"),
@@ -171,6 +177,7 @@ func TestZip(t *testing.T) {
 
 	t.Run("9 sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		r := Zip9(
 			values("a", "b", "c", "d", "e", "f", "g", "h", "i"),
@@ -202,10 +209,10 @@ func TestZip(t *testing.T) {
 
 func TestZipBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	t.Run("2 sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		r := ZipBy2(
 			values("a", "b"),
@@ -223,6 +230,7 @@ func TestZipBy(t *testing.T) {
 
 	t.Run("3 sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		r := ZipBy3(
 			values("a", "b", "c"),
@@ -242,6 +250,7 @@ func TestZipBy(t *testing.T) {
 
 	t.Run("4 sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		r := ZipBy4(
 			values("a", "b", "c", "d"),
@@ -263,6 +272,7 @@ func TestZipBy(t *testing.T) {
 
 	t.Run("5 sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		r := ZipBy5(
 			values("a", "b", "c", "d", "e"),
@@ -286,6 +296,7 @@ func TestZipBy(t *testing.T) {
 
 	t.Run("6 sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		r := ZipBy6(
 			values("a", "b", "c", "d", "e", "f"),
@@ -311,6 +322,7 @@ func TestZipBy(t *testing.T) {
 
 	t.Run("7 sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		r := ZipBy7(
 			values("a", "b", "c", "d", "e", "f", "g"),
@@ -338,6 +350,7 @@ func TestZipBy(t *testing.T) {
 
 	t.Run("8 sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		r := ZipBy8(
 			values("a", "b", "c", "d", "e", "f", "g", "h"),
@@ -367,6 +380,7 @@ func TestZipBy(t *testing.T) {
 
 	t.Run("9 sequences", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		r := ZipBy9(
 			values("a", "b", "c", "d", "e", "f", "g", "h", "i"),
@@ -399,7 +413,6 @@ func TestZipBy(t *testing.T) {
 
 func TestCrossJoin(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	listOne := values("a", "b", "c")
 	listTwo := values(1, 2, 3)
@@ -408,6 +421,7 @@ func TestCrossJoin(t *testing.T) {
 
 	t.Run("empty first list", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		results := CrossJoin2(emptyList, listTwo)
 		is.Empty(slices.Collect(results))
@@ -415,6 +429,7 @@ func TestCrossJoin(t *testing.T) {
 
 	t.Run("empty second list", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		results := CrossJoin2(listOne, emptyList)
 		is.Empty(slices.Collect(results))
@@ -422,6 +437,7 @@ func TestCrossJoin(t *testing.T) {
 
 	t.Run("both lists empty", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		results := CrossJoin2(emptyList, emptyList)
 		is.Empty(slices.Collect(results))
@@ -429,6 +445,7 @@ func TestCrossJoin(t *testing.T) {
 
 	t.Run("single element first list", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		results := CrossJoin2(values("a"), listTwo)
 		is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("a", 2), lo.T2("a", 3)}, slices.Collect(results))
@@ -436,6 +453,7 @@ func TestCrossJoin(t *testing.T) {
 
 	t.Run("single element second list", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		results := CrossJoin2(listOne, values(1))
 		is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("b", 1), lo.T2("c", 1)}, slices.Collect(results))
@@ -443,6 +461,7 @@ func TestCrossJoin(t *testing.T) {
 
 	t.Run("multiple elements both lists", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		results := CrossJoin2(listOne, listTwo)
 		is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("a", 2), lo.T2("a", 3), lo.T2("b", 1), lo.T2("b", 2), lo.T2("b", 3), lo.T2("c", 1), lo.T2("c", 2), lo.T2("c", 3)}, slices.Collect(results))
@@ -450,6 +469,7 @@ func TestCrossJoin(t *testing.T) {
 
 	t.Run("mixed type second list", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		results := CrossJoin2(listOne, mixedList)
 		is.Equal([]lo.Tuple2[string, any]{lo.T2[string, any]("a", 9.6), lo.T2[string, any]("a", 4), lo.T2[string, any]("a", "foobar"), lo.T2[string, any]("b", 9.6), lo.T2[string, any]("b", 4), lo.T2[string, any]("b", "foobar"), lo.T2[string, any]("c", 9.6), lo.T2[string, any]("c", 4), lo.T2[string, any]("c", "foobar")}, slices.Collect(results))
@@ -458,7 +478,6 @@ func TestCrossJoin(t *testing.T) {
 
 func TestCrossJoinBy(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	listOne := values("a", "b", "c")
 	listTwo := values(1, 2, 3)
@@ -467,6 +486,7 @@ func TestCrossJoinBy(t *testing.T) {
 
 	t.Run("empty first list", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		results := CrossJoinBy2(emptyList, listTwo, lo.T2[any, int])
 		is.Empty(slices.Collect(results))
@@ -474,6 +494,7 @@ func TestCrossJoinBy(t *testing.T) {
 
 	t.Run("empty second list", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		results := CrossJoinBy2(listOne, emptyList, lo.T2[string, any])
 		is.Empty(slices.Collect(results))
@@ -481,6 +502,7 @@ func TestCrossJoinBy(t *testing.T) {
 
 	t.Run("both lists empty", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		results := CrossJoinBy2(emptyList, emptyList, lo.T2[any, any])
 		is.Empty(slices.Collect(results))
@@ -488,6 +510,7 @@ func TestCrossJoinBy(t *testing.T) {
 
 	t.Run("single element first list", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		results := CrossJoinBy2(values("a"), listTwo, lo.T2[string, int])
 		is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("a", 2), lo.T2("a", 3)}, slices.Collect(results))
@@ -495,6 +518,7 @@ func TestCrossJoinBy(t *testing.T) {
 
 	t.Run("single element second list", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		results := CrossJoinBy2(listOne, values(1), lo.T2[string, int])
 		is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("b", 1), lo.T2("c", 1)}, slices.Collect(results))
@@ -502,6 +526,7 @@ func TestCrossJoinBy(t *testing.T) {
 
 	t.Run("multiple elements both lists", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		results := CrossJoinBy2(listOne, listTwo, lo.T2[string, int])
 		is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("a", 2), lo.T2("a", 3), lo.T2("b", 1), lo.T2("b", 2), lo.T2("b", 3), lo.T2("c", 1), lo.T2("c", 2), lo.T2("c", 3)}, slices.Collect(results))
@@ -509,6 +534,7 @@ func TestCrossJoinBy(t *testing.T) {
 
 	t.Run("mixed type second list", func(t *testing.T) {
 		t.Parallel()
+		is := assert.New(t)
 
 		results := CrossJoinBy2(listOne, mixedList, lo.T2[string, any])
 		is.Equal([]lo.Tuple2[string, any]{lo.T2[string, any]("a", 9.6), lo.T2[string, any]("a", 4), lo.T2[string, any]("a", "foobar"), lo.T2[string, any]("b", 9.6), lo.T2[string, any]("b", 4), lo.T2[string, any]("b", "foobar"), lo.T2[string, any]("c", 9.6), lo.T2[string, any]("c", 4), lo.T2[string, any]("c", "foobar")}, slices.Collect(results))

--- a/it/tuples_test.go
+++ b/it/tuples_test.go
@@ -15,308 +15,386 @@ func TestZip(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := Zip2(
-		values("a", "b"),
-		values(1, 2),
-	)
+	t.Run("2 sequences", func(t *testing.T) {
+		t.Parallel()
 
-	r2 := Zip3(
-		values("a", "b", "c"),
-		values(1, 2, 3),
-		values(4, 5, 6),
-	)
+		r := Zip2(
+			values("a", "b"),
+			values(1, 2),
+		)
 
-	r3 := Zip4(
-		values("a", "b", "c", "d"),
-		values(1, 2, 3, 4),
-		values(5, 6, 7, 8),
-		values(true, true, true, true),
-	)
+		assertSeqSupportBreak(t, r)
 
-	r4 := Zip5(
-		values("a", "b", "c", "d", "e"),
-		values(1, 2, 3, 4, 5),
-		values(6, 7, 8, 9, 10),
-		values(true, true, true, true, true),
-		values[float32](0.1, 0.2, 0.3, 0.4, 0.5),
-	)
+		is.Equal([]lo.Tuple2[string, int]{
+			{A: "a", B: 1},
+			{A: "b", B: 2},
+		}, slices.Collect(r))
+	})
 
-	r5 := Zip6(
-		values("a", "b", "c", "d", "e", "f"),
-		values(1, 2, 3, 4, 5, 6),
-		values(7, 8, 9, 10, 11, 12),
-		values(true, true, true, true, true, true),
-		values[float32](0.1, 0.2, 0.3, 0.4, 0.5, 0.6),
-		values(0.01, 0.02, 0.03, 0.04, 0.05, 0.06),
-	)
+	t.Run("3 sequences", func(t *testing.T) {
+		t.Parallel()
 
-	r6 := Zip7(
-		values("a", "b", "c", "d", "e", "f", "g"),
-		values(1, 2, 3, 4, 5, 6, 7),
-		values(8, 9, 10, 11, 12, 13, 14),
-		values(true, true, true, true, true, true, true),
-		values[float32](0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7),
-		values(0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07),
-		values[int8](1, 2, 3, 4, 5, 6, 7),
-	)
+		r := Zip3(
+			values("a", "b", "c"),
+			values(1, 2, 3),
+			values(4, 5, 6),
+		)
 
-	r7 := Zip8(
-		values("a", "b", "c", "d", "e", "f", "g", "h"),
-		values(1, 2, 3, 4, 5, 6, 7, 8),
-		values(9, 10, 11, 12, 13, 14, 15, 16),
-		values(true, true, true, true, true, true, true, true),
-		values[float32](0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8),
-		values(0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08),
-		values[int8](1, 2, 3, 4, 5, 6, 7, 8),
-		values[int16](1, 2, 3, 4, 5, 6, 7, 8),
-	)
+		assertSeqSupportBreak(t, r)
 
-	r8 := Zip9(
-		values("a", "b", "c", "d", "e", "f", "g", "h", "i"),
-		values(1, 2, 3, 4, 5, 6, 7, 8, 9),
-		values(10, 11, 12, 13, 14, 15, 16, 17, 18),
-		values(true, true, true, true, true, true, true, true, true),
-		values[float32](0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9),
-		values(0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09),
-		values[int8](1, 2, 3, 4, 5, 6, 7, 8, 9),
-		values[int16](1, 2, 3, 4, 5, 6, 7, 8, 9),
-		values[int32](1, 2, 3, 4, 5, 6, 7, 8, 9),
-	)
+		is.Equal([]lo.Tuple3[string, int, int]{
+			{A: "a", B: 1, C: 4},
+			{A: "b", B: 2, C: 5},
+			{A: "c", B: 3, C: 6},
+		}, slices.Collect(r))
+	})
 
-	assertSeqSupportBreak(t, r1)
-	assertSeqSupportBreak(t, r2)
-	assertSeqSupportBreak(t, r3)
-	assertSeqSupportBreak(t, r4)
-	assertSeqSupportBreak(t, r5)
-	assertSeqSupportBreak(t, r6)
-	assertSeqSupportBreak(t, r7)
-	assertSeqSupportBreak(t, r8)
+	t.Run("4 sequences", func(t *testing.T) {
+		t.Parallel()
 
-	is.Equal([]lo.Tuple2[string, int]{
-		{A: "a", B: 1},
-		{A: "b", B: 2},
-	}, slices.Collect(r1))
+		r := Zip4(
+			values("a", "b", "c", "d"),
+			values(1, 2, 3, 4),
+			values(5, 6, 7, 8),
+			values(true, true, true, true),
+		)
 
-	is.Equal([]lo.Tuple3[string, int, int]{
-		{A: "a", B: 1, C: 4},
-		{A: "b", B: 2, C: 5},
-		{A: "c", B: 3, C: 6},
-	}, slices.Collect(r2))
+		assertSeqSupportBreak(t, r)
 
-	is.Equal([]lo.Tuple4[string, int, int, bool]{
-		{A: "a", B: 1, C: 5, D: true},
-		{A: "b", B: 2, C: 6, D: true},
-		{A: "c", B: 3, C: 7, D: true},
-		{A: "d", B: 4, C: 8, D: true},
-	}, slices.Collect(r3))
+		is.Equal([]lo.Tuple4[string, int, int, bool]{
+			{A: "a", B: 1, C: 5, D: true},
+			{A: "b", B: 2, C: 6, D: true},
+			{A: "c", B: 3, C: 7, D: true},
+			{A: "d", B: 4, C: 8, D: true},
+		}, slices.Collect(r))
+	})
 
-	is.Equal([]lo.Tuple5[string, int, int, bool, float32]{
-		{A: "a", B: 1, C: 6, D: true, E: 0.1},
-		{A: "b", B: 2, C: 7, D: true, E: 0.2},
-		{A: "c", B: 3, C: 8, D: true, E: 0.3},
-		{A: "d", B: 4, C: 9, D: true, E: 0.4},
-		{A: "e", B: 5, C: 10, D: true, E: 0.5},
-	}, slices.Collect(r4))
+	t.Run("5 sequences", func(t *testing.T) {
+		t.Parallel()
 
-	is.Equal([]lo.Tuple6[string, int, int, bool, float32, float64]{
-		{A: "a", B: 1, C: 7, D: true, E: 0.1, F: 0.01},
-		{A: "b", B: 2, C: 8, D: true, E: 0.2, F: 0.02},
-		{A: "c", B: 3, C: 9, D: true, E: 0.3, F: 0.03},
-		{A: "d", B: 4, C: 10, D: true, E: 0.4, F: 0.04},
-		{A: "e", B: 5, C: 11, D: true, E: 0.5, F: 0.05},
-		{A: "f", B: 6, C: 12, D: true, E: 0.6, F: 0.06},
-	}, slices.Collect(r5))
+		r := Zip5(
+			values("a", "b", "c", "d", "e"),
+			values(1, 2, 3, 4, 5),
+			values(6, 7, 8, 9, 10),
+			values(true, true, true, true, true),
+			values[float32](0.1, 0.2, 0.3, 0.4, 0.5),
+		)
 
-	is.Equal([]lo.Tuple7[string, int, int, bool, float32, float64, int8]{
-		{A: "a", B: 1, C: 8, D: true, E: 0.1, F: 0.01, G: 1},
-		{A: "b", B: 2, C: 9, D: true, E: 0.2, F: 0.02, G: 2},
-		{A: "c", B: 3, C: 10, D: true, E: 0.3, F: 0.03, G: 3},
-		{A: "d", B: 4, C: 11, D: true, E: 0.4, F: 0.04, G: 4},
-		{A: "e", B: 5, C: 12, D: true, E: 0.5, F: 0.05, G: 5},
-		{A: "f", B: 6, C: 13, D: true, E: 0.6, F: 0.06, G: 6},
-		{A: "g", B: 7, C: 14, D: true, E: 0.7, F: 0.07, G: 7},
-	}, slices.Collect(r6))
+		assertSeqSupportBreak(t, r)
 
-	is.Equal([]lo.Tuple8[string, int, int, bool, float32, float64, int8, int16]{
-		{A: "a", B: 1, C: 9, D: true, E: 0.1, F: 0.01, G: 1, H: 1},
-		{A: "b", B: 2, C: 10, D: true, E: 0.2, F: 0.02, G: 2, H: 2},
-		{A: "c", B: 3, C: 11, D: true, E: 0.3, F: 0.03, G: 3, H: 3},
-		{A: "d", B: 4, C: 12, D: true, E: 0.4, F: 0.04, G: 4, H: 4},
-		{A: "e", B: 5, C: 13, D: true, E: 0.5, F: 0.05, G: 5, H: 5},
-		{A: "f", B: 6, C: 14, D: true, E: 0.6, F: 0.06, G: 6, H: 6},
-		{A: "g", B: 7, C: 15, D: true, E: 0.7, F: 0.07, G: 7, H: 7},
-		{A: "h", B: 8, C: 16, D: true, E: 0.8, F: 0.08, G: 8, H: 8},
-	}, slices.Collect(r7))
+		is.Equal([]lo.Tuple5[string, int, int, bool, float32]{
+			{A: "a", B: 1, C: 6, D: true, E: 0.1},
+			{A: "b", B: 2, C: 7, D: true, E: 0.2},
+			{A: "c", B: 3, C: 8, D: true, E: 0.3},
+			{A: "d", B: 4, C: 9, D: true, E: 0.4},
+			{A: "e", B: 5, C: 10, D: true, E: 0.5},
+		}, slices.Collect(r))
+	})
 
-	is.Equal([]lo.Tuple9[string, int, int, bool, float32, float64, int8, int16, int32]{
-		{A: "a", B: 1, C: 10, D: true, E: 0.1, F: 0.01, G: 1, H: 1, I: 1},
-		{A: "b", B: 2, C: 11, D: true, E: 0.2, F: 0.02, G: 2, H: 2, I: 2},
-		{A: "c", B: 3, C: 12, D: true, E: 0.3, F: 0.03, G: 3, H: 3, I: 3},
-		{A: "d", B: 4, C: 13, D: true, E: 0.4, F: 0.04, G: 4, H: 4, I: 4},
-		{A: "e", B: 5, C: 14, D: true, E: 0.5, F: 0.05, G: 5, H: 5, I: 5},
-		{A: "f", B: 6, C: 15, D: true, E: 0.6, F: 0.06, G: 6, H: 6, I: 6},
-		{A: "g", B: 7, C: 16, D: true, E: 0.7, F: 0.07, G: 7, H: 7, I: 7},
-		{A: "h", B: 8, C: 17, D: true, E: 0.8, F: 0.08, G: 8, H: 8, I: 8},
-		{A: "i", B: 9, C: 18, D: true, E: 0.9, F: 0.09, G: 9, H: 9, I: 9},
-	}, slices.Collect(r8))
+	t.Run("6 sequences", func(t *testing.T) {
+		t.Parallel()
+
+		r := Zip6(
+			values("a", "b", "c", "d", "e", "f"),
+			values(1, 2, 3, 4, 5, 6),
+			values(7, 8, 9, 10, 11, 12),
+			values(true, true, true, true, true, true),
+			values[float32](0.1, 0.2, 0.3, 0.4, 0.5, 0.6),
+			values(0.01, 0.02, 0.03, 0.04, 0.05, 0.06),
+		)
+
+		assertSeqSupportBreak(t, r)
+
+		is.Equal([]lo.Tuple6[string, int, int, bool, float32, float64]{
+			{A: "a", B: 1, C: 7, D: true, E: 0.1, F: 0.01},
+			{A: "b", B: 2, C: 8, D: true, E: 0.2, F: 0.02},
+			{A: "c", B: 3, C: 9, D: true, E: 0.3, F: 0.03},
+			{A: "d", B: 4, C: 10, D: true, E: 0.4, F: 0.04},
+			{A: "e", B: 5, C: 11, D: true, E: 0.5, F: 0.05},
+			{A: "f", B: 6, C: 12, D: true, E: 0.6, F: 0.06},
+		}, slices.Collect(r))
+	})
+
+	t.Run("7 sequences", func(t *testing.T) {
+		t.Parallel()
+
+		r := Zip7(
+			values("a", "b", "c", "d", "e", "f", "g"),
+			values(1, 2, 3, 4, 5, 6, 7),
+			values(8, 9, 10, 11, 12, 13, 14),
+			values(true, true, true, true, true, true, true),
+			values[float32](0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7),
+			values(0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07),
+			values[int8](1, 2, 3, 4, 5, 6, 7),
+		)
+
+		assertSeqSupportBreak(t, r)
+
+		is.Equal([]lo.Tuple7[string, int, int, bool, float32, float64, int8]{
+			{A: "a", B: 1, C: 8, D: true, E: 0.1, F: 0.01, G: 1},
+			{A: "b", B: 2, C: 9, D: true, E: 0.2, F: 0.02, G: 2},
+			{A: "c", B: 3, C: 10, D: true, E: 0.3, F: 0.03, G: 3},
+			{A: "d", B: 4, C: 11, D: true, E: 0.4, F: 0.04, G: 4},
+			{A: "e", B: 5, C: 12, D: true, E: 0.5, F: 0.05, G: 5},
+			{A: "f", B: 6, C: 13, D: true, E: 0.6, F: 0.06, G: 6},
+			{A: "g", B: 7, C: 14, D: true, E: 0.7, F: 0.07, G: 7},
+		}, slices.Collect(r))
+	})
+
+	t.Run("8 sequences", func(t *testing.T) {
+		t.Parallel()
+
+		r := Zip8(
+			values("a", "b", "c", "d", "e", "f", "g", "h"),
+			values(1, 2, 3, 4, 5, 6, 7, 8),
+			values(9, 10, 11, 12, 13, 14, 15, 16),
+			values(true, true, true, true, true, true, true, true),
+			values[float32](0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8),
+			values(0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08),
+			values[int8](1, 2, 3, 4, 5, 6, 7, 8),
+			values[int16](1, 2, 3, 4, 5, 6, 7, 8),
+		)
+
+		assertSeqSupportBreak(t, r)
+
+		is.Equal([]lo.Tuple8[string, int, int, bool, float32, float64, int8, int16]{
+			{A: "a", B: 1, C: 9, D: true, E: 0.1, F: 0.01, G: 1, H: 1},
+			{A: "b", B: 2, C: 10, D: true, E: 0.2, F: 0.02, G: 2, H: 2},
+			{A: "c", B: 3, C: 11, D: true, E: 0.3, F: 0.03, G: 3, H: 3},
+			{A: "d", B: 4, C: 12, D: true, E: 0.4, F: 0.04, G: 4, H: 4},
+			{A: "e", B: 5, C: 13, D: true, E: 0.5, F: 0.05, G: 5, H: 5},
+			{A: "f", B: 6, C: 14, D: true, E: 0.6, F: 0.06, G: 6, H: 6},
+			{A: "g", B: 7, C: 15, D: true, E: 0.7, F: 0.07, G: 7, H: 7},
+			{A: "h", B: 8, C: 16, D: true, E: 0.8, F: 0.08, G: 8, H: 8},
+		}, slices.Collect(r))
+	})
+
+	t.Run("9 sequences", func(t *testing.T) {
+		t.Parallel()
+
+		r := Zip9(
+			values("a", "b", "c", "d", "e", "f", "g", "h", "i"),
+			values(1, 2, 3, 4, 5, 6, 7, 8, 9),
+			values(10, 11, 12, 13, 14, 15, 16, 17, 18),
+			values(true, true, true, true, true, true, true, true, true),
+			values[float32](0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9),
+			values(0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09),
+			values[int8](1, 2, 3, 4, 5, 6, 7, 8, 9),
+			values[int16](1, 2, 3, 4, 5, 6, 7, 8, 9),
+			values[int32](1, 2, 3, 4, 5, 6, 7, 8, 9),
+		)
+
+		assertSeqSupportBreak(t, r)
+
+		is.Equal([]lo.Tuple9[string, int, int, bool, float32, float64, int8, int16, int32]{
+			{A: "a", B: 1, C: 10, D: true, E: 0.1, F: 0.01, G: 1, H: 1, I: 1},
+			{A: "b", B: 2, C: 11, D: true, E: 0.2, F: 0.02, G: 2, H: 2, I: 2},
+			{A: "c", B: 3, C: 12, D: true, E: 0.3, F: 0.03, G: 3, H: 3, I: 3},
+			{A: "d", B: 4, C: 13, D: true, E: 0.4, F: 0.04, G: 4, H: 4, I: 4},
+			{A: "e", B: 5, C: 14, D: true, E: 0.5, F: 0.05, G: 5, H: 5, I: 5},
+			{A: "f", B: 6, C: 15, D: true, E: 0.6, F: 0.06, G: 6, H: 6, I: 6},
+			{A: "g", B: 7, C: 16, D: true, E: 0.7, F: 0.07, G: 7, H: 7, I: 7},
+			{A: "h", B: 8, C: 17, D: true, E: 0.8, F: 0.08, G: 8, H: 8, I: 8},
+			{A: "i", B: 9, C: 18, D: true, E: 0.9, F: 0.09, G: 9, H: 9, I: 9},
+		}, slices.Collect(r))
+	})
 }
 
 func TestZipBy(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := ZipBy2(
-		values("a", "b"),
-		values(1, 2),
-		lo.T2[string, int],
-	)
+	t.Run("2 sequences", func(t *testing.T) {
+		t.Parallel()
 
-	r2 := ZipBy3(
-		values("a", "b", "c"),
-		values(1, 2, 3),
-		values(4, 5, 6),
-		lo.T3[string, int, int],
-	)
+		r := ZipBy2(
+			values("a", "b"),
+			values(1, 2),
+			lo.T2[string, int],
+		)
 
-	r3 := ZipBy4(
-		values("a", "b", "c", "d"),
-		values(1, 2, 3, 4),
-		values(5, 6, 7, 8),
-		values(true, true, true, true),
-		lo.T4[string, int, int, bool],
-	)
+		assertSeqSupportBreak(t, r)
 
-	r4 := ZipBy5(
-		values("a", "b", "c", "d", "e"),
-		values(1, 2, 3, 4, 5),
-		values(6, 7, 8, 9, 10),
-		values(true, true, true, true, true),
-		values[float32](0.1, 0.2, 0.3, 0.4, 0.5),
-		lo.T5[string, int, int, bool, float32],
-	)
+		is.Equal([]lo.Tuple2[string, int]{
+			{A: "a", B: 1},
+			{A: "b", B: 2},
+		}, slices.Collect(r))
+	})
 
-	r5 := ZipBy6(
-		values("a", "b", "c", "d", "e", "f"),
-		values(1, 2, 3, 4, 5, 6),
-		values(7, 8, 9, 10, 11, 12),
-		values(true, true, true, true, true, true),
-		values[float32](0.1, 0.2, 0.3, 0.4, 0.5, 0.6),
-		values(0.01, 0.02, 0.03, 0.04, 0.05, 0.06),
-		lo.T6[string, int, int, bool, float32, float64],
-	)
+	t.Run("3 sequences", func(t *testing.T) {
+		t.Parallel()
 
-	r6 := ZipBy7(
-		values("a", "b", "c", "d", "e", "f", "g"),
-		values(1, 2, 3, 4, 5, 6, 7),
-		values(8, 9, 10, 11, 12, 13, 14),
-		values(true, true, true, true, true, true, true),
-		values[float32](0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7),
-		values(0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07),
-		values[int8](1, 2, 3, 4, 5, 6, 7),
-		lo.T7[string, int, int, bool, float32, float64, int8],
-	)
+		r := ZipBy3(
+			values("a", "b", "c"),
+			values(1, 2, 3),
+			values(4, 5, 6),
+			lo.T3[string, int, int],
+		)
 
-	r7 := ZipBy8(
-		values("a", "b", "c", "d", "e", "f", "g", "h"),
-		values(1, 2, 3, 4, 5, 6, 7, 8),
-		values(9, 10, 11, 12, 13, 14, 15, 16),
-		values(true, true, true, true, true, true, true, true),
-		values[float32](0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8),
-		values(0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08),
-		values[int8](1, 2, 3, 4, 5, 6, 7, 8),
-		values[int16](1, 2, 3, 4, 5, 6, 7, 8),
-		lo.T8[string, int, int, bool, float32, float64, int8, int16],
-	)
+		assertSeqSupportBreak(t, r)
 
-	r8 := ZipBy9(
-		values("a", "b", "c", "d", "e", "f", "g", "h", "i"),
-		values(1, 2, 3, 4, 5, 6, 7, 8, 9),
-		values(10, 11, 12, 13, 14, 15, 16, 17, 18),
-		values(true, true, true, true, true, true, true, true, true),
-		values[float32](0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9),
-		values(0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09),
-		values[int8](1, 2, 3, 4, 5, 6, 7, 8, 9),
-		values[int16](1, 2, 3, 4, 5, 6, 7, 8, 9),
-		values[int32](1, 2, 3, 4, 5, 6, 7, 8, 9),
-		lo.T9[string, int, int, bool, float32, float64, int8, int16, int32],
-	)
+		is.Equal([]lo.Tuple3[string, int, int]{
+			{A: "a", B: 1, C: 4},
+			{A: "b", B: 2, C: 5},
+			{A: "c", B: 3, C: 6},
+		}, slices.Collect(r))
+	})
 
-	assertSeqSupportBreak(t, r1)
-	assertSeqSupportBreak(t, r2)
-	assertSeqSupportBreak(t, r3)
-	assertSeqSupportBreak(t, r4)
-	assertSeqSupportBreak(t, r5)
-	assertSeqSupportBreak(t, r6)
-	assertSeqSupportBreak(t, r7)
-	assertSeqSupportBreak(t, r8)
+	t.Run("4 sequences", func(t *testing.T) {
+		t.Parallel()
 
-	is.Equal([]lo.Tuple2[string, int]{
-		{A: "a", B: 1},
-		{A: "b", B: 2},
-	}, slices.Collect(r1))
+		r := ZipBy4(
+			values("a", "b", "c", "d"),
+			values(1, 2, 3, 4),
+			values(5, 6, 7, 8),
+			values(true, true, true, true),
+			lo.T4[string, int, int, bool],
+		)
 
-	is.Equal([]lo.Tuple3[string, int, int]{
-		{A: "a", B: 1, C: 4},
-		{A: "b", B: 2, C: 5},
-		{A: "c", B: 3, C: 6},
-	}, slices.Collect(r2))
+		assertSeqSupportBreak(t, r)
 
-	is.Equal([]lo.Tuple4[string, int, int, bool]{
-		{A: "a", B: 1, C: 5, D: true},
-		{A: "b", B: 2, C: 6, D: true},
-		{A: "c", B: 3, C: 7, D: true},
-		{A: "d", B: 4, C: 8, D: true},
-	}, slices.Collect(r3))
+		is.Equal([]lo.Tuple4[string, int, int, bool]{
+			{A: "a", B: 1, C: 5, D: true},
+			{A: "b", B: 2, C: 6, D: true},
+			{A: "c", B: 3, C: 7, D: true},
+			{A: "d", B: 4, C: 8, D: true},
+		}, slices.Collect(r))
+	})
 
-	is.Equal([]lo.Tuple5[string, int, int, bool, float32]{
-		{A: "a", B: 1, C: 6, D: true, E: 0.1},
-		{A: "b", B: 2, C: 7, D: true, E: 0.2},
-		{A: "c", B: 3, C: 8, D: true, E: 0.3},
-		{A: "d", B: 4, C: 9, D: true, E: 0.4},
-		{A: "e", B: 5, C: 10, D: true, E: 0.5},
-	}, slices.Collect(r4))
+	t.Run("5 sequences", func(t *testing.T) {
+		t.Parallel()
 
-	is.Equal([]lo.Tuple6[string, int, int, bool, float32, float64]{
-		{A: "a", B: 1, C: 7, D: true, E: 0.1, F: 0.01},
-		{A: "b", B: 2, C: 8, D: true, E: 0.2, F: 0.02},
-		{A: "c", B: 3, C: 9, D: true, E: 0.3, F: 0.03},
-		{A: "d", B: 4, C: 10, D: true, E: 0.4, F: 0.04},
-		{A: "e", B: 5, C: 11, D: true, E: 0.5, F: 0.05},
-		{A: "f", B: 6, C: 12, D: true, E: 0.6, F: 0.06},
-	}, slices.Collect(r5))
+		r := ZipBy5(
+			values("a", "b", "c", "d", "e"),
+			values(1, 2, 3, 4, 5),
+			values(6, 7, 8, 9, 10),
+			values(true, true, true, true, true),
+			values[float32](0.1, 0.2, 0.3, 0.4, 0.5),
+			lo.T5[string, int, int, bool, float32],
+		)
 
-	is.Equal([]lo.Tuple7[string, int, int, bool, float32, float64, int8]{
-		{A: "a", B: 1, C: 8, D: true, E: 0.1, F: 0.01, G: 1},
-		{A: "b", B: 2, C: 9, D: true, E: 0.2, F: 0.02, G: 2},
-		{A: "c", B: 3, C: 10, D: true, E: 0.3, F: 0.03, G: 3},
-		{A: "d", B: 4, C: 11, D: true, E: 0.4, F: 0.04, G: 4},
-		{A: "e", B: 5, C: 12, D: true, E: 0.5, F: 0.05, G: 5},
-		{A: "f", B: 6, C: 13, D: true, E: 0.6, F: 0.06, G: 6},
-		{A: "g", B: 7, C: 14, D: true, E: 0.7, F: 0.07, G: 7},
-	}, slices.Collect(r6))
+		assertSeqSupportBreak(t, r)
 
-	is.Equal([]lo.Tuple8[string, int, int, bool, float32, float64, int8, int16]{
-		{A: "a", B: 1, C: 9, D: true, E: 0.1, F: 0.01, G: 1, H: 1},
-		{A: "b", B: 2, C: 10, D: true, E: 0.2, F: 0.02, G: 2, H: 2},
-		{A: "c", B: 3, C: 11, D: true, E: 0.3, F: 0.03, G: 3, H: 3},
-		{A: "d", B: 4, C: 12, D: true, E: 0.4, F: 0.04, G: 4, H: 4},
-		{A: "e", B: 5, C: 13, D: true, E: 0.5, F: 0.05, G: 5, H: 5},
-		{A: "f", B: 6, C: 14, D: true, E: 0.6, F: 0.06, G: 6, H: 6},
-		{A: "g", B: 7, C: 15, D: true, E: 0.7, F: 0.07, G: 7, H: 7},
-		{A: "h", B: 8, C: 16, D: true, E: 0.8, F: 0.08, G: 8, H: 8},
-	}, slices.Collect(r7))
+		is.Equal([]lo.Tuple5[string, int, int, bool, float32]{
+			{A: "a", B: 1, C: 6, D: true, E: 0.1},
+			{A: "b", B: 2, C: 7, D: true, E: 0.2},
+			{A: "c", B: 3, C: 8, D: true, E: 0.3},
+			{A: "d", B: 4, C: 9, D: true, E: 0.4},
+			{A: "e", B: 5, C: 10, D: true, E: 0.5},
+		}, slices.Collect(r))
+	})
 
-	is.Equal([]lo.Tuple9[string, int, int, bool, float32, float64, int8, int16, int32]{
-		{A: "a", B: 1, C: 10, D: true, E: 0.1, F: 0.01, G: 1, H: 1, I: 1},
-		{A: "b", B: 2, C: 11, D: true, E: 0.2, F: 0.02, G: 2, H: 2, I: 2},
-		{A: "c", B: 3, C: 12, D: true, E: 0.3, F: 0.03, G: 3, H: 3, I: 3},
-		{A: "d", B: 4, C: 13, D: true, E: 0.4, F: 0.04, G: 4, H: 4, I: 4},
-		{A: "e", B: 5, C: 14, D: true, E: 0.5, F: 0.05, G: 5, H: 5, I: 5},
-		{A: "f", B: 6, C: 15, D: true, E: 0.6, F: 0.06, G: 6, H: 6, I: 6},
-		{A: "g", B: 7, C: 16, D: true, E: 0.7, F: 0.07, G: 7, H: 7, I: 7},
-		{A: "h", B: 8, C: 17, D: true, E: 0.8, F: 0.08, G: 8, H: 8, I: 8},
-		{A: "i", B: 9, C: 18, D: true, E: 0.9, F: 0.09, G: 9, H: 9, I: 9},
-	}, slices.Collect(r8))
+	t.Run("6 sequences", func(t *testing.T) {
+		t.Parallel()
+
+		r := ZipBy6(
+			values("a", "b", "c", "d", "e", "f"),
+			values(1, 2, 3, 4, 5, 6),
+			values(7, 8, 9, 10, 11, 12),
+			values(true, true, true, true, true, true),
+			values[float32](0.1, 0.2, 0.3, 0.4, 0.5, 0.6),
+			values(0.01, 0.02, 0.03, 0.04, 0.05, 0.06),
+			lo.T6[string, int, int, bool, float32, float64],
+		)
+
+		assertSeqSupportBreak(t, r)
+
+		is.Equal([]lo.Tuple6[string, int, int, bool, float32, float64]{
+			{A: "a", B: 1, C: 7, D: true, E: 0.1, F: 0.01},
+			{A: "b", B: 2, C: 8, D: true, E: 0.2, F: 0.02},
+			{A: "c", B: 3, C: 9, D: true, E: 0.3, F: 0.03},
+			{A: "d", B: 4, C: 10, D: true, E: 0.4, F: 0.04},
+			{A: "e", B: 5, C: 11, D: true, E: 0.5, F: 0.05},
+			{A: "f", B: 6, C: 12, D: true, E: 0.6, F: 0.06},
+		}, slices.Collect(r))
+	})
+
+	t.Run("7 sequences", func(t *testing.T) {
+		t.Parallel()
+
+		r := ZipBy7(
+			values("a", "b", "c", "d", "e", "f", "g"),
+			values(1, 2, 3, 4, 5, 6, 7),
+			values(8, 9, 10, 11, 12, 13, 14),
+			values(true, true, true, true, true, true, true),
+			values[float32](0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7),
+			values(0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07),
+			values[int8](1, 2, 3, 4, 5, 6, 7),
+			lo.T7[string, int, int, bool, float32, float64, int8],
+		)
+
+		assertSeqSupportBreak(t, r)
+
+		is.Equal([]lo.Tuple7[string, int, int, bool, float32, float64, int8]{
+			{A: "a", B: 1, C: 8, D: true, E: 0.1, F: 0.01, G: 1},
+			{A: "b", B: 2, C: 9, D: true, E: 0.2, F: 0.02, G: 2},
+			{A: "c", B: 3, C: 10, D: true, E: 0.3, F: 0.03, G: 3},
+			{A: "d", B: 4, C: 11, D: true, E: 0.4, F: 0.04, G: 4},
+			{A: "e", B: 5, C: 12, D: true, E: 0.5, F: 0.05, G: 5},
+			{A: "f", B: 6, C: 13, D: true, E: 0.6, F: 0.06, G: 6},
+			{A: "g", B: 7, C: 14, D: true, E: 0.7, F: 0.07, G: 7},
+		}, slices.Collect(r))
+	})
+
+	t.Run("8 sequences", func(t *testing.T) {
+		t.Parallel()
+
+		r := ZipBy8(
+			values("a", "b", "c", "d", "e", "f", "g", "h"),
+			values(1, 2, 3, 4, 5, 6, 7, 8),
+			values(9, 10, 11, 12, 13, 14, 15, 16),
+			values(true, true, true, true, true, true, true, true),
+			values[float32](0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8),
+			values(0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08),
+			values[int8](1, 2, 3, 4, 5, 6, 7, 8),
+			values[int16](1, 2, 3, 4, 5, 6, 7, 8),
+			lo.T8[string, int, int, bool, float32, float64, int8, int16],
+		)
+
+		assertSeqSupportBreak(t, r)
+
+		is.Equal([]lo.Tuple8[string, int, int, bool, float32, float64, int8, int16]{
+			{A: "a", B: 1, C: 9, D: true, E: 0.1, F: 0.01, G: 1, H: 1},
+			{A: "b", B: 2, C: 10, D: true, E: 0.2, F: 0.02, G: 2, H: 2},
+			{A: "c", B: 3, C: 11, D: true, E: 0.3, F: 0.03, G: 3, H: 3},
+			{A: "d", B: 4, C: 12, D: true, E: 0.4, F: 0.04, G: 4, H: 4},
+			{A: "e", B: 5, C: 13, D: true, E: 0.5, F: 0.05, G: 5, H: 5},
+			{A: "f", B: 6, C: 14, D: true, E: 0.6, F: 0.06, G: 6, H: 6},
+			{A: "g", B: 7, C: 15, D: true, E: 0.7, F: 0.07, G: 7, H: 7},
+			{A: "h", B: 8, C: 16, D: true, E: 0.8, F: 0.08, G: 8, H: 8},
+		}, slices.Collect(r))
+	})
+
+	t.Run("9 sequences", func(t *testing.T) {
+		t.Parallel()
+
+		r := ZipBy9(
+			values("a", "b", "c", "d", "e", "f", "g", "h", "i"),
+			values(1, 2, 3, 4, 5, 6, 7, 8, 9),
+			values(10, 11, 12, 13, 14, 15, 16, 17, 18),
+			values(true, true, true, true, true, true, true, true, true),
+			values[float32](0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9),
+			values(0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09),
+			values[int8](1, 2, 3, 4, 5, 6, 7, 8, 9),
+			values[int16](1, 2, 3, 4, 5, 6, 7, 8, 9),
+			values[int32](1, 2, 3, 4, 5, 6, 7, 8, 9),
+			lo.T9[string, int, int, bool, float32, float64, int8, int16, int32],
+		)
+
+		assertSeqSupportBreak(t, r)
+
+		is.Equal([]lo.Tuple9[string, int, int, bool, float32, float64, int8, int16, int32]{
+			{A: "a", B: 1, C: 10, D: true, E: 0.1, F: 0.01, G: 1, H: 1, I: 1},
+			{A: "b", B: 2, C: 11, D: true, E: 0.2, F: 0.02, G: 2, H: 2, I: 2},
+			{A: "c", B: 3, C: 12, D: true, E: 0.3, F: 0.03, G: 3, H: 3, I: 3},
+			{A: "d", B: 4, C: 13, D: true, E: 0.4, F: 0.04, G: 4, H: 4, I: 4},
+			{A: "e", B: 5, C: 14, D: true, E: 0.5, F: 0.05, G: 5, H: 5, I: 5},
+			{A: "f", B: 6, C: 15, D: true, E: 0.6, F: 0.06, G: 6, H: 6, I: 6},
+			{A: "g", B: 7, C: 16, D: true, E: 0.7, F: 0.07, G: 7, H: 7, I: 7},
+			{A: "h", B: 8, C: 17, D: true, E: 0.8, F: 0.08, G: 8, H: 8, I: 8},
+			{A: "i", B: 9, C: 18, D: true, E: 0.9, F: 0.09, G: 9, H: 9, I: 9},
+		}, slices.Collect(r))
+	})
 }
 
 func TestCrossJoin(t *testing.T) {
@@ -328,26 +406,54 @@ func TestCrossJoin(t *testing.T) {
 	emptyList := values[any]()
 	mixedList := values[any](9.6, 4, "foobar")
 
-	results1 := CrossJoin2(emptyList, listTwo)
-	is.Empty(slices.Collect(results1))
+	t.Run("empty first list", func(t *testing.T) {
+		t.Parallel()
 
-	results2 := CrossJoin2(listOne, emptyList)
-	is.Empty(slices.Collect(results2))
+		results := CrossJoin2(emptyList, listTwo)
+		is.Empty(slices.Collect(results))
+	})
 
-	results3 := CrossJoin2(emptyList, emptyList)
-	is.Empty(slices.Collect(results3))
+	t.Run("empty second list", func(t *testing.T) {
+		t.Parallel()
 
-	results4 := CrossJoin2(values("a"), listTwo)
-	is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("a", 2), lo.T2("a", 3)}, slices.Collect(results4))
+		results := CrossJoin2(listOne, emptyList)
+		is.Empty(slices.Collect(results))
+	})
 
-	results5 := CrossJoin2(listOne, values(1))
-	is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("b", 1), lo.T2("c", 1)}, slices.Collect(results5))
+	t.Run("both lists empty", func(t *testing.T) {
+		t.Parallel()
 
-	results6 := CrossJoin2(listOne, listTwo)
-	is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("a", 2), lo.T2("a", 3), lo.T2("b", 1), lo.T2("b", 2), lo.T2("b", 3), lo.T2("c", 1), lo.T2("c", 2), lo.T2("c", 3)}, slices.Collect(results6))
+		results := CrossJoin2(emptyList, emptyList)
+		is.Empty(slices.Collect(results))
+	})
 
-	results7 := CrossJoin2(listOne, mixedList)
-	is.Equal([]lo.Tuple2[string, any]{lo.T2[string, any]("a", 9.6), lo.T2[string, any]("a", 4), lo.T2[string, any]("a", "foobar"), lo.T2[string, any]("b", 9.6), lo.T2[string, any]("b", 4), lo.T2[string, any]("b", "foobar"), lo.T2[string, any]("c", 9.6), lo.T2[string, any]("c", 4), lo.T2[string, any]("c", "foobar")}, slices.Collect(results7))
+	t.Run("single element first list", func(t *testing.T) {
+		t.Parallel()
+
+		results := CrossJoin2(values("a"), listTwo)
+		is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("a", 2), lo.T2("a", 3)}, slices.Collect(results))
+	})
+
+	t.Run("single element second list", func(t *testing.T) {
+		t.Parallel()
+
+		results := CrossJoin2(listOne, values(1))
+		is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("b", 1), lo.T2("c", 1)}, slices.Collect(results))
+	})
+
+	t.Run("multiple elements both lists", func(t *testing.T) {
+		t.Parallel()
+
+		results := CrossJoin2(listOne, listTwo)
+		is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("a", 2), lo.T2("a", 3), lo.T2("b", 1), lo.T2("b", 2), lo.T2("b", 3), lo.T2("c", 1), lo.T2("c", 2), lo.T2("c", 3)}, slices.Collect(results))
+	})
+
+	t.Run("mixed type second list", func(t *testing.T) {
+		t.Parallel()
+
+		results := CrossJoin2(listOne, mixedList)
+		is.Equal([]lo.Tuple2[string, any]{lo.T2[string, any]("a", 9.6), lo.T2[string, any]("a", 4), lo.T2[string, any]("a", "foobar"), lo.T2[string, any]("b", 9.6), lo.T2[string, any]("b", 4), lo.T2[string, any]("b", "foobar"), lo.T2[string, any]("c", 9.6), lo.T2[string, any]("c", 4), lo.T2[string, any]("c", "foobar")}, slices.Collect(results))
+	})
 }
 
 func TestCrossJoinBy(t *testing.T) {
@@ -359,24 +465,52 @@ func TestCrossJoinBy(t *testing.T) {
 	emptyList := values[any]()
 	mixedList := values[any](9.6, 4, "foobar")
 
-	results1 := CrossJoinBy2(emptyList, listTwo, lo.T2[any, int])
-	is.Empty(slices.Collect(results1))
+	t.Run("empty first list", func(t *testing.T) {
+		t.Parallel()
 
-	results2 := CrossJoinBy2(listOne, emptyList, lo.T2[string, any])
-	is.Empty(slices.Collect(results2))
+		results := CrossJoinBy2(emptyList, listTwo, lo.T2[any, int])
+		is.Empty(slices.Collect(results))
+	})
 
-	results3 := CrossJoinBy2(emptyList, emptyList, lo.T2[any, any])
-	is.Empty(slices.Collect(results3))
+	t.Run("empty second list", func(t *testing.T) {
+		t.Parallel()
 
-	results4 := CrossJoinBy2(values("a"), listTwo, lo.T2[string, int])
-	is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("a", 2), lo.T2("a", 3)}, slices.Collect(results4))
+		results := CrossJoinBy2(listOne, emptyList, lo.T2[string, any])
+		is.Empty(slices.Collect(results))
+	})
 
-	results5 := CrossJoinBy2(listOne, values(1), lo.T2[string, int])
-	is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("b", 1), lo.T2("c", 1)}, slices.Collect(results5))
+	t.Run("both lists empty", func(t *testing.T) {
+		t.Parallel()
 
-	results6 := CrossJoinBy2(listOne, listTwo, lo.T2[string, int])
-	is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("a", 2), lo.T2("a", 3), lo.T2("b", 1), lo.T2("b", 2), lo.T2("b", 3), lo.T2("c", 1), lo.T2("c", 2), lo.T2("c", 3)}, slices.Collect(results6))
+		results := CrossJoinBy2(emptyList, emptyList, lo.T2[any, any])
+		is.Empty(slices.Collect(results))
+	})
 
-	results7 := CrossJoinBy2(listOne, mixedList, lo.T2[string, any])
-	is.Equal([]lo.Tuple2[string, any]{lo.T2[string, any]("a", 9.6), lo.T2[string, any]("a", 4), lo.T2[string, any]("a", "foobar"), lo.T2[string, any]("b", 9.6), lo.T2[string, any]("b", 4), lo.T2[string, any]("b", "foobar"), lo.T2[string, any]("c", 9.6), lo.T2[string, any]("c", 4), lo.T2[string, any]("c", "foobar")}, slices.Collect(results7))
+	t.Run("single element first list", func(t *testing.T) {
+		t.Parallel()
+
+		results := CrossJoinBy2(values("a"), listTwo, lo.T2[string, int])
+		is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("a", 2), lo.T2("a", 3)}, slices.Collect(results))
+	})
+
+	t.Run("single element second list", func(t *testing.T) {
+		t.Parallel()
+
+		results := CrossJoinBy2(listOne, values(1), lo.T2[string, int])
+		is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("b", 1), lo.T2("c", 1)}, slices.Collect(results))
+	})
+
+	t.Run("multiple elements both lists", func(t *testing.T) {
+		t.Parallel()
+
+		results := CrossJoinBy2(listOne, listTwo, lo.T2[string, int])
+		is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("a", 2), lo.T2("a", 3), lo.T2("b", 1), lo.T2("b", 2), lo.T2("b", 3), lo.T2("c", 1), lo.T2("c", 2), lo.T2("c", 3)}, slices.Collect(results))
+	})
+
+	t.Run("mixed type second list", func(t *testing.T) {
+		t.Parallel()
+
+		results := CrossJoinBy2(listOne, mixedList, lo.T2[string, any])
+		is.Equal([]lo.Tuple2[string, any]{lo.T2[string, any]("a", 9.6), lo.T2[string, any]("a", 4), lo.T2[string, any]("a", "foobar"), lo.T2[string, any]("b", 9.6), lo.T2[string, any]("b", 4), lo.T2[string, any]("b", "foobar"), lo.T2[string, any]("c", 9.6), lo.T2[string, any]("c", 4), lo.T2[string, any]("c", "foobar")}, slices.Collect(results))
+	})
 }

--- a/it/type_manipulation_test.go
+++ b/it/type_manipulation_test.go
@@ -45,7 +45,6 @@ func TestFromSeqPtrOr(t *testing.T) {
 
 func TestToAnySeq(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -60,6 +59,7 @@ func TestToAnySeq(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, slices.Collect(ToAnySeq(tt.input)))
 		})
 	}
@@ -67,7 +67,6 @@ func TestToAnySeq(t *testing.T) {
 
 func TestFromAnySeq(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name        string
@@ -83,6 +82,7 @@ func TestFromAnySeq(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 
 			out := FromAnySeq[string](tt.input)
 
@@ -104,7 +104,6 @@ func TestEmpty(t *testing.T) {
 
 func TestIsEmpty(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -119,6 +118,7 @@ func TestIsEmpty(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, IsEmpty(tt.input))
 		})
 	}
@@ -126,7 +126,6 @@ func TestIsEmpty(t *testing.T) {
 
 func TestIsNotEmpty(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -141,6 +140,7 @@ func TestIsNotEmpty(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 			is.Equal(tt.expected, IsNotEmpty(tt.input))
 		})
 	}
@@ -148,7 +148,6 @@ func TestIsNotEmpty(t *testing.T) {
 
 func TestCoalesceSeq(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	seq0 := values[int]()
 	seq1 := values(1)
@@ -173,6 +172,7 @@ func TestCoalesceSeq(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 
 			result, ok := CoalesceSeq(tt.args...)
 
@@ -190,7 +190,6 @@ func TestCoalesceSeq(t *testing.T) {
 
 func TestCoalesceSeqOrEmpty(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
 	seq0 := values[int]()
 	seq1 := values(1)
@@ -215,6 +214,7 @@ func TestCoalesceSeqOrEmpty(t *testing.T) {
 		tt := tt //nolint:modernize
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			is := assert.New(t)
 
 			result := CoalesceSeqOrEmpty(tt.args...)
 

--- a/it/type_manipulation_test.go
+++ b/it/type_manipulation_test.go
@@ -3,6 +3,7 @@
 package it
 
 import (
+	"iter"
 	"slices"
 	"testing"
 
@@ -46,24 +47,52 @@ func TestToAnySeq(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	in1 := values(0, 1, 2, 3)
-	in2 := values[int]()
-	out1 := ToAnySeq(in1)
-	out2 := ToAnySeq(in2)
+	tests := []struct {
+		name     string
+		input    iter.Seq[int]
+		expected []any
+	}{
+		{name: "with elements", input: values(0, 1, 2, 3), expected: []any{0, 1, 2, 3}},
+		{name: "empty", input: values[int](), expected: nil},
+	}
 
-	is.Equal([]any{0, 1, 2, 3}, slices.Collect(out1))
-	is.Empty(slices.Collect(out2))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, slices.Collect(ToAnySeq(tt.input)))
+		})
+	}
 }
 
 func TestFromAnySeq(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	out1 := FromAnySeq[string](values[any]("foobar", 42))
-	out2 := FromAnySeq[string](values[any]("foobar", "42"))
+	tests := []struct {
+		name        string
+		input       iter.Seq[any]
+		expectPanic bool
+		expected    []string
+	}{
+		{name: "type conversion failure panics", input: values[any]("foobar", 42), expectPanic: true},
+		{name: "successful conversion", input: values[any]("foobar", "42"), expected: []string{"foobar", "42"}},
+	}
 
-	is.PanicsWithValue("it.FromAnySeq: type conversion failed", func() { _ = slices.Collect(out1) })
-	is.Equal([]string{"foobar", "42"}, slices.Collect(out2))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			out := FromAnySeq[string](tt.input)
+
+			if tt.expectPanic {
+				is.PanicsWithValue("it.FromAnySeq: type conversion failed", func() { _ = slices.Collect(out) })
+			} else {
+				is.Equal(tt.expected, slices.Collect(out))
+			}
+		})
+	}
 }
 
 func TestEmpty(t *testing.T) {
@@ -77,16 +106,44 @@ func TestIsEmpty(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.True(IsEmpty(values[string]()))
-	is.False(IsEmpty(values("foo")))
+	tests := []struct {
+		name     string
+		input    iter.Seq[string]
+		expected bool
+	}{
+		{name: "empty sequence", input: values[string](), expected: true},
+		{name: "non-empty sequence", input: values("foo"), expected: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, IsEmpty(tt.input))
+		})
+	}
 }
 
 func TestIsNotEmpty(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	is.False(IsNotEmpty(values[string]()))
-	is.True(IsNotEmpty(values("foo")))
+	tests := []struct {
+		name     string
+		input    iter.Seq[string]
+		expected bool
+	}{
+		{name: "empty sequence", input: values[string](), expected: false},
+		{name: "non-empty sequence", input: values("foo"), expected: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is.Equal(tt.expected, IsNotEmpty(tt.input))
+		})
+	}
 }
 
 func TestCoalesceSeq(t *testing.T) {
@@ -97,41 +154,38 @@ func TestCoalesceSeq(t *testing.T) {
 	seq1 := values(1)
 	seq2 := values(1, 2)
 
-	result1, ok1 := CoalesceSeq[int]()
-	result4, ok4 := CoalesceSeq(seq0)
-	result6, ok6 := CoalesceSeq(seq2)
-	result7, ok7 := CoalesceSeq(seq1)
-	result8, ok8 := CoalesceSeq(seq1, seq2)
-	result9, ok9 := CoalesceSeq(seq2, seq1)
-	result10, ok10 := CoalesceSeq(seq0, seq1, seq2)
+	tests := []struct {
+		name       string
+		args       []iter.Seq[int]
+		expected   []int
+		expectedOk bool
+	}{
+		{name: "no sequences", args: nil, expectedOk: false},
+		{name: "single empty sequence", args: []iter.Seq[int]{seq0}, expectedOk: false},
+		{name: "single sequence with two elements", args: []iter.Seq[int]{seq2}, expected: []int{1, 2}, expectedOk: true},
+		{name: "single sequence with one element", args: []iter.Seq[int]{seq1}, expected: []int{1}, expectedOk: true},
+		{name: "first non-empty sequence wins (one then two elements)", args: []iter.Seq[int]{seq1, seq2}, expected: []int{1}, expectedOk: true},
+		{name: "first non-empty sequence wins (two then one elements)", args: []iter.Seq[int]{seq2, seq1}, expected: []int{1, 2}, expectedOk: true},
+		{name: "skips leading empty sequence", args: []iter.Seq[int]{seq0, seq1, seq2}, expected: []int{1}, expectedOk: true},
+	}
 
-	is.NotNil(result1)
-	is.Empty(slices.Collect(result1))
-	is.False(ok1)
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	is.NotNil(result4)
-	is.Empty(slices.Collect(result4))
-	is.False(ok4)
+			result, ok := CoalesceSeq(tt.args...)
 
-	is.NotNil(result6)
-	is.Equal(slices.Collect(seq2), slices.Collect(result6))
-	is.True(ok6)
+			is.NotNil(result)
+			is.Equal(tt.expectedOk, ok)
 
-	is.NotNil(result7)
-	is.Equal(slices.Collect(seq1), slices.Collect(result7))
-	is.True(ok7)
-
-	is.NotNil(result8)
-	is.Equal(slices.Collect(seq1), slices.Collect(result8))
-	is.True(ok8)
-
-	is.NotNil(result9)
-	is.Equal(slices.Collect(seq2), slices.Collect(result9))
-	is.True(ok9)
-
-	is.NotNil(result10)
-	is.Equal(slices.Collect(seq1), slices.Collect(result10))
-	is.True(ok10)
+			if tt.expectedOk {
+				is.Equal(tt.expected, slices.Collect(result))
+			} else {
+				is.Empty(slices.Collect(result))
+			}
+		})
+	}
 }
 
 func TestCoalesceSeqOrEmpty(t *testing.T) {
@@ -142,26 +196,35 @@ func TestCoalesceSeqOrEmpty(t *testing.T) {
 	seq1 := values(1)
 	seq2 := values(1, 2)
 
-	result1 := CoalesceSeqOrEmpty[int]()
-	result4 := CoalesceSeqOrEmpty(seq0)
-	result6 := CoalesceSeqOrEmpty(seq2)
-	result7 := CoalesceSeqOrEmpty(seq1)
-	result8 := CoalesceSeqOrEmpty(seq1, seq2)
-	result9 := CoalesceSeqOrEmpty(seq2, seq1)
-	result10 := CoalesceSeqOrEmpty(seq0, seq1, seq2)
+	tests := []struct {
+		name       string
+		args       []iter.Seq[int]
+		expected   []int
+		expectHits bool
+	}{
+		{name: "no sequences", args: nil, expectHits: false},
+		{name: "single empty sequence", args: []iter.Seq[int]{seq0}, expectHits: false},
+		{name: "single sequence with two elements", args: []iter.Seq[int]{seq2}, expected: []int{1, 2}, expectHits: true},
+		{name: "single sequence with one element", args: []iter.Seq[int]{seq1}, expected: []int{1}, expectHits: true},
+		{name: "first non-empty sequence wins (one then two elements)", args: []iter.Seq[int]{seq1, seq2}, expected: []int{1}, expectHits: true},
+		{name: "first non-empty sequence wins (two then one elements)", args: []iter.Seq[int]{seq2, seq1}, expected: []int{1, 2}, expectHits: true},
+		{name: "skips leading empty sequence", args: []iter.Seq[int]{seq0, seq1, seq2}, expected: []int{1}, expectHits: true},
+	}
 
-	is.NotNil(result1)
-	is.Empty(slices.Collect(result1))
-	is.NotNil(result4)
-	is.Empty(slices.Collect(result4))
-	is.NotNil(result6)
-	is.Equal(slices.Collect(seq2), slices.Collect(result6))
-	is.NotNil(result7)
-	is.Equal(slices.Collect(seq1), slices.Collect(result7))
-	is.NotNil(result8)
-	is.Equal(slices.Collect(seq1), slices.Collect(result8))
-	is.NotNil(result9)
-	is.Equal(slices.Collect(seq2), slices.Collect(result9))
-	is.NotNil(result10)
-	is.Equal(slices.Collect(seq1), slices.Collect(result10))
+	for _, tt := range tests {
+		tt := tt //nolint:modernize
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := CoalesceSeqOrEmpty(tt.args...)
+
+			is.NotNil(result)
+
+			if tt.expectHits {
+				is.Equal(tt.expected, slices.Collect(result))
+			} else {
+				is.Empty(slices.Collect(result))
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

All `it/` test files already used testify. Splits multi-scenario `Test` functions into named `t.Run` subtests:
- A shared `[]struct{name string; ...}` data table + loop, when cases share the same generic instantiation of the function under test.
- Separate named `t.Run` subtests (no shared struct), when cases use different generic instantiations (e.g. `Tuple2`..`Tuple9` arities in `TestZip`/`TestCrossJoin`, or `int` vs. `string` instantiations elsewhere) — forcing those into one `any`-typed table would lose type safety for no benefit.

Files touched: `find_test.go`, `intersect_test.go`, `map_test.go`, `math_test.go`, `seq_test.go`, `string_test.go`, `tuples_test.go`, `type_manipulation_test.go`. `channel_test.go` and `lo_test.go` are unchanged — every test there is already single-scenario, and wrapping a single case in a fake one-row table adds no value.

### `//nolint:modernize` on table loops

`it/` files carry the `//go:build go1.23` constraint, which makes that file's loop-variable semantics per-iteration already (Go 1.22+ behavior applies per-file, not just per-module). That means golangci-lint's `modernize`/`forvar` check flags the usual `tt := tt` reinit as redundant, while `paralleltest` still requires it for any `t.Run` closure that calls `t.Parallel()`. Both linters are satisfied with `tt := tt //nolint:modernize`, following the precedent already present in `it/seq_test.go` before this change.

## Test plan

`go build`, `go vet`, `go test -race -count=1`, and `golangci-lint run` all pass clean for the `it` package, and `go build ./...` / `go vet ./...` confirm the rest of the repo is unaffected.
