### PR TITLE
docs: fix broken benchmark link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5152,7 +5152,7 @@ lo.Assertf(age >= 15, "user age must be >= 15, got %d", age)
 
 We executed a simple benchmark with a dead-simple `lo.Map` loop:
 
-See the full implementation [here](./map_benchmark_test.go).
+See the full implementation [here](./benchmark/core_map_bench_test.go).
 
 ```go
 _ = lo.Map[int64](arr, func(x int64, i int) string {


### PR DESCRIPTION
The README links the map benchmark implementation:

> See the full implementation [here](./map_benchmark_test.go).

`map_benchmark_test.go` no longer exists at the repo root, so the link 404s. The root test files were moved out in #719 ("reduce the number of files in root directory"), and the map benchmarks now live in `benchmark/core_map_bench_test.go`. This repoints the link there.
