### PR TITLE
test(it): cover early-termination branches

### DIFF
--- a/it/find_test.go
+++ b/it/find_test.go
@@ -301,6 +301,7 @@ func TestFindUniquesBy(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
 			result := FindUniquesBy(values(tt.input...), mod3)
+			assertSeqSupportBreak(t, result)
 			is.Equal(tt.expected, slices.Collect(result))
 		})
 	}
@@ -372,6 +373,7 @@ func TestFindDuplicatesBy(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
 			result := FindDuplicatesBy(values(tt.input...), tt.keyFn)
+			assertSeqSupportBreak(t, result)
 			is.Equal(tt.expected, slices.Collect(result))
 		})
 	}

--- a/it/intersect_test.go
+++ b/it/intersect_test.go
@@ -263,7 +263,9 @@ func TestIntersect(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			result := slices.Collect(Intersect(tt.inputs...))
+			seq := Intersect(tt.inputs...)
+			assertSeqSupportBreak(t, seq)
+			result := slices.Collect(seq)
 			if tt.expected == nil {
 				is.Empty(result)
 			} else {
@@ -310,7 +312,9 @@ func TestIntersectBy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			result := slices.Collect(IntersectBy(transform, tt.inputs...))
+			seq := IntersectBy(transform, tt.inputs...)
+			assertSeqSupportBreak(t, seq)
+			result := slices.Collect(seq)
 			if tt.expected == nil {
 				is.Empty(result)
 			} else {
@@ -356,7 +360,9 @@ func TestUnion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			result := slices.Collect(Union(tt.inputs...))
+			seq := Union(tt.inputs...)
+			assertSeqSupportBreak(t, seq)
+			result := slices.Collect(seq)
 			if tt.expected == nil {
 				is.Empty(result)
 			} else {

--- a/it/lo_test.go
+++ b/it/lo_test.go
@@ -26,6 +26,22 @@ func assertSeqSupportBreak[T any](t *testing.T, seq iter.Seq[T]) iter.Seq[T] {
 	return seq
 }
 
+// assertSeq2SupportBreak checks whether it is possible to break iteration over a [iter.Seq2].
+func assertSeq2SupportBreak[K, V any](t *testing.T, seq iter.Seq2[K, V]) iter.Seq2[K, V] {
+	t.Helper()
+	assert.NotPanics(t, func() {
+		for range seq {
+			break
+		}
+
+		for range seq {
+			return
+		}
+	})
+
+	return seq
+}
+
 func values[T any](v ...T) iter.Seq[T] { return slices.Values(v) }
 
 type foo struct {

--- a/it/map_test.go
+++ b/it/map_test.go
@@ -32,7 +32,9 @@ func TestKeys(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.ElementsMatch(tt.expected, slices.Collect(Keys(tt.maps...)))
+			seq := Keys(tt.maps...)
+			assertSeqSupportBreak(t, seq)
+			is.ElementsMatch(tt.expected, slices.Collect(seq))
 		})
 	}
 }
@@ -59,7 +61,9 @@ func TestUniqKeys(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			result := slices.Collect(UniqKeys(tt.maps...))
+			seq := UniqKeys(tt.maps...)
+			assertSeqSupportBreak(t, seq)
+			result := slices.Collect(seq)
 			if tt.exact {
 				is.Equal(tt.expected, result)
 			} else {
@@ -89,7 +93,9 @@ func TestValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.ElementsMatch(tt.expected, slices.Collect(Values(tt.maps...)))
+			seq := Values(tt.maps...)
+			assertSeqSupportBreak(t, seq)
+			is.ElementsMatch(tt.expected, slices.Collect(seq))
 		})
 	}
 }
@@ -117,7 +123,9 @@ func TestUniqValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			result := slices.Collect(UniqValues(tt.maps...))
+			seq := UniqValues(tt.maps...)
+			assertSeqSupportBreak(t, seq)
+			result := slices.Collect(seq)
 			if tt.exact {
 				is.Equal(tt.expected, result)
 			} else {
@@ -131,7 +139,9 @@ func TestEntries(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	r1 := maps.Collect(Entries(map[string]int{"foo": 1, "bar": 2}))
+	seq := Entries(map[string]int{"foo": 1, "bar": 2})
+	assertSeq2SupportBreak(t, seq)
+	r1 := maps.Collect(seq)
 	is.Equal(map[string]int{"foo": 1, "bar": 2}, r1)
 }
 
@@ -172,6 +182,7 @@ func TestInvert(t *testing.T) {
 		t.Parallel()
 		is := assert.New(t)
 		r1 := Invert(maps.All(map[string]int{"a": 1, "b": 2}))
+		assertSeq2SupportBreak(t, r1)
 		is.Equal(map[int]string{1: "a", 2: "b"}, maps.Collect(r1))
 	})
 
