### PR TITLE
fix: relax it.WithoutNth type constraint from comparable to any

### DIFF
--- a/docs/data/core-withoutnth.md
+++ b/docs/data/core-withoutnth.md
@@ -13,7 +13,7 @@ similarHelpers:
   - core#slice#dropbyindex
 position: 140
 signatures:
-  - "func WithoutNth[T comparable, Slice ~[]T](collection Slice, nths ...int) Slice"
+  - "func WithoutNth[T any, Slice ~[]T](collection Slice, nths ...int) Slice"
 ---
 
 Returns a slice excluding the elements at the given indexes.

--- a/docs/data/it-withoutnth.md
+++ b/docs/data/it-withoutnth.md
@@ -5,7 +5,7 @@ sourceRef: it/intersect.go#L253
 category: iter
 subCategory: intersect
 signatures:
-  - "func WithoutNth[T comparable, I ~func(func(T) bool)](collection I, nths ...int) I"
+  - "func WithoutNth[T any, I ~func(func(T) bool)](collection I, nths ...int) I"
 playUrl: "https://go.dev/play/p/KGE7Lpsk18P"
 variantHelpers:
   - iter#intersect#withoutnth

--- a/it/intersect.go
+++ b/it/intersect.go
@@ -250,7 +250,7 @@ func WithoutBy[T any, K comparable, I ~func(func(T) bool)](collection I, transfo
 // WithoutNth returns a sequence excluding the nth value.
 // Will allocate a map large enough to hold all distinct nths.
 // Play: https://go.dev/play/p/KGE7Lpsk18P
-func WithoutNth[T comparable, I ~func(func(T) bool)](collection I, nths ...int) I {
+func WithoutNth[T any, I ~func(func(T) bool)](collection I, nths ...int) I {
 	set := lo.Keyify(nths)
 	return RejectI(collection, func(_ T, index int) bool { return lo.HasKey(set, index) })
 }

--- a/it/intersect_test.go
+++ b/it/intersect_test.go
@@ -517,6 +517,17 @@ func TestWithoutNth(t *testing.T) {
 	})
 }
 
+func TestWithoutNthNonComparable(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	// Slices are not comparable; WithoutNth should accept T any (not T comparable)
+	// since it only operates on indices.
+	input := slices.Values([][]int{{1, 2}, {3, 4}, {5, 6}})
+	result := slices.Collect(WithoutNth(input, 1))
+	is.Equal([][]int{{1, 2}, {5, 6}}, result)
+}
+
 func TestElementsMatch(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #959

## Problem

`it.WithoutNth` uses `T comparable` type constraint, but `lo.WithoutNth` correctly uses `T any`. Since `WithoutNth` only operates on indices (`nths ...int`) and never compares `T` values, the `comparable` constraint is unnecessarily restrictive. This prevents using `it.WithoutNth` with non-comparable types such as slices, maps, or funcs.

## Reproduction

`go
seq := slices.Values([][]int{{1, 2}, {3, 4}, {5, 6}})
result := slices.Collect(it.WithoutNth(seq, 1))
// compile error: []int does not satisfy comparable
`

## Root Cause

The `T comparable` constraint on `it.WithoutNth` was copied from `it.Without` (which genuinely needs it to compare values). But `WithoutNth` calls `RejectI` (`T any`) and `lo.Keyify` on `nths` (`[]int`), neither of which requires `T` to be comparable.

## Fix

- Changed `it.WithoutNth` type parameter from `T comparable` to `T any`
- Fixed doc signatures in `docs/data/core-withoutnth.md` (`lo.WithoutNth` was already `T any` in code but `T comparable` in docs)
- Fixed doc signature in `docs/data/it-withoutnth.md`

## Compatibility

This is a **non-breaking** change. Loosening a type constraint from `comparable` to `any` is backward compatible — all existing code continues to compile, and new code with non-comparable types now also works.

## Validation

`
ok  github.com/samber/lo       8.391s
ok  github.com/samber/lo/it    0.536s
ok  github.com/samber/lo/mutable  0.396s
ok  github.com/samber/lo/parallel 0.386s
`

`go build ./...`, `go vet ./...`, and `gofmt` all clean. Added regression test `TestWithoutNthNonComparable` that verifies non-comparable types (`[][]int`) work correctly.