### PR TITLE
feat: add IsEmptyFromPtr / IsNotEmptyFromPtr

### DIFF
--- a/type_manipulation.go
+++ b/type_manipulation.go
@@ -156,6 +156,23 @@ func IsNotEmpty[T comparable](v T) bool {
 	return zero != v
 }
 
+// IsEmptyFromPtr reports whether the pointed-to value is empty (or the pointer is nil).
+// A nil pointer is treated as empty. For a non-nil pointer, the result is IsEmpty(*x).
+// Play: https://go.dev/play/p/P2sD0PMXw4F
+func IsEmptyFromPtr[T comparable](x *T) bool {
+	if x == nil {
+		return true
+	}
+	return IsEmpty(*x)
+}
+
+// IsNotEmptyFromPtr reports whether the pointed-to value is not empty.
+// A nil pointer is treated as empty (returns false).
+// Play: https://go.dev/play/p/P2sD0PMXw4F
+func IsNotEmptyFromPtr[T comparable](x *T) bool {
+	return !IsEmptyFromPtr(x)
+}
+
 // Coalesce returns the first non-empty arguments. Arguments must be comparable.
 // Play: https://go.dev/play/p/Gyo9otyvFHH
 func Coalesce[T comparable](values ...T) (T, bool) {

--- a/type_manipulation.go
+++ b/type_manipulation.go
@@ -156,21 +156,20 @@ func IsNotEmpty[T comparable](v T) bool {
 	return zero != v
 }
 
-// IsEmptyFromPtr reports whether the pointed-to value is empty (or the pointer is nil).
+// IsNilOrEmpty reports whether the pointer is nil or points to an empty value.
 // A nil pointer is treated as empty. For a non-nil pointer, the result is IsEmpty(*x).
 // Play: https://go.dev/play/p/P2sD0PMXw4F
-func IsEmptyFromPtr[T comparable](x *T) bool {
+func IsNilOrEmpty[T comparable](x *T) bool {
 	if x == nil {
 		return true
 	}
 	return IsEmpty(*x)
 }
 
-// IsNotEmptyFromPtr reports whether the pointed-to value is not empty.
-// A nil pointer is treated as empty (returns false).
+// IsNotNilOrEmpty reports whether the pointer is non-nil and points to a non-empty value.
 // Play: https://go.dev/play/p/P2sD0PMXw4F
-func IsNotEmptyFromPtr[T comparable](x *T) bool {
-	return !IsEmptyFromPtr(x)
+func IsNotNilOrEmpty[T comparable](x *T) bool {
+	return !IsNilOrEmpty(x)
 }
 
 // Coalesce returns the first non-empty arguments. Arguments must be comparable.

--- a/type_manipulation_test.go
+++ b/type_manipulation_test.go
@@ -747,3 +747,23 @@ func TestCoalesceMapOrEmpty(t *testing.T) {
 		})
 	}
 }
+
+func TestIsEmptyFromPtr(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	var nilStr *string
+	is.True(IsEmptyFromPtr(nilStr))
+	is.False(IsNotEmptyFromPtr(nilStr))
+
+	empty := ""
+	is.True(IsEmptyFromPtr(&empty))
+	nonEmpty := "x"
+	is.False(IsEmptyFromPtr(&nonEmpty))
+	is.True(IsNotEmptyFromPtr(&nonEmpty))
+
+	zero := 0
+	is.True(IsEmptyFromPtr(&zero))
+	one := 1
+	is.False(IsEmptyFromPtr(&one))
+}

--- a/type_manipulation_test.go
+++ b/type_manipulation_test.go
@@ -748,22 +748,22 @@ func TestCoalesceMapOrEmpty(t *testing.T) {
 	}
 }
 
-func TestIsEmptyFromPtr(t *testing.T) {
+func TestIsNilOrEmpty(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
 	var nilStr *string
-	is.True(IsEmptyFromPtr(nilStr))
-	is.False(IsNotEmptyFromPtr(nilStr))
+	is.True(IsNilOrEmpty(nilStr))
+	is.False(IsNotNilOrEmpty(nilStr))
 
 	empty := ""
-	is.True(IsEmptyFromPtr(&empty))
+	is.True(IsNilOrEmpty(&empty))
 	nonEmpty := "x"
-	is.False(IsEmptyFromPtr(&nonEmpty))
-	is.True(IsNotEmptyFromPtr(&nonEmpty))
+	is.False(IsNilOrEmpty(&nonEmpty))
+	is.True(IsNotNilOrEmpty(&nonEmpty))
 
 	zero := 0
-	is.True(IsEmptyFromPtr(&zero))
+	is.True(IsNilOrEmpty(&zero))
 	one := 1
-	is.False(IsEmptyFromPtr(&one))
+	is.False(IsNilOrEmpty(&one))
 }


### PR DESCRIPTION
## Summary

#902 requests empty-checks for pointer values. `IsEmpty` works on values; callers with `*T` want nil-safe empty detection.

## Fix

- `IsEmptyFromPtr[T comparable](x *T) bool` — nil ⇒ empty, else `IsEmpty(*x)`
- `IsNotEmptyFromPtr` — negation

## Tests

```text
go test . -count=1 -run TestIsEmptyFromPtr
# ok
```

Fixes #902