@@ -179,6 +190,7 @@ func TestInvert(t *testing.T) {
 		t.Parallel()
 		is := assert.New(t)
 		r2 := Invert(maps.All(map[string]int{"a": 1, "b": 2, "c": 1}))
+		assertSeq2SupportBreak(t, r2)
 		is.Len(maps.Collect(r2), 2)
 	})
 }
@@ -227,7 +239,9 @@ func TestChunkEntries(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 				is := assert.New(t)
-				is.Len(slices.Collect(ChunkEntries(tt.input, tt.size)), tt.expectedLen)
+				seq := ChunkEntries(tt.input, tt.size)
+				assertSeqSupportBreak(t, seq)
+				is.Len(slices.Collect(seq), tt.expectedLen)
 			})
 		}
 	})
@@ -310,7 +324,9 @@ func TestMapToSeq(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.ElementsMatch(tt.expected, slices.Collect(MapToSeq(tt.input, tt.transform)))
+			seq := MapToSeq(tt.input, tt.transform)
+			assertSeqSupportBreak(t, seq)
+			is.ElementsMatch(tt.expected, slices.Collect(seq))
 		})
 	}
 }
@@ -343,7 +359,9 @@ func TestFilterMapToSeq(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.ElementsMatch(tt.expected, slices.Collect(FilterMapToSeq(tt.input, tt.filter)))
+			seq := FilterMapToSeq(tt.input, tt.filter)
+			assertSeqSupportBreak(t, seq)
+			is.ElementsMatch(tt.expected, slices.Collect(seq))
 		})
 	}
 }
@@ -357,6 +375,7 @@ func TestFilterKeys(t *testing.T) {
 		result1 := FilterKeys(map[int]string{1: "foo", 2: "bar", 3: "baz"}, func(k int, v string) bool {
 			return v == "foo"
 		})
+		assertSeqSupportBreak(t, result1)
 		is.Equal([]int{1}, slices.Collect(result1))
 	})
 
@@ -379,6 +398,7 @@ func TestFilterValues(t *testing.T) {
 		result1 := FilterValues(map[int]string{1: "foo", 2: "bar", 3: "baz"}, func(k int, v string) bool {
 			return v == "foo"
 		})
+		assertSeqSupportBreak(t, result1)
 		is.Equal([]string{"foo"}, slices.Collect(result1))
 	})
 
@@ -409,7 +429,9 @@ func TestSeq2KeyToSeq(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.ElementsMatch(tt.expected, slices.Collect(Seq2KeyToSeq(maps.All(tt.input))))
+			seq := Seq2KeyToSeq(maps.All(tt.input))
+			assertSeqSupportBreak(t, seq)
+			is.ElementsMatch(tt.expected, slices.Collect(seq))
 		})
 	}
 }
@@ -431,7 +453,9 @@ func TestSeq2ValueToSeq(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.ElementsMatch(tt.expected, slices.Collect(Seq2ValueToSeq(maps.All(tt.input))))
+			seq := Seq2ValueToSeq(maps.All(tt.input))
+			assertSeqSupportBreak(t, seq)
+			is.ElementsMatch(tt.expected, slices.Collect(seq))
 		})
 	}
 }

