### PR TITLE
fix(string): Capitalize only upper-cases the first character

### DIFF
--- a/README.md
+++ b/README.md
@@ -2453,11 +2453,14 @@ str := lo.Words("helloWorld")
 
 ### Capitalize
 
-Converts the first character of string to upper case and the remaining to lower case.
+Converts the first character of string to upper case and the remaining to lower case. Only the first character is affected — this is not per-word title casing, so letters after spaces, digits or punctuation stay lower-cased (matching lodash's `capitalize`).
 
 ```go
 str := lo.Capitalize("heLLO")
 // Hello
+
+str := lo.Capitalize("hello world")
+// Hello world
 ```
 
 [[play](https://go.dev/play/p/uLTZZQXqnsa)]

--- a/string.go
+++ b/string.go
@@ -499,6 +499,11 @@ func fieldsAlnum(s string) []string {
 }
 
 // Capitalize converts the first character of string to upper case and the remaining to lower case.
+//
+// Only the very first character is upper-cased. This is not per-word title casing: letters that
+// follow spaces, digits or punctuation stay lower-cased (e.g. "hello world" -> "Hello world",
+// "123abc" -> "123abc"), matching lodash's capitalize. Earlier releases title-cased every word
+// segment, so multi-word inputs are affected by this change.
 // Play: https://go.dev/play/p/uLTZZQXqnsa
 func Capitalize(str string) string {
 	if str == "" {
@@ -514,7 +519,8 @@ func Capitalize(str string) string {
 
 // CapitalizeWithLanguage converts the first character of string to upper case and the remaining to
 // lower case, using language-aware casing.
-// This matters for languages such as Turkish where the uppercase of "i" is "İ", not "I".
+// As with [Capitalize], only the first character is upper-cased (not each word). Language awareness
+// matters for languages such as Turkish where the uppercase of "i" is "İ", not "I".
 func CapitalizeWithLanguage(str string, tag language.Tag) string {
 	if str == "" {
 		return str

--- a/string.go
+++ b/string.go
@@ -501,18 +501,30 @@ func fieldsAlnum(s string) []string {
 // Capitalize converts the first character of string to upper case and the remaining to lower case.
 // Play: https://go.dev/play/p/uLTZZQXqnsa
 func Capitalize(str string) string {
-	c, _ := englishTitleCaserPool.Get().(*cases.Caser)
-	defer englishTitleCaserPool.Put(c)
-	return c.String(str)
+	if str == "" {
+		return str
+	}
+	tc, _ := englishTitleCaserPool.Get().(*cases.Caser)
+	defer englishTitleCaserPool.Put(tc)
+	lc, _ := englishLowerCaserPool.Get().(*cases.Caser)
+	defer englishLowerCaserPool.Put(lc)
+	_, size := utf8.DecodeRuneInString(str)
+	return tc.String(str[:size]) + lc.String(str[size:])
 }
 
 // CapitalizeWithLanguage converts the first character of string to upper case and the remaining to
-// lower case, using language-aware title casing.
+// lower case, using language-aware casing.
 // This matters for languages such as Turkish where the uppercase of "i" is "İ", not "I".
 func CapitalizeWithLanguage(str string, tag language.Tag) string {
-	pool, c := acquireTitleCaser(tag)
-	defer pool.Put(c)
-	return c.String(str)
+	if str == "" {
+		return str
+	}
+	tPool, tc := acquireTitleCaser(tag)
+	defer tPool.Put(tc)
+	lPool, lc := acquireLowerCaser(tag)
+	defer lPool.Put(lc)
+	_, size := utf8.DecodeRuneInString(str)
+	return tc.String(str[:size]) + lc.String(str[size:])
 }
 
 // Ellipsis trims and truncates a string to a specified length in runes and appends an ellipsis

--- a/string_test.go
+++ b/string_test.go
@@ -542,6 +542,19 @@ func TestCapitalize(t *testing.T) {
 	}{
 		{"lower case", "hello", "Hello"},
 		{"mixed case", "heLLO", "Hello"},
+		// Only the first character is upper-cased; every other character is lower-cased,
+		// regardless of word boundaries (spaces, digits or punctuation).
+		{"empty", "", ""},
+		{"single letter", "a", "A"},
+		{"multiple words", "hello world", "Hello world"},
+		{"all upper words", "HELLO WORLD", "Hello world"},
+		{"leading digits", "123abc", "123abc"},
+		{"leading punctuation", "(abc", "(abc"},
+		{"dash separated", "foo-bar baz", "Foo-bar baz"},
+		// Regression for #974: characters following "%" (and other word separators) must not
+		// be upper-cased.
+		{"format verbs", `strf("%d%m")`, `Strf("%d%m")`},
+		{"multibyte", "über GRüße", "Über grüße"},
 	}
 	for _, tc := range testCases {
 		tc := tc
@@ -563,6 +576,9 @@ func TestCapitalizeWithLanguage(t *testing.T) {
 	}{
 		{name: "english plain I", in: "istanbul", lang: language.English, want: "Istanbul"},
 		{name: "english mixed case", in: "heLLO", lang: language.English, want: "Hello"},
+		// Regression for #974: only the first character is upper-cased, the rest is lower-cased.
+		{name: "english format verbs", in: `strf("%d%m")`, lang: language.English, want: `Strf("%d%m")`},
+		{name: "english multiple words", in: "hello world", lang: language.English, want: "Hello world"},
 		// Turkish: lowercase i → title İ (dotted capital I, U+0130)
 		{name: "turkish lowercase i", in: "istanbul", lang: language.Turkish, want: "İstanbul"},
 		// Turkish: ISTANBUL starts with capital I (the uppercase form of ı); title case


### PR DESCRIPTION
## What broke

`Capitalize("strf(\"%d%m\")")` returned `Strf("%D%M")` instead of `Strf("%d%m")`. More generally, any character after a word boundary (a space, digit or punctuation) was upper-cased too: `Capitalize("hello world")` gave `Hello World`, and `Capitalize("123abc")` gave `123Abc`. The doc comment promises the opposite: only the first character is upper-cased and the remainder lower-cased, matching lodash's `capitalize`.

## Root cause

`Capitalize` (and `CapitalizeWithLanguage`) ran the whole string through a `cases.Title` caser. A title caser upper-cases the first letter of every segment, not just the very first character, so text following `%`, spaces and punctuation was capitalized as well.

## Fix

Decode the first rune, send only that rune through the title caser and lower-case the remainder. `CapitalizeWithLanguage` keeps its language-aware behaviour (e.g. Turkish `i` -> `İ`) by pairing the title caser with the matching lower caser pool. Empty input is handled explicitly so we never slice an empty string.

## Tests

Extended `TestCapitalize` and `TestCapitalizeWithLanguage` with regression cases: the `%`-format-verb example from the issue, plus multi-word, all-caps, leading-digit, leading-punctuation, dash-separated, single-rune, multibyte and empty inputs.

## Verification

```
go build ./...
go vet ./...
gofmt -l string.go string_test.go   # no output (clean)
go test -run TestCapitalize ./...    # ok
go test ./...                        # ok
```

Fixes #974
