### PR TITLE
docs(slice): add example and README entry for ForEachErr

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Supported helpers for slices:
 - [ReduceRight](#reduceright)
 - [ForEach](#foreach)
 - [ForEachWhile](#foreachwhile)
+- [ForEachErr](#foreacherr)
 - [Times](#times)
 - [Uniq](#uniq)
 - [UniqBy](#uniqby)
@@ -625,6 +626,27 @@ lo.ForEachWhile(list, func(x int64, _ int) bool {
 ```
 
 [[play](https://go.dev/play/p/QnLGt35tnow)]
+
+### ForEachErr
+
+Iterates over elements of a collection, invokes the iteratee for each element, and returns the first error returned by the iteratee. Iteration stops on the first error.
+
+```go
+import "github.com/samber/lo"
+
+list := []int64{1, 2, -42, 4}
+
+err := lo.ForEachErr(list, func(x int64, _ int) error {
+	if x < 0 {
+		return fmt.Errorf("%d is not allowed", x)
+	}
+	fmt.Println(x)
+	return nil
+})
+// 1
+// 2
+// err: "-42 is not allowed"
+```
 
 ### Times
 

--- a/docs/data/core-associate.md
+++ b/docs/data/core-associate.md
@@ -1,7 +1,7 @@
 ---
 name: Associate
 slug: associate
-sourceRef: slice.go#L673
+sourceRef: slice.go#L762
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/WHa2CfMO3Lr

--- a/docs/data/core-chunk.md
+++ b/docs/data/core-chunk.md
@@ -1,7 +1,7 @@
 ---
 name: Chunk
 slug: chunk
-sourceRef: slice.go#L388
+sourceRef: slice.go#L477
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/kEMkFbdu85g

--- a/docs/data/core-clone.md
+++ b/docs/data/core-clone.md
@@ -1,7 +1,7 @@
 ---
 name: Clone
 slug: clone
-sourceRef: slice.go#L1132
+sourceRef: slice.go#L1229
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/66LJ2wAF0rN

--- a/docs/data/core-compact.md
+++ b/docs/data/core-compact.md
@@ -1,7 +1,7 @@
 ---
 name: Compact
 slug: compact
-sourceRef: slice.go#L1147
+sourceRef: slice.go#L1244
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/tXiy-iK6PAc

--- a/docs/data/core-concat.md
+++ b/docs/data/core-concat.md
@@ -1,7 +1,7 @@
 ---
 name: Concat
 slug: concat
-sourceRef: slice.go#L488
+sourceRef: slice.go#L577
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/Ux2UuR2xpRK

--- a/docs/data/core-count.md
+++ b/docs/data/core-count.md
@@ -1,7 +1,7 @@
 ---
 name: Count
 slug: count
-sourceRef: slice.go#L992
+sourceRef: slice.go#L1081
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/Y3FlK54yveC

--- a/docs/data/core-countby.md
+++ b/docs/data/core-countby.md
@@ -1,7 +1,7 @@
 ---
 name: CountBy
 slug: countby
-sourceRef: slice.go#L1006
+sourceRef: slice.go#L1095
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/5GMQP5vNT4q

--- a/docs/data/core-countbyerr.md
+++ b/docs/data/core-countbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: CountByErr
 slug: countbyerr
-sourceRef: slice.go#L1021
+sourceRef: slice.go#L1110
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-countvalues.md
+++ b/docs/data/core-countvalues.md
@@ -1,7 +1,7 @@
 ---
 name: CountValues
 slug: countvalues
-sourceRef: slice.go#L1039
+sourceRef: slice.go#L1128
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/-p-PyLT4dfy

--- a/docs/data/core-countvaluesby.md
+++ b/docs/data/core-countvaluesby.md
@@ -1,7 +1,7 @@
 ---
 name: CountValuesBy
 slug: countvaluesby
-sourceRef: slice.go#L1052
+sourceRef: slice.go#L1141
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/2U0dG1SnOmS

--- a/docs/data/core-cut.md
+++ b/docs/data/core-cut.md
@@ -1,7 +1,7 @@
 ---
 name: Cut
 slug: cut
-sourceRef: slice.go#L1222
+sourceRef: slice.go#L1319
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/GiL3qhpIP3f

--- a/docs/data/core-cutprefix.md
+++ b/docs/data/core-cutprefix.md
@@ -1,7 +1,7 @@
 ---
 name: CutPrefix
 slug: cutprefix
-sourceRef: slice.go#L1248
+sourceRef: slice.go#L1345
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/P1scQj53aFa

--- a/docs/data/core-cutsuffix.md
+++ b/docs/data/core-cutsuffix.md
@@ -1,7 +1,7 @@
 ---
 name: CutSuffix
 slug: cutsuffix
-sourceRef: slice.go#L1259
+sourceRef: slice.go#L1356
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/7FKfBFvPTaT

--- a/docs/data/core-drop.md
+++ b/docs/data/core-drop.md
@@ -1,7 +1,7 @@
 ---
 name: Drop
 slug: drop
-sourceRef: slice.go#L755
+sourceRef: slice.go#L844
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/JswS7vXRJP2

--- a/docs/data/core-dropbyindex.md
+++ b/docs/data/core-dropbyindex.md
@@ -1,7 +1,7 @@
 ---
 name: DropByIndex
 slug: dropbyindex
-sourceRef: slice.go#L856
+sourceRef: slice.go#L945
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/bPIH4npZRxS

--- a/docs/data/core-dropright.md
+++ b/docs/data/core-dropright.md
@@ -1,7 +1,7 @@
 ---
 name: DropRight
 slug: dropright
-sourceRef: slice.go#L771
+sourceRef: slice.go#L860
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/GG0nXkSJJa3

--- a/docs/data/core-droprightwhile.md
+++ b/docs/data/core-droprightwhile.md
@@ -1,7 +1,7 @@
 ---
 name: DropRightWhile
 slug: droprightwhile
-sourceRef: slice.go#L800
+sourceRef: slice.go#L889
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/HBh8pHl-ZZz

--- a/docs/data/core-dropwhile.md
+++ b/docs/data/core-dropwhile.md
@@ -1,7 +1,7 @@
 ---
 name: DropWhile
 slug: dropwhile
-sourceRef: slice.go#L786
+sourceRef: slice.go#L875
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/b_PYomVQLGy

--- a/docs/data/core-fill.md
+++ b/docs/data/core-fill.md
@@ -1,7 +1,7 @@
 ---
 name: Fill
 slug: fill
-sourceRef: slice.go#L589
+sourceRef: slice.go#L678
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/VwR34GzqEub

--- a/docs/data/core-filterreject.md
+++ b/docs/data/core-filterreject.md
@@ -1,7 +1,7 @@
 ---
 name: FilterReject
 slug: filterreject
-sourceRef: slice.go#L975
+sourceRef: slice.go#L1064
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/lHSEGSznJjB

--- a/docs/data/core-filterslicetomap.md
+++ b/docs/data/core-filterslicetomap.md
@@ -1,7 +1,7 @@
 ---
 name: FilterSliceToMap
 slug: filterslicetomap
-sourceRef: slice.go#L717
+sourceRef: slice.go#L806
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/eurMiQEqey2

--- a/docs/data/core-flatten.md
+++ b/docs/data/core-flatten.md
@@ -1,7 +1,7 @@
 ---
 name: Flatten
 slug: flatten
-sourceRef: slice.go#L471
+sourceRef: slice.go#L560
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/rbp9ORaMpjw

--- a/docs/data/core-foreacherr.md
+++ b/docs/data/core-foreacherr.md
@@ -1,0 +1,40 @@
+---
+name: ForEachErr
+slug: foreacherr
+sourceRef: slice.go#L200
+category: core
+subCategory: slice
+signatures:
+  - "func ForEachErr[T any](collection []T, callback func(item T, index int) error) error"
+variantHelpers:
+  - core#slice#foreacherr
+similarHelpers:
+  - core#slice#foreach
+  - core#slice#foreachwhile
+  - core#slice#filtererr
+  - core#slice#maperr
+position: 75
+---
+
+Iterates over elements of a collection and invokes the callback for each element. If the callback returns a non-nil error, iteration stops immediately and that error is returned; otherwise the function returns `nil` after the last element.
+
+```go
+lo.ForEachErr([]string{"hello", "world"}, func(x string, _ int) error {
+    println(x)
+    return nil
+})
+// prints "hello\nworld\n"
+// returns nil
+```
+
+```go
+err := lo.ForEachErr([]int64{1, 2, -42, 4}, func(x int64, _ int) error {
+    if x < 0 {
+        return fmt.Errorf("%d is not allowed", x)
+    }
+    println(x)
+    return nil
+})
+// prints "1\n2\n"
+// returns error("-42 is not allowed")
+```

--- a/docs/data/core-foreachwhile.md
+++ b/docs/data/core-foreachwhile.md
@@ -1,7 +1,7 @@
 ---
 name: ForEachWhile
 slug: foreachwhile
-sourceRef: slice.go#L201
+sourceRef: slice.go#L212
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-groupby.md
+++ b/docs/data/core-groupby.md
@@ -1,7 +1,7 @@
 ---
 name: GroupBy
 slug: groupby
-sourceRef: slice.go#L324
+sourceRef: slice.go#L413
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/XnQBd_v6brd

--- a/docs/data/core-groupbyerr.md
+++ b/docs/data/core-groupbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: GroupByErr
 slug: groupbyerr
-sourceRef: slice.go#L339
+sourceRef: slice.go#L428
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/BzKPcY3AdX2

--- a/docs/data/core-groupbymap.md
+++ b/docs/data/core-groupbymap.md
@@ -1,7 +1,7 @@
 ---
 name: GroupByMap
 slug: groupbymap
-sourceRef: slice.go#L356
+sourceRef: slice.go#L445
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/iMeruQ3_W80

--- a/docs/data/core-groupbymaperr.md
+++ b/docs/data/core-groupbymaperr.md
@@ -1,7 +1,7 @@
 ---
 name: GroupByMapErr
 slug: groupbymaperr
-sourceRef: slice.go#L370
+sourceRef: slice.go#L459
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-interleave.md
+++ b/docs/data/core-interleave.md
@@ -1,7 +1,7 @@
 ---
 name: Interleave
 slug: interleave
-sourceRef: slice.go#L533
+sourceRef: slice.go#L622
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/KOVtGUt-tdI

--- a/docs/data/core-issorted.md
+++ b/docs/data/core-issorted.md
@@ -1,7 +1,7 @@
 ---
 name: IsSorted
 slug: issorted
-sourceRef: slice.go#L1163
+sourceRef: slice.go#L1260
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/mc3qR-t4mcx

--- a/docs/data/core-issortedby.md
+++ b/docs/data/core-issortedby.md
@@ -1,7 +1,7 @@
 ---
 name: IsSortedBy
 slug: issortedby
-sourceRef: slice.go#L1174
+sourceRef: slice.go#L1271
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/wiG6XyBBu49

--- a/docs/data/core-isuniq.md
+++ b/docs/data/core-isuniq.md
@@ -1,7 +1,7 @@
 ---
 name: IsUniq
 slug: isuniq
-sourceRef: slice.go#L290
+sourceRef: slice.go#L379
 category: core
 subCategory: slice
 playUrl:

--- a/docs/data/core-isuniqby.md
+++ b/docs/data/core-isuniqby.md
@@ -1,7 +1,7 @@
 ---
 name: IsUniqBy
 slug: isuniqby
-sourceRef: slice.go#L307
+sourceRef: slice.go#L396
 category: core
 subCategory: slice
 playUrl:

--- a/docs/data/core-keyby.md
+++ b/docs/data/core-keyby.md
@@ -1,7 +1,7 @@
 ---
 name: KeyBy
 slug: keyby
-sourceRef: slice.go#L641
+sourceRef: slice.go#L730
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/ccUiUL_Lnel

--- a/docs/data/core-keybyerr.md
+++ b/docs/data/core-keybyerr.md
@@ -1,7 +1,7 @@
 ---
 name: KeyByErr
 slug: keybyerr
-sourceRef: slice.go#L655
+sourceRef: slice.go#L744
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-keyify.md
+++ b/docs/data/core-keyify.md
@@ -1,7 +1,7 @@
 ---
 name: Keyify
 slug: keyify
-sourceRef: slice.go#L743
+sourceRef: slice.go#L832
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/_d5lXdzfw32

--- a/docs/data/core-partitionby.md
+++ b/docs/data/core-partitionby.md
@@ -1,7 +1,7 @@
 ---
 name: PartitionBy
 slug: partitionby
-sourceRef: slice.go#L419
+sourceRef: slice.go#L508
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/NfQ_nGjkgXW

--- a/docs/data/core-partitionbyerr.md
+++ b/docs/data/core-partitionbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: PartitionByErr
 slug: partitionbyerr
-sourceRef: slice.go#L446
+sourceRef: slice.go#L535
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-reject.md
+++ b/docs/data/core-reject.md
@@ -1,7 +1,7 @@
 ---
 name: Reject
 slug: reject
-sourceRef: slice.go#L923
+sourceRef: slice.go#L1012
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/pFCF5WVB225

--- a/docs/data/core-rejecterr.md
+++ b/docs/data/core-rejecterr.md
@@ -1,7 +1,7 @@
 ---
 name: RejectErr
 slug: rejecterr
-sourceRef: slice.go#L938
+sourceRef: slice.go#L1027
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-rejectmap.md
+++ b/docs/data/core-rejectmap.md
@@ -1,7 +1,7 @@
 ---
 name: RejectMap
 slug: rejectmap
-sourceRef: slice.go#L960
+sourceRef: slice.go#L1049
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/bmXhtuM2OMq

--- a/docs/data/core-repeat.md
+++ b/docs/data/core-repeat.md
@@ -1,7 +1,7 @@
 ---
 name: Repeat
 slug: repeat
-sourceRef: slice.go#L601
+sourceRef: slice.go#L690
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/g3uHXbmc3b6

--- a/docs/data/core-repeatby.md
+++ b/docs/data/core-repeatby.md
@@ -1,7 +1,7 @@
 ---
 name: RepeatBy
 slug: repeatby
-sourceRef: slice.go#L613
+sourceRef: slice.go#L702
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/ozZLCtX_hNU

--- a/docs/data/core-repeatbyerr.md
+++ b/docs/data/core-repeatbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: RepeatByErr
 slug: repeatbyerr
-sourceRef: slice.go#L625
+sourceRef: slice.go#L714
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-replace.md
+++ b/docs/data/core-replace.md
@@ -1,7 +1,7 @@
 ---
 name: Replace
 slug: replace
-sourceRef: slice.go#L1110
+sourceRef: slice.go#L1199
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/XfPzmf9gql6

--- a/docs/data/core-replaceall.md
+++ b/docs/data/core-replaceall.md
@@ -1,7 +1,7 @@
 ---
 name: ReplaceAll
 slug: replaceall
-sourceRef: slice.go#L1126
+sourceRef: slice.go#L1223
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/a9xZFUHfYcV

--- a/docs/data/core-reverse.md
+++ b/docs/data/core-reverse.md
@@ -1,7 +1,7 @@
 ---
 name: Reverse
 slug: reverse
-sourceRef: slice.go#L582
+sourceRef: slice.go#L671
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/iv2e9jslfBM

--- a/docs/data/core-shuffle.md
+++ b/docs/data/core-shuffle.md
@@ -1,7 +1,7 @@
 ---
 name: Shuffle
 slug: shuffle
-sourceRef: slice.go#L573
+sourceRef: slice.go#L662
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/whgrQWwOy-j

--- a/docs/data/core-slice.md
+++ b/docs/data/core-slice.md
@@ -1,7 +1,7 @@
 ---
 name: Slice
 slug: slice
-sourceRef: slice.go#L1087
+sourceRef: slice.go#L1176
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/8XWYhfMMA1h

--- a/docs/data/core-slicetomap.md
+++ b/docs/data/core-slicetomap.md
@@ -1,7 +1,7 @@
 ---
 name: SliceToMap
 slug: slicetomap
-sourceRef: slice.go#L699
+sourceRef: slice.go#L788
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/WHa2CfMO3Lr

--- a/docs/data/core-sliding.md
+++ b/docs/data/core-sliding.md
@@ -1,7 +1,7 @@
 ---
 name: Sliding
 slug: sliding
-sourceRef: slice.go#L506
+sourceRef: slice.go#L595
 category: core
 subCategory: slice
 variantHelpers:

--- a/docs/data/core-splice.md
+++ b/docs/data/core-splice.md
@@ -1,7 +1,7 @@
 ---
 name: Splice
 slug: splice
-sourceRef: slice.go#L1196
+sourceRef: slice.go#L1293
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/G5_GhkeSUBA

--- a/docs/data/core-subset.md
+++ b/docs/data/core-subset.md
@@ -1,7 +1,7 @@
 ---
 name: Subset
 slug: subset
-sourceRef: slice.go#L1064
+sourceRef: slice.go#L1153
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/tOQu1GhFcog

--- a/docs/data/core-take.md
+++ b/docs/data/core-take.md
@@ -1,7 +1,7 @@
 ---
 name: Take
 slug: take
-sourceRef: slice.go#L813
+sourceRef: slice.go#L902
 category: core
 subCategory: slice
 variantHelpers:

--- a/docs/data/core-takefilter.md
+++ b/docs/data/core-takefilter.md
@@ -1,7 +1,7 @@
 ---
 name: TakeFilter
 slug: takefilter
-sourceRef: slice.go#L896
+sourceRef: slice.go#L985
 category: core
 subCategory: slice
 variantHelpers:

--- a/docs/data/core-takewhile.md
+++ b/docs/data/core-takewhile.md
@@ -1,7 +1,7 @@
 ---
 name: TakeWhile
 slug: takewhile
-sourceRef: slice.go#L840
+sourceRef: slice.go#L929
 category: core
 subCategory: slice
 variantHelpers:

--- a/docs/data/core-times.md
+++ b/docs/data/core-times.md
@@ -1,7 +1,7 @@
 ---
 name: Times
 slug: times
-sourceRef: slice.go#L212
+sourceRef: slice.go#L223
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/vgQj3Glr6lT

--- a/docs/data/core-trim.md
+++ b/docs/data/core-trim.md
@@ -1,7 +1,7 @@
 ---
 name: Trim
 slug: trim
-sourceRef: slice.go#L1268
+sourceRef: slice.go#L1385
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/LZLfLj5C8Lg

--- a/docs/data/core-trimleft.md
+++ b/docs/data/core-trimleft.md
@@ -1,7 +1,7 @@
 ---
 name: TrimLeft
 slug: trimleft
-sourceRef: slice.go#L1295
+sourceRef: slice.go#L1442
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/fJK-AhROy9w

--- a/docs/data/core-trimprefix.md
+++ b/docs/data/core-trimprefix.md
@@ -1,7 +1,7 @@
 ---
 name: TrimPrefix
 slug: trimprefix
-sourceRef: slice.go#L1306
+sourceRef: slice.go#L1474
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/8O2RoWYzi8J

--- a/docs/data/core-trimright.md
+++ b/docs/data/core-trimright.md
@@ -1,7 +1,7 @@
 ---
 name: TrimRight
 slug: trimright
-sourceRef: slice.go#L1320
+sourceRef: slice.go#L1488
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/9V_N8sRyyiZ

--- a/docs/data/core-trimsuffix.md
+++ b/docs/data/core-trimsuffix.md
@@ -1,7 +1,7 @@
 ---
 name: TrimSuffix
 slug: trimsuffix
-sourceRef: slice.go#L1331
+sourceRef: slice.go#L1520
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/IjEUrV0iofq

--- a/docs/data/core-uniq.md
+++ b/docs/data/core-uniq.md
@@ -1,7 +1,7 @@
 ---
 name: Uniq
 slug: uniq
-sourceRef: slice.go#L225
+sourceRef: slice.go#L242
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/DTzbeXZ6iEN

--- a/docs/data/core-uniqby.md
+++ b/docs/data/core-uniqby.md
@@ -1,7 +1,7 @@
 ---
 name: UniqBy
 slug: uniqby
-sourceRef: slice.go#L245
+sourceRef: slice.go#L293
 category: core
 subCategory: slice
 playUrl: https://go.dev/play/p/g42Z3QSb53u

--- a/docs/data/core-uniqbyerr.md
+++ b/docs/data/core-uniqbyerr.md
@@ -1,7 +1,7 @@
 ---
 name: UniqByErr
 slug: uniqbyerr
-sourceRef: slice.go#L267
+sourceRef: slice.go#L356
 category: core
 subCategory: slice
 signatures:

--- a/docs/data/core-window.md
+++ b/docs/data/core-window.md
@@ -1,7 +1,7 @@
 ---
 name: Window
 slug: window
-sourceRef: slice.go#L495
+sourceRef: slice.go#L584
 category: core
 subCategory: slice
 variantHelpers:

--- a/lo_example_test.go
+++ b/lo_example_test.go
@@ -2587,6 +2587,24 @@ func ExampleForEachWhile() {
 	// 2
 }
 
+func ExampleForEachErr() {
+	list := []int64{1, 2, -42, 4}
+
+	err := ForEachErr(list, func(x int64, _ int) error {
+		if x < 0 {
+			return fmt.Errorf("%d is not allowed", x)
+		}
+		fmt.Println(x)
+		return nil
+	})
+
+	fmt.Printf("%v\n", err)
+	// Output:
+	// 1
+	// 2
+	// -42 is not allowed
+}
+
 func ExampleTimes() {
 	result := Times(3, func(i int) string {
 		return strconv.FormatInt(int64(i), 10)


### PR DESCRIPTION
ForEachErr landed in #980 without an example, a README entry, or a docs/data entry. This PR finishes the documentation surface.

**Added**
- `docs/data/core-foreacherr.md` following the same shape as `core-foreach.md` / `core-foreachwhile.md` / `core-filtererr.md` (position 75, between ForEach and ForEachWhile). Two example blocks: success path and early-terminate-on-error path. `playUrl` left empty per `docs/CLAUDE.md` because the helper is not in a published release yet.
- `ExampleForEachErr` in `lo_example_test.go`, next to `ExampleForEach` / `ExampleForEachWhile`.
- `### ForEachErr` section in `README.md` plus a TOC link.

**Refreshed**
While verifying the new sourceRef, scanning the rest of `docs/data/core-*.md` against `gopls symbols slice.go` caught 65 stale `sourceRef` lines (delta `+11` from #980 plus older drift from #923 and other PRs). Fixed all of them, as required by the `docs/CLAUDE.md` rule: *"Whenever Go source code is modified... Update any `sourceRef` whose line number no longer matches."*

**Verified**
- `go test -race ./...`: pass
- `go vet ./...`: clean
- `golangci-lint`: no issues in touched files (pre-existing `it/math.go:151` untouched)
- `node docs/scripts/check-cross-references.js`: OK
- `node docs/scripts/check-similar-exists.js`: OK
- `node docs/scripts/check-similar-keys-exist-in-directory.js`: OK
- Pre-existing `check-filename-matches-frontmatter.js` and `check-duplicates-in-category.js` failures are in `it-*`/`simd-*` files and unrelated.