--- a/it/math_test.go
+++ b/it/math_test.go
@@ -28,7 +28,9 @@ func TestRange(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
 
-			result := slices.Collect(Range(tt.n))
+			seq := Range(tt.n)
+			assertSeqSupportBreak(t, seq)
+			result := slices.Collect(seq)
 			if tt.expected == nil {
 				is.Empty(result)
 			} else {
@@ -121,7 +123,9 @@ func TestRangeWithSteps(t *testing.T) {
 				t.Parallel()
 				is := assert.New(t)
 
-				result := slices.Collect(RangeWithSteps(tt.start, tt.end, tt.step))
+				seq := RangeWithSteps(tt.start, tt.end, tt.step)
+				assertSeqSupportBreak(t, seq)
+				result := slices.Collect(seq)
 				if tt.expected == nil {
 					is.Empty(result)
 				} else {
@@ -161,6 +165,7 @@ func TestRangeWithSteps(t *testing.T) {
 		is := assert.New(t)
 
 		result := RangeWithSteps[float32](-1.0, -4.0, -1.0)
+		assertSeqSupportBreak(t, result)
 		is.Equal([]float32{-1.0, -2.0, -3.0}, slices.Collect(result))
 	})
 

--- a/it/seq_test.go
+++ b/it/seq_test.go
@@ -92,6 +92,7 @@ func TestFilterI(t *testing.T) {
 		r1 := FilterI(values(1, 2, 3, 4), func(x, _ int) bool {
 			return x%2 == 0
 		})
+		assertSeqSupportBreak(t, r1)
 		is.Equal([]int{2, 4}, slices.Collect(r1))
 	})
 
@@ -230,6 +231,7 @@ func TestFilterMapI(t *testing.T) {
 			}
 			return "", false
 		})
+		assertSeqSupportBreak(t, r1)
 		is.Equal([]string{"2", "4"}, slices.Collect(r1))
 	})
 
@@ -281,6 +283,7 @@ func TestFlatMapI(t *testing.T) {
 		result1 := FlatMapI(values(0, 1, 2, 3, 4), func(x, _ int) iter.Seq[string] {
 			return values("Hello")
 		})
+		assertSeqSupportBreak(t, result1)
 		is.Equal([]string{"Hello", "Hello", "Hello", "Hello", "Hello"}, slices.Collect(result1))
 	})
 
@@ -307,6 +310,7 @@ func TestTimes(t *testing.T) {
 	result1 := Times(3, func(i int) string {
 		return strconv.FormatInt(int64(i), 10)
 	})
+	assertSeqSupportBreak(t, result1)
 	is.Equal([]string{"0", "1", "2"}, slices.Collect(result1))
 }
 
@@ -469,6 +473,7 @@ func TestUniqBy(t *testing.T) {
 		result1 := UniqBy(values(0, 1, 2, 3, 4, 5), func(i int) int {
 			return i % 3
 		})
+		assertSeqSupportBreak(t, result1)
 		is.Equal([]int{0, 1, 2}, slices.Collect(result1))
 	})
 
@@ -571,7 +576,9 @@ func TestChunk(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.Equal(tt.expected, slices.Collect(Chunk(values(tt.input...), tt.size)))
+			seq := Chunk(values(tt.input...), tt.size)
+			assertSeqSupportBreak(t, seq)
+			is.Equal(tt.expected, slices.Collect(seq))
 		})
 	}
 
@@ -667,7 +674,9 @@ func TestSliding(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.Equal(tt.expected, slices.Collect(Sliding(values(tt.input...), tt.size, tt.step)))
+			seq := Sliding(values(tt.input...), tt.size, tt.step)
+			assertSeqSupportBreak(t, seq)
+			is.Equal(tt.expected, slices.Collect(seq))
 		})
 	}
 
@@ -811,6 +820,7 @@ func TestFlatten(t *testing.T) {
 		t.Parallel()
 		is := assert.New(t)
 		result1 := Flatten([]iter.Seq[int]{values(0, 1), values(2, 3, 4, 5)})
+		assertSeqSupportBreak(t, result1)
 		is.Equal([]int{0, 1, 2, 3, 4, 5}, slices.Collect(result1))
 	})
 
@@ -881,7 +891,9 @@ func TestInterleave(t *testing.T) {
 		tc := tc //nolint:modernize
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.want, slices.Collect(Interleave(tc.in...)))
+			seq := Interleave(tc.in...)
+			assertSeqSupportBreak(t, seq)
+			assert.Equal(t, tc.want, slices.Collect(seq))
 		})
 	}
 }
@@ -931,7 +943,9 @@ func TestReverse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.Equal(tt.expected, slices.Collect(Reverse(values(tt.input...))))
+			seq := Reverse(values(tt.input...))
+			assertSeqSupportBreak(t, seq)
+			is.Equal(tt.expected, slices.Collect(seq))
 		})
 	}
 
