### PR TITLE
fix(Nth): reject indexes that do not fit an int instead of wrapping

### DIFF
--- a/find.go
+++ b/find.go
@@ -1067,16 +1067,23 @@ func Nth[T any, N constraints.Integer](collection []T, nth N) (T, error) {
 }
 
 func sliceNth[T any, N constraints.Integer](collection []T, nth N) (T, bool) {
-	n := int(nth)
 	l := len(collection)
-	if n >= l || -n > l {
-		return Empty[T](), false
+
+	if nth >= 0 {
+		// Compared in an unsigned domain: int(nth) would wrap negative for a
+		// large unsigned N and then take the count-from-the-end branch below.
+		if uint64(nth) >= uint64(l) {
+			return Empty[T](), false
+		}
+		return collection[int(nth)], true
 	}
 
-	if n >= 0 {
-		return collection[n], true
+	// Compared in a signed domain: -nth overflows back to nth when nth is the
+	// minimum value of its type, so the bound must be tested without negating.
+	if int64(nth) < int64(-l) {
+		return Empty[T](), false
 	}
-	return collection[l+n], true
+	return collection[l+int(nth)], true
 }
 
 // NthOr returns the element at index `nth` of collection.

--- a/find_test.go
+++ b/find_test.go
@@ -2,6 +2,7 @@ package lo
 
 import (
 	"errors"
+	"math"
 	"math/rand"
 	"testing"
 	"time"
@@ -2156,6 +2157,49 @@ func TestNth(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNth_indexTypeBounds(t *testing.T) {
+	t.Parallel()
+
+	collection := []int{10, 20, 30}
+
+	t.Run("unsigned index wider than the slice", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		_, err := Nth(collection, uint64(math.MaxUint64))
+		is.EqualError(err, "nth: 18446744073709551615 out of slice bounds")
+		is.Equal(-1, NthOr(collection, uint64(math.MaxUint64), -1))
+		is.Zero(NthOrEmpty(collection, uint64(math.MaxUint64)))
+
+		_, err = Nth(collection, uint64(1)<<63)
+		is.EqualError(err, "nth: 9223372036854775808 out of slice bounds")
+	})
+
+	t.Run("most negative index of its type", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		_, err := Nth(collection, math.MinInt)
+		is.Error(err)
+		_, err = Nth(collection, int64(math.MinInt64))
+		is.EqualError(err, "nth: -9223372036854775808 out of slice bounds")
+		is.Equal(-1, NthOr(collection, int8(math.MinInt8), -1))
+	})
+
+	t.Run("in-range indexes of other integer types", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		v, err := Nth(collection, uint8(1))
+		is.NoError(err)
+		is.Equal(20, v)
+
+		v, err = Nth(collection, int16(-1))
+		is.NoError(err)
+		is.Equal(30, v)
+	})
 }
 
 func TestNthOr(t *testing.T) {


### PR DESCRIPTION
`sliceNth` narrows the generic index with `n := int(nth)` *before* any bounds check, so a value that does not fit an `int` wraps and lands in the count-from-the-end branch.

```go
c := []int{10, 20, 30}
lo.Nth(c, uint64(math.MaxUint64))       // 30, err == nil
lo.NthOr(c, uint64(math.MaxUint64), -1) // 30 — fallback ignored
lo.Nth(c, math.MinInt)                  // panic: index out of range [-9223372036854775805]
```

Both contradict the doc comments — "An error is returned when nth is out of slice bounds" / "it returns the fallback value".

Two distinct overflows:
- `int(nth)` is lossy for unsigned `N`: `int(MaxUint64)` is `-1`.
- `-n > l` overflows back to `n` when `n` is its type's minimum, so the guard passes and `collection[l+n]` panics.

The fix compares in the unsigned domain when `nth >= 0` and in the signed domain otherwise, never negating.

Fence: #137 added `-nth > l` while `nth` was still `int`; #151 generalised it to `constraints.Integer` a day later and introduced the narrowing, with a commit message only about the parameter type. `TestNth` declares `nth int`, so no existing test instantiates `N` with another type.

Blast radius: over lengths 0–8 × nth −30…30 (549 cells) old and new agree exactly — only previously-wrapping values change. `go test ./...` 6/6 ok. A naive guard rejecting only the unsigned wrap still panics on `MinInt`; both cases are in the new test.

Drafted with Claude Opus 5 (`claude-opus-5`); every claim was executed.
