### PR TITLE
fix(it): relax WithoutNth type constraint from comparable to any

### DIFF
--- a/docs/data/core-withoutnth.md
+++ b/docs/data/core-withoutnth.md
@@ -13,7 +13,7 @@ similarHelpers:
   - core#slice#dropbyindex
 position: 140
 signatures:
-  - "func WithoutNth[T comparable, Slice ~[]T](collection Slice, nths ...int) Slice"
+  - "func WithoutNth[T any, Slice ~[]T](collection Slice, nths ...int) Slice"
 ---
 
 Returns a slice excluding the elements at the given indexes.

--- a/docs/data/it-withoutnth.md
+++ b/docs/data/it-withoutnth.md
@@ -5,7 +5,7 @@ sourceRef: it/intersect.go#L253
 category: iter
 subCategory: intersect
 signatures:
-  - "func WithoutNth[T comparable, I ~func(func(T) bool)](collection I, nths ...int) I"
+  - "func WithoutNth[T any, I ~func(func(T) bool)](collection I, nths ...int) I"
 playUrl: "https://go.dev/play/p/KGE7Lpsk18P"
 variantHelpers:
   - iter#intersect#withoutnth

--- a/it/intersect.go
+++ b/it/intersect.go
@@ -250,7 +250,7 @@ func WithoutBy[T any, K comparable, I ~func(func(T) bool)](collection I, transfo
 // WithoutNth returns a sequence excluding the nth value.
 // Will allocate a map large enough to hold all distinct nths.
 // Play: https://go.dev/play/p/KGE7Lpsk18P
-func WithoutNth[T comparable, I ~func(func(T) bool)](collection I, nths ...int) I {
+func WithoutNth[T any, I ~func(func(T) bool)](collection I, nths ...int) I {
 	set := lo.Keyify(nths)
 	return RejectI(collection, func(_ T, index int) bool { return lo.HasKey(set, index) })
 }

--- a/it/intersect_test.go
+++ b/it/intersect_test.go
@@ -521,6 +521,15 @@ func TestWithoutNth(t *testing.T) {
 		nonempty := WithoutNth(allStrings)
 		is.IsType(nonempty, allStrings, "type preserved")
 	})
+
+	t.Run("non-comparable element type", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		seq := values([]int{1, 2}, []int{3, 4}, []int{5, 6})
+		result := slices.Collect(WithoutNth(seq, 1))
+		is.Equal([][]int{{1, 2}, {5, 6}}, result)
+	})
 }
 
 func TestElementsMatch(t *testing.T) {


### PR DESCRIPTION
Fixes #959.

`it.WithoutNth` was declared with a `T comparable` constraint:

```go
func WithoutNth[T comparable, I ~func(func(T) bool)](collection I, nths ...int) I
```

but it only removes elements by index (`nths ...int`) and never compares the element values. The `comparable` bound is therefore unnecessary, and it prevents the helper from being used with non-comparable element types (slices, maps, funcs) even though nothing about the operation requires comparability. The `core` variant `lo.WithoutNth` already uses `T any`, so the two were inconsistent.

Internally it delegates to `RejectI` (`T any`) and calls `lo.Keyify` on the `[]int` indices, so widening the constraint is safe:

```go
func WithoutNth[T any, I ~func(func(T) bool)](collection I, nths ...int) I {
	set := lo.Keyify(nths)
	return RejectI(collection, func(_ T, index int) bool { return lo.HasKey(set, index) })
}
```

Changes:

- Relax the constraint to `T any` in `it/intersect.go`.
- Add a test covering a non-comparable element type (`iter.Seq[[]int]`), which did not compile before.
- Update the `signatures` in `docs/data/it-withoutnth.md` and `docs/data/core-withoutnth.md` to match the source (the core doc still listed `T comparable` while the core code already used `T any`).

Loosening a generic constraint is backward compatible: existing comparable element types still satisfy `any`. `go build ./...` and `go test ./it/` pass.