@@ -962,7 +976,9 @@ func TestFill(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.Equal(tt.expected, slices.Collect(Fill(values(tt.input...), tt.fillWith)))
+			seq := Fill(values(tt.input...), tt.fillWith)
+			assertSeqSupportBreak(t, seq)
+			is.Equal(tt.expected, slices.Collect(seq))
 		})
 	}
 }
@@ -1010,7 +1026,9 @@ func TestRepeatBy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.Equal(tt.expected, slices.Collect(RepeatBy(tt.count, cb)))
+			seq := RepeatBy(tt.count, cb)
+			assertSeqSupportBreak(t, seq)
+			is.Equal(tt.expected, slices.Collect(seq))
 		})
 	}
 }
@@ -1316,7 +1334,9 @@ func TestDropLast(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.Equal(tt.expected, slices.Collect(DropLast(values(0, 1, 2, 3, 4), tt.n)))
+			seq := DropLast(values(0, 1, 2, 3, 4), tt.n)
+			assertSeqSupportBreak(t, seq)
+			is.Equal(tt.expected, slices.Collect(seq))
 		})
 	}
 
@@ -1355,7 +1375,9 @@ func TestDropWhile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.Equal(tt.expected, slices.Collect(DropWhile(values(0, 1, 2, 3, 4, 5, 6), tt.predicate)))
+			seq := DropWhile(values(0, 1, 2, 3, 4, 5, 6), tt.predicate)
+			assertSeqSupportBreak(t, seq)
+			is.Equal(tt.expected, slices.Collect(seq))
 		})
 	}
 
@@ -1389,7 +1411,9 @@ func TestDropLastWhile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.Equal(tt.expected, slices.Collect(DropLastWhile(values(0, 1, 2, 3, 4, 5, 6), tt.predicate)))
+			seq := DropLastWhile(values(0, 1, 2, 3, 4, 5, 6), tt.predicate)
+			assertSeqSupportBreak(t, seq)
+			is.Equal(tt.expected, slices.Collect(seq))
 		})
 	}
 
@@ -1672,6 +1696,7 @@ func TestRejectI(t *testing.T) {
 		r1 := RejectI(values(1, 2, 3, 4), func(x, _ int) bool {
 			return x%2 == 0
 		})
+		assertSeqSupportBreak(t, r1)
 		is.Equal([]int{1, 3}, slices.Collect(r1))
 	})
 
@@ -1734,6 +1759,7 @@ func TestRejectMapI(t *testing.T) {
 			}
 			return "", true
 		})
+		assertSeqSupportBreak(t, r1)
 		is.Equal([]string{"2", "4"}, slices.Collect(r1))
 	})
 
@@ -1874,6 +1900,22 @@ func TestSubset(t *testing.T) {
 		nonempty := Subset(allStrings, 0, 2)
 		is.IsType(nonempty, allStrings, "type preserved")
 	})
+
+	t.Run("panics on negative offset", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+		is.PanicsWithValue("it.Subset: offset must not be negative", func() {
+			Subset(values(0, 1, 2), -1, 2)
+		})
+	})
+
+	t.Run("panics on negative length", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+		is.PanicsWithValue("it.Subset: length must not be negative", func() {
+			Subset(values(0, 1, 2), 0, -1)
+		})
+	})
 }
 
 func TestSlice(t *testing.T) {
@@ -1899,6 +1941,8 @@ func TestSlice(t *testing.T) {
 		{name: "start after end both large", start: 5, end: 0, expected: nil},
 		{name: "start beyond collection end within", start: 6, end: 4, expected: nil},
 		{name: "start and end both beyond collection", start: 6, end: 7, expected: nil},
+		{name: "negative start clamped to zero", start: -10, end: 2, expected: []int{0, 1}},
+		{name: "negative end clamped to zero", start: -10, end: -1, expected: nil},
 	}
 
 	for _, tt := range tests {
@@ -2122,7 +2166,9 @@ func TestSplice(t *testing.T) {
 		t.Parallel()
 		is := assert.New(t)
 		sample := values("a", "b", "c", "d", "e", "f", "g")
-		results := slices.Collect(Splice(sample, 1, "1", "2"))
+		seq := Splice(sample, 1, "1", "2")
+		assertSeqSupportBreak(t, seq) // first yield is the original item ("a"), before any inserted element
+		results := slices.Collect(seq)
 		is.Equal([]string{"a", "b", "c", "d", "e", "f", "g"}, slices.Collect(sample))
 		is.Equal([]string{"a", "1", "2", "b", "c", "d", "e", "f", "g"}, results)
 	})
@@ -2136,13 +2182,46 @@ func TestSplice(t *testing.T) {
 		is.Equal([]string{"a", "b", "c", "d", "e", "f", "g", "1", "2"}, results)
 	})
 
