### PR TITLE
Add llms.txt linking Sourcey-generated API docs

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,14 @@
+# lo
+
+> github.com/samber/lo
+
+## Go API
+
+- [github.com/samber/lo](https://gemquota.github.io/lo-sourcey-docs/api/package-root.html): github.com/samber/lo
+- [internal/constraints](https://gemquota.github.io/lo-sourcey-docs/api/pkg-internal-constraints.html): Package constraints defines a set of useful constraints to be used with type parameters.
+- [internal/xrand](https://gemquota.github.io/lo-sourcey-docs/api/pkg-internal-xrand.html): github.com/samber/lo/internal/xrand
+- [internal/xtime](https://gemquota.github.io/lo-sourcey-docs/api/pkg-internal-xtime.html): github.com/samber/lo/internal/xtime
+- [it](https://gemquota.github.io/lo-sourcey-docs/api/pkg-it.html): github.com/samber/lo/it
+- [mutable](https://gemquota.github.io/lo-sourcey-docs/api/pkg-mutable.html): github.com/samber/lo/mutable
+- [parallel](https://gemquota.github.io/lo-sourcey-docs/api/pkg-parallel.html): github.com/samber/lo/parallel
+- [Go API](https://gemquota.github.io/lo-sourcey-docs/api.html): github.com/samber/lo


### PR DESCRIPTION
Adds an `llms.txt` pointing agents at the live Sourcey-generated reference for `lo`.

- Generated with Sourcey v3.6.5 (godoc mode) from pinned commit `b17aaeb2cd42dbd47e6fb4a9dcab137dcc903474`
- Published live: https://gemquota.github.io/lo-sourcey-docs/
- The docs are regenerable from source (sourcey.config.ts + pinned checkout); happy to move them under the repo's own hosting if preferred

Ref: https://llmstxt.org