### PR TITLE
Add ForEachErr() func

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -195,6 +195,17 @@ func ForEach[T any](collection []T, callback func(item T, index int)) {
 	}
 }
 
+// ForEachErr iterates over elements of collection and invokes callback for each element.
+// It returns the first error returned by the iteratee function.
+func ForEachErr[T any](collection []T, callback func(item T, index int) error) error {
+	for i := range collection {
+		if err := callback(collection[i], i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // ForEachWhile iterates over elements of collection and invokes predicate for each element
 // collection return value decide to continue or break, like do while().
 // Play: https://go.dev/play/p/QnLGt35tnow

--- a/slice_test.go
+++ b/slice_test.go
@@ -789,6 +789,31 @@ func TestForEach(t *testing.T) {
 	is.IsIncreasing(callParams2)
 }
 
+func TestForEachErr(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	// check of callback is called for every element and in proper order
+
+	var callParams1 []string
+	var callParams2 []int
+
+	err := ForEachErr([]string{"a", "b", "c"}, func(item string, i int) error {
+		if item == "c" {
+			return errors.New("'c' is not allowed")
+		}
+		callParams1 = append(callParams1, item)
+		callParams2 = append(callParams2, i)
+		return nil
+	})
+
+	is.Equal([]string{"a", "b"}, callParams1)
+	is.Equal([]int{0, 1}, callParams2)
+	is.IsIncreasing(callParams2)
+	is.Error(err)
+	is.Equal("'c' is not allowed", err.Error())
+}
+
 func TestForEachWhile(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)


### PR DESCRIPTION
Description:
This PR introduces ForEachErr, a utility function that iterates over a collection and invokes a provided callback for each item. If the callback returns a non-nil error, ForEachErr stops processing and returns that error immediately. This makes it easier to perform per-item operations that may fail and to propagate errors without manual loop boilerplate.

Why:
- Reduces repetitive boilerplate for error-aware iteration.
- Provides a clear and consistent pattern for early-exit item processing.

What changed:
- Adds the ForEachErr implementation.
- Adds accompanying unit tests and/or examples demonstrating typical usage.
- No changes to existing public APIs or behavior beyond adding this new helper.