+	t.Run("breaks during trailing insert when index beyond collection", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+		seq := Splice(values("a", "b", "c"), 42, "1", "2")
+		var collected []string
+		count := 0
+		for item := range seq {
+			collected = append(collected, item)
+			count++
+			if count == 4 { // stop mid-way through the trailing appended elements
+				break
+			}
+		}
+		is.Equal([]string{"a", "b", "c", "1"}, collected)
+	})
+
 	t.Run("other cases", func(t *testing.T) {
 		t.Parallel()
 		is := assert.New(t)
 		is.Equal([]string{"1", "2"}, slices.Collect(Splice(values[string](), 0, "1", "2")))
 		is.Equal([]string{"1", "2"}, slices.Collect(Splice(values[string](), 1, "1", "2")))
-		is.Equal([]string{"1", "2", "0"}, slices.Collect(Splice(values("0"), 0, "1", "2")))
+		seq := Splice(values("0"), 0, "1", "2")
+		assertSeqSupportBreak(t, seq) // first yield is an inserted element ("1"), since index == 0
+		is.Equal([]string{"1", "2", "0"}, slices.Collect(seq))
 		is.Equal([]string{"0", "1", "2"}, slices.Collect(Splice(values("0"), 1, "1", "2")))
+	})
+
+	t.Run("panics on negative index", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+		is.PanicsWithValue("it.Splice: index must not be negative", func() {
+			Splice(values("a", "b"), -1, "1")
+		})
+	})
+
+	t.Run("no elements returns collection unchanged", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+		seq := Splice(values("a", "b", "c"), 1)
+		is.Equal([]string{"a", "b", "c"}, slices.Collect(seq))
 	})
 
 	t.Run("type preserved", func(t *testing.T) {
@@ -2178,11 +2257,34 @@ func TestCutPrefix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
+			// CutPrefix's returned sequence shares state (via iter.Pull) with the call that
+			// produced it, so a break-support check must use its own fresh call rather than
+			// re-consume `actual` below.
+			breakSeq, _ := CutPrefix(values(tt.input...), tt.prefix)
+			assertSeqSupportBreak(t, breakSeq)
+
 			actual, result := CutPrefix(values(tt.input...), tt.prefix)
 			is.Equal(tt.expectedFound, result)
 			is.Equal(tt.expectedAfter, slices.Collect(actual))
 		})
 	}
+
+	t.Run("breaks on the mismatched item itself, after the replayed prefix", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+		actual, found := CutPrefix(values("a", "a", "b"), []string{"a", "b"})
+		is.False(found)
+		var collected []string
+		count := 0
+		for item := range actual {
+			collected = append(collected, item)
+			count++
+			if count == 2 { // stop right as the mismatched item itself is yielded
+				break
+			}
+		}
+		is.Equal([]string{"a", "a"}, collected)
+	})
 }
 
 func TestCutSuffix(t *testing.T) {
@@ -2276,6 +2378,7 @@ func TestTrimPrefix(t *testing.T) {
 		{name: "prefix equals entire collection", input: []string{"a", "b", "c", "d", "e", "f", "g"}, prefix: []string{"a", "b", "c", "d", "e", "f", "g"}, expected: nil},
 		{name: "prefix longer than collection", input: []string{"a", "b", "c", "d", "e", "f", "g"}, prefix: []string{"a", "b", "c", "d", "e", "f", "g", "h"}, expected: []string{"a", "b", "c", "d", "e", "f", "g"}},
 		{name: "empty prefix", input: []string{"a", "b", "c", "d", "e", "f", "g"}, prefix: []string{}, expected: []string{"a", "b", "c", "d", "e", "f", "g"}},
+		{name: "prefix partially matches then diverges", input: []string{"a", "b", "x", "y"}, prefix: []string{"a", "b", "c"}, expected: []string{"a", "b", "x", "y"}},
 	}
 
 	for _, tt := range tests {
@@ -2283,7 +2386,9 @@ func TestTrimPrefix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.Equal(tt.expected, slices.Collect(TrimPrefix(values(tt.input...), tt.prefix)))
+			seq := TrimPrefix(values(tt.input...), tt.prefix)
+			assertSeqSupportBreak(t, seq)
+			is.Equal(tt.expected, slices.Collect(seq))
 		})
 	}
 }
@@ -2328,6 +2433,7 @@ func TestTrimSuffix(t *testing.T) {
 		{name: "suffix equals entire collection", input: []string{"a", "b", "c", "d", "e", "f", "g"}, suffix: []string{"a", "b", "c", "d", "e", "f", "g"}, expected: nil},
 		{name: "suffix longer than collection", input: []string{"a", "b", "c", "d", "e", "f", "g"}, suffix: []string{"a", "b", "c", "d", "e", "f", "g", "h"}, expected: []string{"a", "b", "c", "d", "e", "f", "g"}},
 		{name: "empty suffix", input: []string{"a", "b", "c", "d", "e", "f", "g"}, suffix: []string{}, expected: []string{"a", "b", "c", "d", "e", "f", "g"}},
+		{name: "suffix candidate then diverges immediately", input: []string{"f", "x", "y"}, suffix: []string{"f", "g"}, expected: []string{"f", "x", "y"}},
 	}
 
 	for _, tt := range tests {
@@ -2335,7 +2441,9 @@ func TestTrimSuffix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.Equal(tt.expected, slices.Collect(TrimSuffix(values(tt.input...), tt.suffix)))
+			seq := TrimSuffix(values(tt.input...), tt.suffix)
+			assertSeqSupportBreak(t, seq)
+			is.Equal(tt.expected, slices.Collect(seq))
 		})
 	}
 }
@@ -2387,7 +2495,9 @@ func TestSeqToSeq2(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
-			is.Equal(tt.expected, maps.Collect(SeqToSeq2(values(tt.input...))))
+			seq := SeqToSeq2(values(tt.input...))
+			assertSeq2SupportBreak(t, seq)
+			is.Equal(tt.expected, maps.Collect(seq))
 		})
 	}
 }

--- a/it/string_test.go
+++ b/it/string_test.go
@@ -63,6 +63,7 @@ func TestChunkString(t *testing.T) {
 			is := assert.New(t)
 
 			result := ChunkString(tt.input, tt.size)
+			assertSeqSupportBreak(t, result)
 			is.Equal(tt.expected, slices.Collect(result))
 		})
 	}

--- a/it/tuples_test.go
+++ b/it/tuples_test.go
@@ -529,6 +529,7 @@ func TestCrossJoinBy(t *testing.T) {
 		is := assert.New(t)
 
 		results := CrossJoinBy2(listOne, listTwo, lo.T2[string, int])
+		assertSeqSupportBreak(t, results)
 		is.Equal([]lo.Tuple2[string, int]{lo.T2("a", 1), lo.T2("a", 2), lo.T2("a", 3), lo.T2("b", 1), lo.T2("b", 2), lo.T2("b", 3), lo.T2("c", 1), lo.T2("c", 2), lo.T2("c", 3)}, slices.Collect(results))
 	})
 
@@ -538,5 +539,89 @@ func TestCrossJoinBy(t *testing.T) {
 
 		results := CrossJoinBy2(listOne, mixedList, lo.T2[string, any])
 		is.Equal([]lo.Tuple2[string, any]{lo.T2[string, any]("a", 9.6), lo.T2[string, any]("a", 4), lo.T2[string, any]("a", "foobar"), lo.T2[string, any]("b", 9.6), lo.T2[string, any]("b", 4), lo.T2[string, any]("b", "foobar"), lo.T2[string, any]("c", 9.6), lo.T2[string, any]("c", 4), lo.T2[string, any]("c", "foobar")}, slices.Collect(results))
+	})
+
+	t.Run("3 lists", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		r := CrossJoinBy3(values("a"), values(1), values(10, 20), lo.T3[string, int, int])
+		assertSeqSupportBreak(t, r)
+		is.Equal([]lo.Tuple3[string, int, int]{
+			lo.T3("a", 1, 10),
+			lo.T3("a", 1, 20),
+		}, slices.Collect(r))
+	})
+
+	t.Run("4 lists", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		r := CrossJoinBy4(values("a"), values(1), values(true), values(10, 20), lo.T4[string, int, bool, int])
+		assertSeqSupportBreak(t, r)
+		is.Equal([]lo.Tuple4[string, int, bool, int]{
+			lo.T4("a", 1, true, 10),
+			lo.T4("a", 1, true, 20),
+		}, slices.Collect(r))
+	})
+
+	t.Run("5 lists", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		r := CrossJoinBy5(values("a"), values(1), values(true), values[float32](0.5), values(10, 20), lo.T5[string, int, bool, float32, int])
+		assertSeqSupportBreak(t, r)
+		is.Equal([]lo.Tuple5[string, int, bool, float32, int]{
+			lo.T5[string, int, bool, float32, int]("a", 1, true, 0.5, 10),
+			lo.T5[string, int, bool, float32, int]("a", 1, true, 0.5, 20),
+		}, slices.Collect(r))
+	})
+
+	t.Run("6 lists", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		r := CrossJoinBy6(values("a"), values(1), values(true), values[float32](0.5), values(0.05), values(10, 20), lo.T6[string, int, bool, float32, float64, int])
+		assertSeqSupportBreak(t, r)
+		is.Equal([]lo.Tuple6[string, int, bool, float32, float64, int]{
+			lo.T6[string, int, bool, float32, float64, int]("a", 1, true, 0.5, 0.05, 10),
+			lo.T6[string, int, bool, float32, float64, int]("a", 1, true, 0.5, 0.05, 20),
+		}, slices.Collect(r))
+	})
+
+	t.Run("7 lists", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		r := CrossJoinBy7(values("a"), values(1), values(true), values[float32](0.5), values(0.05), values[int8](7), values(10, 20), lo.T7[string, int, bool, float32, float64, int8, int])
+		assertSeqSupportBreak(t, r)
+		is.Equal([]lo.Tuple7[string, int, bool, float32, float64, int8, int]{
+			lo.T7[string, int, bool, float32, float64, int8, int]("a", 1, true, 0.5, 0.05, 7, 10),
+			lo.T7[string, int, bool, float32, float64, int8, int]("a", 1, true, 0.5, 0.05, 7, 20),
+		}, slices.Collect(r))
+	})
+
+	t.Run("8 lists", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		r := CrossJoinBy8(values("a"), values(1), values(true), values[float32](0.5), values(0.05), values[int8](7), values[int16](8), values(10, 20), lo.T8[string, int, bool, float32, float64, int8, int16, int])
+		assertSeqSupportBreak(t, r)
+		is.Equal([]lo.Tuple8[string, int, bool, float32, float64, int8, int16, int]{
+			lo.T8[string, int, bool, float32, float64, int8, int16, int]("a", 1, true, 0.5, 0.05, 7, 8, 10),
+			lo.T8[string, int, bool, float32, float64, int8, int16, int]("a", 1, true, 0.5, 0.05, 7, 8, 20),
+		}, slices.Collect(r))
+	})
+
+	t.Run("9 lists", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		r := CrossJoinBy9(values("a"), values(1), values(true), values[float32](0.5), values(0.05), values[int8](7), values[int16](8), values[int32](9), values(10, 20), lo.T9[string, int, bool, float32, float64, int8, int16, int32, int])
+		assertSeqSupportBreak(t, r)
+		is.Equal([]lo.Tuple9[string, int, bool, float32, float64, int8, int16, int32, int]{
+			lo.T9[string, int, bool, float32, float64, int8, int16, int32, int]("a", 1, true, 0.5, 0.05, 7, 8, 9, 10),
+			lo.T9[string, int, bool, float32, float64, int8, int16, int32, int]("a", 1, true, 0.5, 0.05, 7, 8, 9, 20),
+		}, slices.Collect(r))
 	})
 }


### PR DESCRIPTION
**Summary**

- Subset/Slice: negative offset/length panics and negative start/end clamping
- Splice: negative index panic, no-elements passthrough, and the two distinct break points (mid-sequence insert vs. trailing append)
- CutPrefix: its returned sequence is stateful (shares an iter.Pull), so break checks need a fresh call rather than reusing the sequence under test. Also adds a missing case where the prefix partially matches before diverging
- TrimPrefix/TrimSuffix: same missing partial-match-then-diverge case
- CrossJoinBy3..9: had no direct tests at all, only incidental coverage via the CrossJoin3..9 example tests